### PR TITLE
Make Honeybadger.wrap() idempotent.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 - Notification is now halted later in the process when `disabled` is `true` so
   that errors are still logged when disabled. -@novito
+- Make calls to `Honeybadger.wrap` idempotent. Previously calling
+  `Honeybadger.wrap(Honeybadger.wrap(func))` would wrap the function twice. Some
+  events can be wrapped numerous times, causing a stack recursion error in
+  certain environments (specifically IE 11).
 
 ## [0.5.0] - 2017-07-19
 ### Changed

--- a/honeybadger.js
+++ b/honeybadger.js
@@ -384,6 +384,7 @@
             }
           };
         }
+        fn.___hb.___hb = fn.___hb;
         return fn.___hb;
       } catch(_e) {
         return fn;

--- a/spec/honeybadger.spec.js
+++ b/spec/honeybadger.spec.js
@@ -433,6 +433,14 @@ describe('Honeybadger', function() {
         expect(Honeybadger.wrap(func)).toEqual(func);
       });
     }
+
+    it('returns the same function when wrapping itself', function() {
+      var f = function() {}
+      var w = Honeybadger.wrap;
+
+      expect(w(w(f))).toEqual(w(f));
+      expect(w(w(w(f)))).toEqual(w(w(f)));
+    });
   });
 
   describe('beforeNotify', function() {


### PR DESCRIPTION
See the CHANGELOG for details. Fixes #75