### PR TITLE
Report unhandled promise rejections #133

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Added
+- Report unhandled promise rejections using `window.onunhandledrejection`. PR #140 by @ryanoglesby08
+
 ## [1.0.3] - 2019-05-15
 ### Fixed
 - Context is now merged if existing in both `err.context` and `opts.context`

--- a/spec/main.spec.js
+++ b/spec/main.spec.js
@@ -818,9 +818,9 @@ describe('Honeybadger', function() {
 
         afterNotify(done, function() {
           expect(requests.length).toEqual(1);
-          expect(request.payload.error.class).toEqual('window.onunhandledrejection')
+          expect(request.payload.error.class).toEqual('window.onunhandledrejection');
           expect(request.payload.error.message).toEqual('UnhandledPromiseRejectionWarning: Something has gone wrong');
-          expect(request.payload.error.backtrace).toEqual('UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch().')
+          expect(request.payload.error.backtrace).toBeUndefined();
         });
       });
 
@@ -835,9 +835,9 @@ describe('Honeybadger', function() {
 
         afterNotify(done, function() {
           expect(requests.length).toEqual(1);
-          expect(request.payload.error.class).toEqual('Error')
+          expect(request.payload.error.class).toEqual('Error');
           expect(request.payload.error.message).toEqual('UnhandledPromiseRejectionWarning: Error: Something has gone wrong');
-          expect(request.payload.error.backtrace).toEqual('the stack trace\nUnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch().')
+          expect(request.payload.error.backtrace).toEqual('the stack trace');
         });
       });
 
@@ -868,9 +868,9 @@ describe('Honeybadger', function() {
 
         afterNotify(done, function() {
           expect(requests.length).toEqual(1);
-          expect(request.payload.error.class).toEqual('window.onunhandledrejection')
+          expect(request.payload.error.class).toEqual('window.onunhandledrejection');
           expect(request.payload.error.message).toEqual('UnhandledPromiseRejectionWarning: {"errorCode":"123"}');
-          expect(request.payload.error.backtrace).toEqual('UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch().')
+          expect(request.payload.error.backtrace).toBeUndefined();
         });
       });
 

--- a/spec/main.spec.js
+++ b/spec/main.spec.js
@@ -800,6 +800,104 @@ describe('Honeybadger', function() {
     });
   });
 
+  describe('window.onunhandledrejection callback', function() {
+    describe('default behavior', function() {
+      beforeEach(function() {
+        Honeybadger.configure({
+          api_key: 'asdf'
+        });
+      });
+
+      it('reports the promise rejection reason when it is a string', function(done) {
+        let reason = 'Something has gone wrong'
+        let promiseRejection = new PromiseRejectionEvent('unhandledrejection', {
+          promise: Promise.reject(reason),
+          reason
+        })
+        window.onunhandledrejection(promiseRejection);
+
+        afterNotify(done, function() {
+          expect(requests.length).toEqual(1);
+          expect(request.payload.error.class).toEqual('window.onunhandledrejection')
+          expect(request.payload.error.message).toEqual('UnhandledPromiseRejectionWarning: Something has gone wrong');
+          expect(request.payload.error.backtrace).toEqual('UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch().')
+        });
+      });
+
+      it('reports the promise rejection reason when it is an Error object', function(done) {
+        let reason = new Error('Something has gone wrong')
+        reason.stack = "the stack trace"
+        let promiseRejection = new PromiseRejectionEvent('unhandledrejection', {
+          promise: Promise.reject(reason),
+          reason
+        })
+        window.onunhandledrejection(promiseRejection);
+
+        afterNotify(done, function() {
+          expect(requests.length).toEqual(1);
+          expect(request.payload.error.class).toEqual('Error')
+          expect(request.payload.error.message).toEqual('UnhandledPromiseRejectionWarning: Error: Something has gone wrong');
+          expect(request.payload.error.backtrace).toEqual('the stack trace\nUnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch().')
+        });
+      });
+
+      it('supplements the stack when the promise rejection reason is an Error but does not have one', function(done) {
+        let reason = new Error('Something has gone wrong')
+        reason.stack = undefined
+        reason.fileName = 'file.js'
+        reason.lineNumber = 25
+        let promiseRejection = new PromiseRejectionEvent('unhandledrejection', {
+          promise: Promise.reject(reason),
+          reason
+        })
+        window.onunhandledrejection(promiseRejection);
+
+        afterNotify(done, function() {
+          expect(requests.length).toEqual(1);
+          expect(request.payload.error.backtrace).toContain('Something has gone wrong\n    at ? (file.js:25)')
+        });
+      });
+
+      it('reports the promise rejection reason when it is a custom object', function(done) {
+        let reason = { errorCode: '123' }
+        let promiseRejection = new PromiseRejectionEvent('unhandledrejection', {
+          promise: Promise.reject(reason),
+          reason
+        })
+        window.onunhandledrejection(promiseRejection);
+
+        afterNotify(done, function() {
+          expect(requests.length).toEqual(1);
+          expect(request.payload.error.class).toEqual('window.onunhandledrejection')
+          expect(request.payload.error.message).toEqual('UnhandledPromiseRejectionWarning: {"errorCode":"123"}');
+          expect(request.payload.error.backtrace).toEqual('UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch().')
+        });
+      });
+
+      describe('when onunhandledrejection is disabled', function() {
+        beforeEach(function() {
+          Honeybadger.configure({
+            api_key: 'asdf',
+            onunhandledrejection: false
+          });
+        });
+  
+        it('ignores unhandled promise rejections', function(done) {
+          let reason = 'Something has gone wrong'
+          let promiseRejection = new PromiseRejectionEvent('unhandledrejection', {
+            promise: Promise.reject(reason),
+            reason
+          })
+          window.onunhandledrejection(promiseRejection);
+
+          afterNotify(done, function() {
+            expect(requests.length).toEqual(0);
+          });
+        });
+      });
+    })
+  })
+
   describe('getVersion', function() {
     it('returns the current version', function() {
       expect(Honeybadger.getVersion()).toMatch(/\d\.\d\.\d/)

--- a/spec/main.spec.js
+++ b/spec/main.spec.js
@@ -803,6 +803,12 @@ describe('Honeybadger', function() {
   describe('window.onunhandledrejection callback', function() {
     describe('default behavior', function() {
       beforeEach(function() {
+        if (typeof PromiseRejectionEvent === 'undefined') {
+          pending();
+        }
+      });
+
+      beforeEach(function() {
         Honeybadger.configure({
           api_key: 'asdf'
         });
@@ -881,7 +887,7 @@ describe('Honeybadger', function() {
             onunhandledrejection: false
           });
         });
-  
+
         it('ignores unhandled promise rejections', function(done) {
           let reason = 'Something has gone wrong'
           let promiseRejection = new PromiseRejectionEvent('unhandledrejection', {

--- a/src/builder.js
+++ b/src/builder.js
@@ -584,17 +584,18 @@ export default function builder() {
 
         if (!onUnhandledRejectionEnabled()) { return; }
 
-        let { reason } = promiseRejectionEvent
+        let { reason } = promiseRejectionEvent;
 
         if (reason instanceof Error) {
           // simulate v8 stack
-          let fileName = reason.fileName || 'unknown'
-          let lineNumber = reason.lineNumber || 0
-          let stackFallback = `${reason.message}\n    at ? (${fileName}:${lineNumber})`
+          let fileName = reason.fileName || 'unknown';
+          let lineNumber = reason.lineNumber || 0;
+          let stackFallback = `${reason.message}\n    at ? (${fileName}:${lineNumber})`;
 
-          let stack = stackTrace(reason) || stackFallback
+          let stack = stackTrace(reason) || stackFallback;
 
-          notify(reason, {
+          notify({
+            name,
             message: `UnhandledPromiseRejectionWarning: ${reason}`,
             stack
           });

--- a/src/builder.js
+++ b/src/builder.js
@@ -596,9 +596,8 @@ export default function builder() {
       return function(promiseRejectionEvent) {
         onunhandledrejection(promiseRejectionEvent);
         if (typeof original === 'function') {
-          return original.apply(this, arguments);
+          original.apply(this, arguments);
         }
-        return false;
       }
     })
 

--- a/src/builder.js
+++ b/src/builder.js
@@ -569,7 +569,7 @@ export default function builder() {
         if (!onUnhandledRejectionEnabled()) { return; }
 
         let { reason } = promiseRejectionEvent
-        
+
         if (reason instanceof Error) {
           // simulate v8 stack
           let fileName = reason.fileName || 'unknown'
@@ -579,7 +579,7 @@ export default function builder() {
           let stack = stackTrace(reason) || stackFallback
 
           notify(reason, {
-            message: `UnhandledPromiseRejectionWarning: ${reason}`,  
+            message: `UnhandledPromiseRejectionWarning: ${reason}`,
             stack
           });
 

--- a/src/builder.js
+++ b/src/builder.js
@@ -570,10 +570,6 @@ export default function builder() {
 
         let { reason } = promiseRejectionEvent
         
-        // This error message is copied from the Node.js warning
-        // See https://nodejs.org/api/process.html#process_event_unhandledrejection
-        const PROMISE_REJECTION_WARNING = 'UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch().'
-
         if (reason instanceof Error) {
           // simulate v8 stack
           let fileName = reason.fileName || 'unknown'
@@ -584,7 +580,7 @@ export default function builder() {
 
           notify(reason, {
             message: `UnhandledPromiseRejectionWarning: ${reason}`,  
-            stack: stack + "\n" + PROMISE_REJECTION_WARNING
+            stack
           });
 
           return;
@@ -594,7 +590,6 @@ export default function builder() {
         notify({
           name: 'window.onunhandledrejection',
           message: `UnhandledPromiseRejectionWarning: ${message}`,
-          stack: PROMISE_REJECTION_WARNING
         });
       }
 

--- a/src/builder.js
+++ b/src/builder.js
@@ -591,11 +591,10 @@ export default function builder() {
           let fileName = reason.fileName || 'unknown';
           let lineNumber = reason.lineNumber || 0;
           let stackFallback = `${reason.message}\n    at ? (${fileName}:${lineNumber})`;
-
           let stack = stackTrace(reason) || stackFallback;
 
           notify({
-            name,
+            name: reason.name,
             message: `UnhandledPromiseRejectionWarning: ${reason}`,
             stack
           });


### PR DESCRIPTION
## Status

**READY**

## Description

This PR adds support for reporting unhandled promise rejections, as described in Issue #133.

In short, this PR adds a listener to `window.onunhandledrejection`, which gets invoked when a promise rejection is not handled with either `try...catch` or `Promise.catch()`. This might happen if an un-expected runtime error occurs, such as as an null pointer exception, or not handling a normal Promise rejection. The normal `window.onerror` handler will NOT be invoked in these cases. Here are some examples.

```js
fetch('/api/user/123')
  .then(data => {
    // User 123 does not have any data, but the API call returned a 200. So data = {}
    let name = data.profile.name // 💥TypeError: Cannot read property 'name' of undefined
  })
```

```js
let stuff = undefined
new Promise((resolve, reject), () => {
  if( stuff ) {
    resolve(stuff)
  }
  else {
    reject(new Error("We have no stuff!"))
  }
}).then(stuff => {
    // do stuff
})

// => 💥Uncaught (in promise) Error: We have no stuff!
```

See: https://developer.mozilla.org/en-US/docs/Web/API/Window/unhandledrejection_event

## More info

* This is enabled by default, but you could switch the config so that it is opt in if that's preferred. Or do a major version bump.
* Will want to add the config option of `onunhandledrejection` to the main docs site too.

## Todos
- [x] Tests
- [ ] Documentation
- [ ] Changelog Entry (unreleased)
