### PR TITLE
Add cookies and params options to ::notify()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ CHANGELOG](http://keepachangelog.com/) for how to update this file. This project
 adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased][unreleased]
+### Added
+- Added option to send params and cookies.
 
 ## [0.4.2] - 2016-04-14
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -187,7 +187,9 @@ Honeybadger.notify(error, {
   context: { badgerId: 1 },
   fingerprint: 'This unique string will group similar errors together',
   environment: 'production',
-  project_root: 'https://www.example.com/'
+  project_root: 'https://www.example.com/',
+  params: { key: 'value' },
+  cookies: { key: 'value' } // May also be sent as a string in the document.cookie "foo=bar;bar=baz" format.
 });
 ```
 
@@ -304,7 +306,8 @@ The following notice attributes may be modified by your notification handlers:
 * action - Similar to a rails action name. example: "create"
 * fingerprint - A unique fingerprint, used to customize grouping of errors in Honeybadger.
 * context - The context object.
-
+* params - An object of request parameters.
+* cookies - An object of cookie key/values. May also be sent as a string in the document.cookie "foo=bar;bar=baz" format.
 
 ---
 
@@ -393,6 +396,17 @@ To find your `Honeybadger-Token` token, visit your project settings page in Hone
 
 One exception is direct links from the Honeybadger UI (such as when displaying links in backtraces); these cannot be authenticated.
 
+## Sending cookies by default
+
+To automatically send cookies with all error reports, use the following `::beforeNotify` handler:
+
+```js
+Honeybadger.beforeNotify(function(err){
+  err.cookies = document.cookie;
+  return true;
+})
+```
+
 ## window.onerror
 
 Honeybadger.js automatically reports uncaught exceptions from window.onerror. To
@@ -405,7 +419,6 @@ Honeybadger.configure({
   onerror: false
 });
 ```
-
 
 ## Contributing
 
@@ -422,4 +435,3 @@ To run the test suite, enter `make test` into the console.
 ### License
 
 The Honeybadger gem is MIT licensed. See the [MIT-LICENSE](https://raw.github.com/honeybadger-io/honeybadger-js/master/MIT-LICENSE) file in this repository for details.
-

--- a/honeybadger.js
+++ b/honeybadger.js
@@ -88,6 +88,19 @@
     return data;
   }
 
+  function encodeCookie(object) {
+    if (typeof object !== 'object') {
+      return undefined;
+    }
+
+    var cookies = [];
+    for (k in object) {
+      cookies.push(k + '=' + object[k]);
+    }
+
+    return cookies.join(';');
+  }
+
   function stackTrace(err) {
     // From TraceKit: Opera 10 *destroys* its stacktrace property if you try to
     // access the stack property first.
@@ -260,6 +273,13 @@
         return false;
       }
 
+      var data = cgiData();
+      if (typeof err.cookies === 'string') {
+        data['HTTP_COOKIE'] = err.cookies;
+      } else if (typeof err.cookies === 'object') {
+        data['HTTP_COOKIE'] = encodeCookie(err.cookies);
+      }
+
       var payload = {
         notifier: NOTIFIER,
         error: {
@@ -274,7 +294,8 @@
           component: err.component || config('component'),
           action: err.action || config('action'),
           context: merge(self.context, err.context),
-          cgi_data: cgiData()
+          cgi_data: data,
+          params: err.params
         },
         server: {
           project_root: err.project_root || config('project_root', window.location.protocol + '//' + window.location.host),

--- a/spec/honeybadger.spec.js
+++ b/spec/honeybadger.spec.js
@@ -243,6 +243,55 @@ describe('Honeybadger', function() {
         expect(requests.length).toEqual(1);
       });
     });
+
+    it('sends params', function() {
+      Honeybadger.configure({
+        api_key: 'asdf'
+      });
+
+      Honeybadger.notify("testing", {
+        params: {
+          foo: 'bar'
+        }
+      });
+
+      afterNotify(function() {
+        expect(requests.length).toEqual(1);
+        expect(requests[0].url).toMatch('notice%5Brequest%5D%5Bparams%5D%5Bfoo%5D=bar');
+      });
+    });
+
+    it('sends cookies as string', function() {
+      Honeybadger.configure({
+        api_key: 'asdf'
+      });
+
+      Honeybadger.notify("testing", {
+        cookies: 'foo=bar'
+      });
+
+      afterNotify(function() {
+        expect(requests.length).toEqual(1);
+        expect(requests[0].url).toMatch('notice%5Brequest%5D%5Bcgi_data%5D%5BHTTP_COOKIE%5D=foo%3Dbar');
+      });
+    });
+
+    it('sends cookies as object', function() {
+      Honeybadger.configure({
+        api_key: 'asdf'
+      });
+
+      Honeybadger.notify("testing", {
+        cookies: {
+          foo: 'bar'
+        }
+      });
+
+      afterNotify(function() {
+        expect(requests.length).toEqual(1);
+        expect(requests[0].url).toMatch('notice%5Brequest%5D%5Bcgi_data%5D%5BHTTP_COOKIE%5D=foo%3Dbar');
+      });
+    });
   });
 
   describe('.wrap', function() {


### PR DESCRIPTION
This allows the user to include cookies and params manually when calling `Honeybadger.notify`:

```js
      // Sending params
      Honeybadger.notify("testing", {
        params: {
          foo: 'bar'
        }
      });

      // Sending cookies as string (i.e. in the format of `document.cookie`)
      Honeybadger.notify("testing", {
        cookies: 'foo=bar'
      });

      // Sending cookies as an object
      Honeybadger.notify("testing", {
        cookies: {
          foo: 'bar'
        }
      });
```

Using this method, you can also configure honeybadger.js to always send cookies:

```js
    Honeybadger.beforeNotify(function(err){
      err.cookies = document.cookie;
      return true;
    })
```