### PR TITLE
Add type declarations for TypeScript

### DIFF
--- a/honeybadger-js.d.ts
+++ b/honeybadger-js.d.ts
@@ -1,0 +1,38 @@
+declare module "honeybadger-js" {
+    interface Config {
+        api_key: string;
+        host?: string;
+        ssl?: boolean;
+        project_root?: string;
+        environment?: string;
+        component?: string;
+        action?: string;
+        onerror?: boolean;
+        disabled?: boolean;
+    }
+
+    interface Notice {
+        stack: any;
+        name: string;
+        message: string;
+        url: string;
+        project_root: string;
+        environment: string;
+        component: string;
+        action: string;
+        fingerprint: string;
+        context: any;
+    }
+
+    class Honeybadger {
+        static configure(config: Config): void;
+        static notify(...args: any[]): void;
+        static wrap<T extends Function>(func: T): T;
+        static setContext<T extends Object>(context: T): void;
+        static resetContext(): void;
+        static beforeNotify(func: (notice?: Notice) => void): void;
+        static factory(config: Config): Honeybadger;
+    }
+
+    export = Honeybadger;
+}

--- a/package.json
+++ b/package.json
@@ -28,5 +28,6 @@
     "grunt-shell": "~1.1.2",
     "phantomjs": "~1.9.0"
   },
-  "readmeFilename": "README.md"
+  "readmeFilename": "README.md",
+  "typings": "./honeybadger-js.d.ts"
 }


### PR DESCRIPTION
This will be very handy for your typescript users (myself included). It allows a user to have access to all of the types in Honeybadger with no configuration at all.

Let me know what you think!
