### PR TITLE
Use typeof instead of instanceof

### DIFF
--- a/honeybadger.js
+++ b/honeybadger.js
@@ -147,7 +147,7 @@
       context: {},
       beforeNotifyHandlers: []
     }
-    if (opts instanceof Object) {
+    if (typeof opts == 'object') {
       for (k in opts) { self[k] = opts[k]; }
     }
 
@@ -180,7 +180,7 @@
       }
       for (k in obj) {
         v = obj[k];
-        if (v instanceof Function) { v = '[FUNC]' }
+        if (typeof v == 'function') { v = '[FUNC]' }
         if (obj.hasOwnProperty(k) && (k != null) && (v != null)) {
           pk = (prefix ? prefix + '[' + k + ']' : k);
           ret.push(typeof v === 'object' ? serialize(v, pk, depth+1) : encodeURIComponent(pk) + '=' + encodeURIComponent(v));
@@ -224,9 +224,9 @@
 
     function notify(err, generated) {
       if (config('disabled', false)) { return false; }
-      if (!(err instanceof Object)) { return false; }
+      if (!(typeof err == 'object')) { return false; }
 
-      if (err instanceof Error) {
+      if (typeof err == 'error') {
         var e = err;
         err = {name: e.name, message: e.message, stack: stackTrace(e)};
       }
@@ -346,17 +346,17 @@
     self.notify = function(err, name, extra) {
       if (!err) { err = {}; }
 
-      if (err instanceof Error) {
+      if (typeof err == 'error') {
         var e = err;
         err = {name: e.name, message: e.message, stack: stackTrace(e)};
       }
 
-      if (!(err instanceof Object)) {
+      if (!(typeof err == 'object')) {
         var m = String(err);
         err = {message: m};
       }
 
-      if (name && !(name instanceof Object)) {
+      if (name && !(typeof name == 'object')) {
         var n = String(name);
         name = {name: n};
       }
@@ -364,7 +364,7 @@
       if (name) {
         err = merge(err, name);
       }
-      if (extra instanceof Object) {
+      if (typeof extra == 'object') {
         err = merge(err, extra);
       }
 
@@ -376,14 +376,14 @@
     };
 
     self.setContext = function(context) {
-      if (context instanceof Object) {
+      if (typeof context == 'object') {
         self.context = merge(self.context, context);
       }
       return self;
     };
 
     self.resetContext = function(context) {
-      if (context instanceof Object) {
+      if (typeof context == 'object') {
         self.context = merge({}, context);
       } else {
         self.context = {};
@@ -431,7 +431,7 @@
     var instrumentTimer = function(original) {
       // See https://developer.mozilla.org/en-US/docs/Web/API/WindowTimers/setTimeout
       return function(func, delay) {
-        if (func instanceof Function) {
+        if (typeof func == 'function') {
           var args = Array.prototype.slice.call(arguments, 2);
           func = wrap(func);
           return original(function() {
@@ -498,7 +498,7 @@
       // See https://developer.mozilla.org/en-US/docs/Web/API/GlobalEventHandlers/onerror
       return function(msg, url, line, col, err) {
         onerror(msg, url, line, col, err);
-        if (original instanceof Function) {
+        if (typeof original == 'function') {
           return original.apply(this, arguments);
         }
         return false;


### PR DESCRIPTION
See here: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/instanceof#instanceof_and_multiple_context_(e.g._frames_or_windows)

> Different scope have different execution environments. This means that they have different built-ins (different global object, different constructors, etc.). This may result in unexpected results. For instance, [] instanceof window.frames[0].Array will return false, because Array.prototype !== window.frames[0].Array and arrays inherit from the former. This may not make sense at first but when you start dealing with multiple frames or windows in your script and pass objects from one context to another via functions, this will be a valid and strong issue. For instance, you can securely check if a given object is in fact an Array using Array.isArray(myObj)

I ran into problems when using honeybadger.js with slimerjs which is a phantomjs alternative. Using typeof solves it for me, but I'm not sure if there are other implications of these changes. However, the tests _do_ pass!

Let me know what you think.
