### PR TITLE
chore: add cookies to Honeybadger types

### DIFF
--- a/honeybadger-js.d.ts
+++ b/honeybadger-js.d.ts
@@ -26,6 +26,7 @@ declare module "honeybadger-js" {
         action: string;
         fingerprint: string;
         context: any;
+        cookies?: string;
     }
 
     class Honeybadger {


### PR DESCRIPTION
## Status
<!--- **READY/WIP/HOLD** --->
**READY**

## Description
In order to align types with documentation about [sending-request-information]( https://docs.honeybadger.io/lib/javascript/guides/customizing-error-reports.html#sending-request-information ) we need to add `cookies` as possible parameter of `Notice` interface.

>Note: I can't really fill in the todo's as this is just a type extending
## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Changelog Entry (unreleased)
