### PR TITLE
Fix issue with array prototype sanitization

### DIFF
--- a/spec/notice.spec.coffee
+++ b/spec/notice.spec.coffee
@@ -59,6 +59,14 @@ describe 'Notice', ->
           json = JSON.stringify(notice.payload()) # shouldn't cause error.
           expect(json.match(/CIRCULAR DATA STRUCTURE/g).length).toEqual(1)
 
+        it 'converts arrays in context', ->
+          Array.prototype.blah = -> 'whatevs'
+          e = mockError()
+          c = { "foo": ['boo'], 'bar': ['baz'] }
+          notice = new Notice({ stack: e.stack, message: e.message, name: e.name, context: c })
+          json = JSON.stringify(notice.payload()) # shouldn't cause error.
+          expect(json.match(/CIRCULAR DATA STRUCTURE/g)).toBeNull()
+
   describe 'with a fingerprint', ->
     describe '#payload()', ->
       it 'has a fingerprint', ->


### PR DESCRIPTION
When sanitizing arrays on older browsers with polyfills we see output
like this:

```
"plugins" => {
  "forEach" => {"bind" => {"bind" => "[CIRCULAR DATA STRUCTURE]"}},
    "map" => {"bind" => "[CIRCULAR DATA STRUCTURE]"},
    "filter" => {"bind" => "[CIRCULAR DATA STRUCTURE]"},
    "every" => {"bind" => "[CIRCULAR DATA STRUCTURE]"},
    "some" => {"bind" => "[CIRCULAR DATA STRUCTURE]"},
    "reduce" => {"bind" => "[CIRCULAR DATA STRUCTURE]"},
    "reduceRight" => {"bind" => "[CIRCULAR DATA STRUCTURE]"},
    "indexOf" => {"bind" => "[CIRCULAR DATA STRUCTURE]"},
    "lastIndexOf" => {"bind" => "[CIRCULAR DATA STRUCTURE]"}
}
```

`Notice#_santize` is serializing arrays like objects and seeing the
functions defined on the prototype. (Side note, `#_sanitize` might also
want to just pass on functions.)