### PR TITLE
Don't send request if disabled is true

### DIFF
--- a/honeybadger.js
+++ b/honeybadger.js
@@ -223,6 +223,8 @@
     }
 
     function request(url) {
+      if (config('disabled', false)) { return false; }
+
       // Use XHR when available.
       try {
         // Inspired by https://gist.github.com/Xeoncross/7663273
@@ -257,7 +259,6 @@
     }
 
     function notify(err, generated) {
-      if (config('disabled', false)) { return false; }
       if (!(typeof err === 'object')) { return false; }
 
       if (Object.prototype.toString.call(err) === '[object Error]') {


### PR DESCRIPTION
# Problem

When disabled is set to true (we don't want to send the request to notify), we are not outputting the error in development mode even if debug option was set to true.  The reason being is that we are halting too early.

# Solution

Halt later in the process. Specifically, any time we try to do a request, if disabled is true, don't do it.