### PR TITLE
add maxErrors to type definition for config

### DIFF
--- a/honeybadger-js.d.ts
+++ b/honeybadger-js.d.ts
@@ -11,6 +11,7 @@ declare module "honeybadger-js" {
         action?: string;
         onerror?: boolean;
         disabled?: boolean;
+        maxErrors?: number;
         ignorePatterns?: RegExp[];
         async?: boolean;
     }


### PR DESCRIPTION
## Status
**READY**

## Description
I was trying to add this configuration to our app, but TypeScript complained that `'maxErrors' does not exist in type 'Config'`.