### PR TITLE
Fix before notify props

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ CHANGELOG](http://keepachangelog.com/) for how to update this file. This project
 adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Fixed
+- Fix a bug in `beforeNotify` logic where notice properties were not
+  correctly passed to the handlers. All properties now [work as
+  documented](https://docs.honeybadger.io/lib/javascript/guides/filtering-sensitive-data.html).
 
 ## [1.0.3] - 2019-05-15
 ### Fixed

--- a/spec/main.spec.js
+++ b/spec/main.spec.js
@@ -592,7 +592,12 @@ describe('Honeybadger', function() {
   describe('beforeNotify', function() {
     beforeEach(function() {
       Honeybadger.configure({
-        apiKey: 'asdf'
+        apiKey: 'asdf',
+        environment: 'config environment',
+        component: 'config component',
+        action: 'config action',
+        revision: 'config revision',
+        projectRoot: 'config projectRoot'
       });
     });
 
@@ -600,7 +605,7 @@ describe('Honeybadger', function() {
       Honeybadger.beforeNotify(function() {
         return false;
       });
-      Honeybadger.notify("testing");
+      Honeybadger.notify('testing');
 
       afterNotify(done, function() {
         expect(requests.length).toEqual(0);
@@ -611,7 +616,7 @@ describe('Honeybadger', function() {
       Honeybadger.beforeNotify(function() {
         return true;
       });
-      Honeybadger.notify("testing");
+      Honeybadger.notify('testing');
 
       afterNotify(done, function() {
         expect(requests.length).toEqual(1);
@@ -620,7 +625,7 @@ describe('Honeybadger', function() {
 
     it('delivers notice when beforeNotify has no return', function(done) {
       Honeybadger.beforeNotify(function() {});
-      Honeybadger.notify("testing");
+      Honeybadger.notify('testing');
 
       afterNotify(done, function() {
         expect(requests.length).toEqual(1);
@@ -628,14 +633,6 @@ describe('Honeybadger', function() {
     });
 
     it('it is called with default notice properties', function(done) {
-      Honeybadger.configure({
-        environment: 'config environment',
-        component: 'config component',
-        action: 'config action',
-        revision: 'config revision',
-        projectRoot: 'config projectRoot'
-      });
-
       let notice;
       Honeybadger.beforeNotify(function(n) {
         notice = n;
@@ -662,7 +659,7 @@ describe('Honeybadger', function() {
       });
     });
 
-    it('it is called with passed notice properties', function(done) {
+    it('it is called with overridden notice properties', function(done) {
       let notice;
       Honeybadger.beforeNotify(function(n) {
         notice = n;
@@ -700,6 +697,44 @@ describe('Honeybadger', function() {
         expect(notice.params).toEqual({ expected_params_key: 'expected value' });
         expect(notice.cookies).toEqual({ expected_cookies_key: 'expected value' });
         expect(notice.revision).toEqual('expected revision');
+      });
+    });
+
+    it('it assigns notice properties', function(done) {
+      Honeybadger.beforeNotify(function(notice) {
+        notice.stack = 'expected stack',
+        notice.name = 'expected name',
+        notice.message = 'expected message',
+        notice.url = 'expected url',
+        notice.projectRoot = 'expected projectRoot',
+        notice.environment = 'expected environment',
+        notice.component = 'expected component',
+        notice.action = 'expected action',
+        notice.fingerprint = 'expected fingerprint',
+        notice.context = { expected_context_key: 'expected value' },
+        notice.params = { expected_params_key: 'expected value' },
+        notice.cookies = 'expected cookie value';
+        notice.revision = 'expected revision'
+      });
+
+      Honeybadger.notify('notify message');
+
+      afterNotify(done, function() {
+        expect(requests.length).toEqual(1);
+
+        expect(request.payload.error.backtrace).toEqual('expected stack');
+        expect(request.payload.error.class).toEqual('expected name');
+        expect(request.payload.error.message).toEqual('expected message');
+        expect(request.payload.request.url).toEqual('expected url');
+        expect(request.payload.server.project_root).toEqual('expected projectRoot');
+        expect(request.payload.server.environment_name).toEqual('expected environment');
+        expect(request.payload.request.component).toEqual('expected component');
+        expect(request.payload.request.action).toEqual('expected action');
+        expect(request.payload.error.fingerprint).toEqual('expected fingerprint');
+        expect(request.payload.request.context).toEqual({ expected_context_key: 'expected value' });
+        expect(request.payload.request.params).toEqual({ expected_params_key: 'expected value' });
+        expect(request.payload.request.cgi_data.HTTP_COOKIE).toEqual('expected cookie value');
+        expect(request.payload.server.revision).toEqual('expected revision');
       });
     });
 

--- a/spec/main.spec.js
+++ b/spec/main.spec.js
@@ -311,13 +311,13 @@ describe('Honeybadger', function() {
         api_key: 'asdf'
       });
 
-      var notice = Honeybadger.notify("Honeybadger don't care, but you might.");
+      Honeybadger.notify('expected message');
 
-      expect(notice.stack).toEqual(jasmine.any(String));
-      expect(notice.generator).toEqual(jasmine.any(String));
-      expect(notice.message).toEqual("Honeybadger don't care, but you might.");
       afterNotify(done, function() {
         expect(requests.length).toEqual(1);
+        expect(request.payload.error.message).toEqual('expected message');
+        expect(request.payload.error.generator).toEqual('throw');
+        expect(request.payload.error.backtrace).toEqual(jasmine.any(String));
       });
     });
 
@@ -636,8 +636,7 @@ describe('Honeybadger', function() {
         projectRoot: 'config projectRoot'
       });
 
-      var notice;
-
+      let notice;
       Honeybadger.beforeNotify(function(n) {
         notice = n;
       });
@@ -664,8 +663,7 @@ describe('Honeybadger', function() {
     });
 
     it('it is called with passed notice properties', function(done) {
-      var notice;
-
+      let notice;
       Honeybadger.beforeNotify(function(n) {
         notice = n;
       });
@@ -702,6 +700,36 @@ describe('Honeybadger', function() {
         expect(notice.params).toEqual({ expected_params_key: 'expected value' });
         expect(notice.cookies).toEqual({ expected_cookies_key: 'expected value' });
         expect(notice.revision).toEqual('expected revision');
+      });
+    });
+
+    it('does not expose the stack generator', function(done) {
+      let notice;
+      Honeybadger.beforeNotify(function(n) {
+        notice = n;
+      });
+
+      Honeybadger.notify('expected message');
+
+      afterNotify(done, function() {
+        expect(requests.length).toEqual(1);
+        expect(notice.generator).toEqual(undefined);
+        expect(request.payload.error.backtrace).toEqual(jasmine.any(String));
+        expect(request.payload.error.generator).toEqual('throw');
+      });
+    });
+
+    it('it resets generator when stack changes', function(done) {
+      Honeybadger.beforeNotify(function(notice) {
+        notice.stack = 'expected stack';
+      });
+
+      Honeybadger.notify('expected message');
+
+      afterNotify(done, function() {
+        expect(requests.length).toEqual(1);
+        expect(request.payload.error.backtrace).toEqual(jasmine.any(String));
+        expect(request.payload.error.generator).toEqual(undefined);
       });
     });
   });

--- a/spec/main.spec.js
+++ b/spec/main.spec.js
@@ -592,7 +592,7 @@ describe('Honeybadger', function() {
   describe('beforeNotify', function() {
     beforeEach(function() {
       Honeybadger.configure({
-        api_key: 'asdf'
+        apiKey: 'asdf'
       });
     });
 
@@ -624,6 +624,84 @@ describe('Honeybadger', function() {
 
       afterNotify(done, function() {
         expect(requests.length).toEqual(1);
+      });
+    });
+
+    it('it is called with default notice properties', function(done) {
+      Honeybadger.configure({
+        environment: 'config environment',
+        component: 'config component',
+        action: 'config action',
+        revision: 'config revision',
+        projectRoot: 'config projectRoot'
+      });
+
+      var notice;
+
+      Honeybadger.beforeNotify(function(n) {
+        notice = n;
+      });
+
+      Honeybadger.notify('expected message');
+
+      afterNotify(done, function() {
+        expect(requests.length).toEqual(1);
+
+        expect(notice.stack).toEqual(jasmine.any(String));
+        expect(notice.name).toEqual('Error');
+        expect(notice.message).toEqual('expected message');
+        expect(notice.url).toEqual(jasmine.any(String));
+        expect(notice.projectRoot).toEqual('config projectRoot');
+        expect(notice.environment).toEqual('config environment');
+        expect(notice.component).toEqual('config component');
+        expect(notice.action).toEqual('config action');
+        expect(notice.fingerprint).toEqual(undefined);
+        expect(notice.context).toEqual({});
+        expect(notice.params).toEqual(undefined);
+        expect(notice.cookies).toEqual(undefined);
+        expect(notice.revision).toEqual('config revision');
+      });
+    });
+
+    it('it is called with passed notice properties', function(done) {
+      var notice;
+
+      Honeybadger.beforeNotify(function(n) {
+        notice = n;
+      });
+
+      Honeybadger.notify({
+        stack: 'expected stack',
+        name: 'expected name',
+        message: 'expected message',
+        url: 'expected url',
+        projectRoot: 'expected projectRoot',
+        environment: 'expected environment',
+        component: 'expected component',
+        action: 'expected action',
+        fingerprint: 'expected fingerprint',
+        context: { expected_context_key: 'expected value' },
+        params: { expected_params_key: 'expected value' },
+        cookies: { expected_cookies_key: 'expected value' },
+        revision: 'expected revision'
+      });
+
+      afterNotify(done, function() {
+        expect(requests.length).toEqual(1);
+
+        expect(notice.stack).toEqual('expected stack');
+        expect(notice.name).toEqual('expected name');
+        expect(notice.message).toEqual('expected message');
+        expect(notice.url).toEqual('expected url');
+        expect(notice.projectRoot).toEqual('expected projectRoot');
+        expect(notice.environment).toEqual('expected environment');
+        expect(notice.component).toEqual('expected component');
+        expect(notice.action).toEqual('expected action');
+        expect(notice.fingerprint).toEqual('expected fingerprint');
+        expect(notice.context).toEqual({ expected_context_key: 'expected value' });
+        expect(notice.params).toEqual({ expected_params_key: 'expected value' });
+        expect(notice.cookies).toEqual({ expected_cookies_key: 'expected value' });
+        expect(notice.revision).toEqual('expected revision');
       });
     });
   });

--- a/src/builder.js
+++ b/src/builder.js
@@ -287,9 +287,9 @@ export default function builder() {
         revision: err.revision || config('revision')
       });
 
-      if (isIgnored(err, config('ignorePatterns'))) { return false; }
-
       if (checkHandlers(self.beforeNotifyHandlers, err)) { return false; }
+
+      if (isIgnored(err, config('ignorePatterns'))) { return false; }
 
       var data = cgiData();
       if (typeof err.cookies === 'string') {

--- a/src/builder.js
+++ b/src/builder.js
@@ -272,8 +272,10 @@ export default function builder() {
         return false;
       }
 
+      let generator;
       if (generated) {
-        err = merge(err, generated);
+        err.stack = generated.stack;
+        generator = generated.generator;
       }
 
       err = merge(err, {
@@ -287,7 +289,12 @@ export default function builder() {
         revision: err.revision || config('revision')
       });
 
+      let stack_before_handlers = err.stack;
       if (checkHandlers(self.beforeNotifyHandlers, err)) { return false; }
+      if (err.stack != stack_before_handlers) {
+        // Stack changed, so it's not generated.
+        generator = undefined;
+      }
 
       if (isIgnored(err, config('ignorePatterns'))) { return false; }
 
@@ -304,7 +311,7 @@ export default function builder() {
           'class': err.name,
           'message': err.message,
           'backtrace': err.stack,
-          'generator': err.generator,
+          'generator': generator,
           'fingerprint': err.fingerprint
         },
         'request': {

--- a/src/builder.js
+++ b/src/builder.js
@@ -124,6 +124,18 @@ export default function builder() {
     return false;
   }
 
+  function objectIsEmpty(obj) {
+    return ((function() {
+      var k, results;
+      results = [];
+      for (k in obj) {
+        if (!Object.prototype.hasOwnProperty.call(obj, k)) continue;
+        results.push(k);
+      }
+      return results;
+    })()).length === 0;
+  }
+
   // Client factory.
   var factory = (function(opts) {
     var notSingleton = installed;
@@ -259,18 +271,7 @@ export default function builder() {
         send(currentPayload);
       }
 
-      // Halt if err is empty.
-      if (((function() {
-        var k, results;
-        results = [];
-        for (k in err) {
-          if (!Object.prototype.hasOwnProperty.call(err, k)) continue;
-          results.push(k);
-        }
-        return results;
-      })()).length === 0) {
-        return false;
-      }
+      if (objectIsEmpty(err)) { return false; }
 
       let generator;
       if (generated) {

--- a/src/builder.js
+++ b/src/builder.js
@@ -276,6 +276,17 @@ export default function builder() {
         err = merge(err, generated);
       }
 
+      err = merge(err, {
+        name: err.name || 'Error',
+        context: merge(self.context, err.context),
+        url: err.url || document.URL,
+        projectRoot: err.projectRoot || err.project_root || config('projectRoot', config('project_root', window.location.protocol + '//' + window.location.host)),
+        environment: err.environment || config('environment'),
+        component: err.component || config('component'),
+        action: err.action || config('action'),
+        revision: err.revision || config('revision')
+      });
+
       if (isIgnored(err, config('ignorePatterns'))) { return false; }
 
       if (checkHandlers(self.beforeNotifyHandlers, err)) { return false; }
@@ -290,24 +301,24 @@ export default function builder() {
       var payload = {
         'notifier': NOTIFIER,
         'error': {
-          'class': err.name || 'Error',
+          'class': err.name,
           'message': err.message,
           'backtrace': err.stack,
           'generator': err.generator,
           'fingerprint': err.fingerprint
         },
         'request': {
-          'url': err.url || document.URL,
-          'component': err.component || config('component'),
-          'action': err.action || config('action'),
-          'context': merge(self.context, err.context),
+          'url': err.url,
+          'component': err.component,
+          'action': err.action,
+          'context': err.context,
           'cgi_data': data,
           'params': err.params
         },
         'server': {
-          'project_root': err.projectRoot || err.project_root || config('projectRoot', config('project_root', window.location.protocol + '//' + window.location.host)),
-          'environment_name': err.environment || config('environment'),
-          'revision': err.revision || config('revision')
+          'project_root': err.projectRoot,
+          'environment_name': err.environment,
+          'revision': err.revision
         }
       };
 

--- a/src/builder.js
+++ b/src/builder.js
@@ -136,6 +136,11 @@ export default function builder() {
     })()).length === 0;
   }
 
+  function objectIsExtensible(obj) {
+    if (typeof Object.isExtensible !== 'function') { return true; }
+    return Object.isExtensible(obj);
+  }
+
   // Client factory.
   var factory = (function(opts) {
     var notSingleton = installed;
@@ -346,11 +351,6 @@ export default function builder() {
       }
 
       return err;
-    }
-
-    function objectIsExtensible(obj) {
-      if (typeof Object.isExtensible !== 'function') { return true; }
-      return Object.isExtensible(obj);
     }
 
     var preferCatch = true;

--- a/src/builder.js
+++ b/src/builder.js
@@ -125,15 +125,12 @@ export default function builder() {
   }
 
   function objectIsEmpty(obj) {
-    return ((function() {
-      var k, results;
-      results = [];
-      for (k in obj) {
-        if (!Object.prototype.hasOwnProperty.call(obj, k)) continue;
-        results.push(k);
+    for (let k in obj) {
+      if (Object.prototype.hasOwnProperty.call(obj, k)) {
+        return false;
       }
-      return results;
-    })()).length === 0;
+    }
+    return true;
   }
 
   function objectIsExtensible(obj) {


### PR DESCRIPTION
## Status
**READY**

## Description
This PR fixes a bug in the `beforeNotify` logic where many notice properties were not passed in to the handler as documented:

https://docs.honeybadger.io/lib/javascript/guides/filtering-sensitive-data.html

Properties (such as `notice.url` could be assigned, but prior values were not available on the object to inspect, causing (i.e.) this example to fail:

```js
Honeybadger.beforeNotify(function(notice) {
  if (/creditCard/.test(notice.url)) { // <-- notice.url is undefined
    notice.url = '[FILTERED]'; // <-- works, but doesn't get here
  }
});
```

This PR also hides the internal stack trace `generator` properties, which were previously exposed through the `notice` (or would have been ;)).

## Todos
- [x] Tests
- [x] Documentation
- [x] Changelog Entry (unreleased)

## Steps to Test or Reproduce
Outline the steps to test or reproduce the PR here.
```bash
git pull --prune
git checkout fix-beforeNotify-props
npm test
```