### PR TITLE
Fix continuing issues with this being undefined/undefined context

### DIFF
--- a/honeybadger.js
+++ b/honeybadger.js
@@ -28,7 +28,7 @@
   // Build the singleton factory. The factory can be accessed through
   // singleton.factory() to instantiate a new instance.
   var factory = function(){
-    var f = builder(root);
+    var f = builder();
     var singleton = f(scriptConfig);
     singleton.factory = f;
     return singleton;
@@ -178,7 +178,8 @@
     }
 
     function log() {
-      if (root.console) {
+      var console = window.console;
+      if (console) {
         var args = Array.prototype.slice.call(arguments);
         args.unshift('[Honeybadger]');
         console.log.apply(console, args);
@@ -187,7 +188,7 @@
 
     function debug() {
       if (config('debug')) {
-        return log.apply(root, arguments);
+        return log.apply(this, arguments);
       }
     }
 
@@ -238,7 +239,7 @@
       // Use XHR when available.
       try {
         // Inspired by https://gist.github.com/Xeoncross/7663273
-        var x = new(root.XMLHttpRequest || ActiveXObject)('MSXML2.XMLHTTP.3.0');
+        var x = new(window.XMLHttpRequest || ActiveXObject)('MSXML2.XMLHTTP.3.0');
         x.open('GET', url, config('async', true));
         x.send();
         incrementErrorsCount();

--- a/honeybadger.js
+++ b/honeybadger.js
@@ -48,7 +48,7 @@
     // Browser globals (root is window).
     root.Honeybadger = factory();
   }
-}(this, function (root) {
+}(typeof self !== 'undefined' ? self : this, function () {
   var VERSION = '0.5.4',
       NOTIFIER = {
         name: 'honeybadger.js',


### PR DESCRIPTION
See the commit messages for each of the commits in this PR, which fix specific aspects of this issue. This reverts the behavior added in #88/#92 and takes a different approach.

This PR does not fix the context for `this` being undefined in certain environments inside the factory builder function (see #89); instead, it relies directly on `window` for objects which depend on `window`, rather than assuming that `this` is window inside the function. We're already using this approach elsewhere in the factory (for instance, in `Honeybadger.notify`), so I think it's fairly safe. If we need to revisit this in the future, we can do it as a whole.

This should also fix #94 and #95.

cc @geoffreak @monde @stympy @rathboma @kellym @shahen94 -- lmk what you think.