### PR TITLE
Merge context from error objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ CHANGELOG](http://keepachangelog.com/) for how to update this file. This project
 adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Fixed
+- Context is now merged if existing in both `err.context` and `opts.context`
+  when: `Honeybadger.notify(err, opts)`.
 
 ## [1.0.2] - 2019-04-17
 ### Fixed

--- a/spec/main.spec.js
+++ b/spec/main.spec.js
@@ -327,7 +327,7 @@ describe('Honeybadger', function() {
       });
 
       try {
-        throw new Error("Honeybadger don't care, but you might.");
+        throw new Error('expected message');
       } catch (e) {
         Honeybadger.notify({
           error: e
@@ -345,13 +345,34 @@ describe('Honeybadger', function() {
       });
 
       try {
-        throw new Error("Honeybadger don't care, but you might.");
+        throw new Error('expected message');
       } catch (e) {
-        Honeybadger.notify(e, 'CustomError');
+        Honeybadger.notify(e, 'expected name');
       }
 
       afterNotify(done, function() {
         expect(requests.length).toEqual(1);
+        expect(request.payload.error.message).toEqual('expected message');
+        expect(request.payload.error.class).toEqual('expected name');
+      });
+    });
+
+    it('accepts options as second argument', function(done) {
+      Honeybadger.configure({
+        api_key: 'asdf'
+      });
+
+      try {
+        throw new Error('original message');
+      } catch (e) {
+        Honeybadger.notify(e, {
+          message: 'expected message'
+        });
+      }
+
+      afterNotify(done, function() {
+        expect(requests.length).toEqual(1);
+        expect(request.payload.error.message).toEqual('expected message');
       });
     });
 
@@ -361,15 +382,17 @@ describe('Honeybadger', function() {
       });
 
       try {
-        throw new Error("Honeybadger don't care, but you might.");
+        throw new Error('original message');
       } catch (e) {
-        Honeybadger.notify(e, 'CustomError', {
-          message: 'Custom message'
+        Honeybadger.notify(e, 'expected name', {
+          message: 'expected message'
         });
       }
 
       afterNotify(done, function() {
         expect(requests.length).toEqual(1);
+        expect(request.payload.error.class).toEqual('expected name');
+        expect(request.payload.error.message).toEqual('expected message');
       });
     });
 

--- a/spec/main.spec.js
+++ b/spec/main.spec.js
@@ -447,9 +447,7 @@ describe('Honeybadger', function() {
       });
 
       var err = new Error("Testing");
-      err.context = {
-        key: 'unique context'
-      }
+      err.component = 'expected component';
 
       try {
         throw err;
@@ -459,7 +457,29 @@ describe('Honeybadger', function() {
 
       afterNotify(done, function() {
         expect(requests.length).toEqual(1);
-        expect(request.payload.request.context.key).toEqual('unique context');
+        expect(request.payload.request.component).toEqual('expected component');
+      });
+    });
+
+    it('merges context from error objects', function(done) {
+      Honeybadger.configure({
+        api_key: 'asdf'
+      });
+
+      var err = new Error("Testing");
+      err.context = {
+        foo: 'foo'
+      }
+
+      try {
+        throw err;
+      } catch (e) {
+        Honeybadger.notify(e, { context: { bar: 'bar' } });
+      }
+
+      afterNotify(done, function() {
+        expect(requests.length).toEqual(1);
+        expect(request.payload.request.context).toEqual({ foo: 'foo', bar: 'bar' });
       });
     });
 

--- a/src/builder.js
+++ b/src/builder.js
@@ -24,7 +24,7 @@ export default function builder() {
   }
 
   function mergeErr(err1, err2) {
-    let ret =  merge(err2, err2);
+    let ret = merge(err1, err2);
 
     if (err1.context && err2.context) {
       ret.context = merge(err1.context, err2.context);

--- a/src/builder.js
+++ b/src/builder.js
@@ -23,6 +23,16 @@ export default function builder() {
     return obj3;
   }
 
+  function mergeErr(err1, err2) {
+    let ret =  merge(err2, err2);
+
+    if (err1.context && err2.context) {
+      ret.context = merge(err1.context, err2.context);
+    }
+
+    return ret;
+  }
+
   function currentErrIs(err) {
     if (!currentErr) { return false; }
     if (currentErr.name !== err.name) { return false; }
@@ -386,10 +396,10 @@ export default function builder() {
       }
 
       if (name) {
-        err = merge(err, name);
+        err = mergeErr(err, name);
       }
       if (typeof extra === 'object') {
-        err = merge(err, extra);
+        err = mergeErr(err, extra);
       }
 
       return notify(err, generateStackTrace(err));


### PR DESCRIPTION
fixes https://github.com/honeybadger-io/honeybadger-react/issues/29

This should allow for the following use case:

    let err = new Error('message');
    err.context = { key1: 'value1' };
    Honeybadger.notify(err, { context: { key2: 'value2' } });
    # => Error reported w/ context: { key1: 'key1', key2: 'key2' }