### PR TITLE
Fix for Google Closure advanced compilation

### DIFF
--- a/honeybadger.js
+++ b/honeybadger.js
@@ -261,7 +261,7 @@
         return false;
       }
 
-      var url = baseURL() + '/v1/notices/js.gif?' + serialize({notice: payload}) +
+      var url = baseURL() + '/v1/notices/js.gif?' + serialize({'notice': payload}) +
         '&api_key=' + apiKey + '&t=' + new Date().getTime();
 
       request(url);
@@ -319,26 +319,26 @@
       }
 
       var payload = {
-        notifier: NOTIFIER,
-        error: {
+        'notifier': NOTIFIER,
+        'error': {
           'class': err.name || 'Error',
-          message: err.message,
-          backtrace: err.stack,
-          generator: err.generator,
-          fingerprint: err.fingerprint
+          'message': err.message,
+          'backtrace': err.stack,
+          'generator': err.generator,
+          'fingerprint': err.fingerprint
         },
-        request: {
-          url: err.url || document.URL,
-          component: err.component || config('component'),
-          action: err.action || config('action'),
-          context: merge(self.context, err.context),
-          cgi_data: data,
-          params: err.params
+        'request': {
+          'url': err.url || document.URL,
+          'component': err.component || config('component'),
+          'action': err.action || config('action'),
+          'context': merge(self.context, err.context),
+          'cgi_data': data,
+          'params': err.params
         },
-        server: {
-          project_root: err.projectRoot || err.project_root || config('projectRoot', config('project_root', window.location.protocol + '//' + window.location.host)),
-          environment_name: err.environment || config('environment'),
-          revision: err.revision || config('revision')
+        'server': {
+          'project_root': err.projectRoot || err.project_root || config('projectRoot', config('project_root', window.location.protocol + '//' + window.location.host)),
+          'environment_name': err.environment || config('environment'),
+          'revision': err.revision || config('revision')
         }
       };
 


### PR DESCRIPTION
We've been trying to use the `honeybadger-js` library from ClojureScript. One problem we ran into was that the Google Closure compiler was renaming the properties of the payload object before it was sent to the API.

This PR changes the payload to use quoted object properties so that Google Closure will not try to optimize it. This enables the library to work with ClojureScript without breaking any existing behavior.