### PR TITLE
Add 'async' configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,10 @@ Honeybadger.configure({
   onerror: true,
 
   // Disable notifications?
-  disabled: false
+  disabled: false,
+
+  // Send notifications asynchronously
+  async: true
 });
 ```
 

--- a/honeybadger.js
+++ b/honeybadger.js
@@ -207,7 +207,7 @@
       try {
         // Inspired by https://gist.github.com/Xeoncross/7663273
         x = new(this.XMLHttpRequest || ActiveXObject)('MSXML2.XMLHTTP.3.0');
-        x.open('GET', url, true);
+        x.open('GET', url, config('async', true));
         x.send();
         return;
       } catch(e) {


### PR DESCRIPTION
We had a situation where we needed to send a Honeybadger notification right before a hard redirect, but as soon as the redirect occurred any XHR requests in progress were cancelled and the notification would never be sent. 

This option allows us to force the request to be synchronous, ensuring that it is send before the redirect happens.
