### PR TITLE
Ensure main fn is bound to `this`

### DIFF
--- a/honeybadger.js
+++ b/honeybadger.js
@@ -631,4 +631,4 @@
   });
 
   return factory;
-}));
+}.bind(this)));


### PR DESCRIPTION
This fixes #88. It seems that UglifyJS is running in an undefined context. This ensures that the function is bound to the current context, i.e. `window`.