### PR TITLE
Wrap function: don't try to extend non-extensible object

### DIFF
--- a/honeybadger.js
+++ b/honeybadger.js
@@ -350,7 +350,7 @@
     // removeEventListener.
     function wrap(fn, force) {
       try {
-        if (typeof fn !== 'function') {
+        if (typeof fn !== 'function' || !Object.isExtensible(fn)) {
           return fn;
         }
         if (!fn.___hb) {

--- a/spec/honeybadger.spec.js
+++ b/spec/honeybadger.spec.js
@@ -381,6 +381,11 @@ describe('Honeybadger', function() {
         expect(requests.length).toEqual(1);
       });
     });
+
+    it('returns original function if fn is not extensible', function() {
+      var func = Object.freeze(function() {});
+      expect(Honeybadger.wrap(func)).toEqual(func);
+    });
   });
 
   describe('beforeNotify', function() {


### PR DESCRIPTION
Some third party ad libraries pass [frozen](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/freeze) functions to setTimeout which results in errors in console and broken functionality.

If function passed to `wrap` is sealed or frozen, fn.__hb would still be undefined after [assignment](https://github.com/honeybadger-io/honeybadger-js/blob/master/honeybadger.js#L357).