### PR TITLE
Allow error messages to be ignored

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,10 @@ Honeybadger.configure({
   // Action (optional)
   action: '',
 
+  // Ignore Patterns (optional)
+  // Array of error messages as regexes that should be ignored
+  ignorePatterns: [/known\ error/i],
+
   // Should unhandled (window.onerror) notifications be sent?
   onerror: true,
 

--- a/honeybadger.js
+++ b/honeybadger.js
@@ -81,6 +81,16 @@
     return true;
   }
 
+  function isIgnored(err, patterns) {
+    var msg = err.message;
+    var ignored = false;
+
+    for (p in patterns) {
+      if (msg.match(patterns[p])) { ignored = true; }
+    }
+    return ignored;
+  }
+
   function cgiData() {
     var data = {};
     data['HTTP_USER_AGENT'] = navigator.userAgent;
@@ -257,6 +267,8 @@
 
       if (currentErrIs(err)) {
         // Skip the duplicate error.
+        return false;
+      } else if (isIgnored(err, config('ignorePatterns'))) {
         return false;
       } else if (currentPayload && loaded) {
         // This is a different error, send the old one now.

--- a/spec/honeybadger.spec.js
+++ b/spec/honeybadger.spec.js
@@ -211,6 +211,19 @@ describe('Honeybadger', function() {
       });
     });
 
+    it('does not deliver notice for ignored message', function() {
+      Honeybadger.configure({
+        api_key: 'asdf',
+        ignorePatterns: [/care/i]
+      });
+
+      var notice = Honeybadger.notify("Honeybadger don't care, but you might.");
+
+      afterNotify(function() {
+        expect(requests.length).toEqual(0);
+      });
+    });
+
     it('generates a stack trace without an error', function() {
       Honeybadger.configure({
         api_key: 'asdf'


### PR DESCRIPTION
Allow the user to provide `ignorePatterns` as an array of regexes. Any
error whose message matches one of these patterns will not trigger a
notification.

Re: issue #6 