### PR TITLE
Documents the debug configuration option

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,9 @@ You can set configuration options by using the `Honeybadger.configure` function.
 
 ```javascript
 Honeybadger.configure({
+  // Output Honeybadger debug messages to the console
+  debug: false,
+  
   // Honeybadger API key (required)
   api_key: '',
 


### PR DESCRIPTION
This doesn't seem to be mentioned on the [documentation site](http://docs.honeybadger.io/lib/javascript.html) or in the `README.md`... not sure if that's intentional.