### PR TITLE
 fix(ChromeExtension): Fixed issue when this is a undefined

### DIFF
--- a/honeybadger.js
+++ b/honeybadger.js
@@ -48,7 +48,7 @@
     // Browser globals (root is window).
     root.Honeybadger = factory();
   }
-}(this, function (root) {
+}(this || window, function (root) {
   var VERSION = '0.5.4',
       NOTIFIER = {
         name: 'honeybadger.js',


### PR DESCRIPTION
## Summary

### Current Behavior

We tried to use honeybadger to send analytics for our chrome extension. But after importing this JS file we get an error `Cannot read console of undefined`.

### Expected Result

No error should be thrown.

### What I did ?

Since `this` is undefined in chrome extension's  `content script`  But `window` exists. We should check it and put it in case when this is undefined.
