### PR TITLE
Deal with nulls in array

### DIFF
--- a/spec/util/sanitize.spec.js
+++ b/spec/util/sanitize.spec.js
@@ -45,6 +45,17 @@ describe('utils/sanitize', () => {
     );
   });
 
+  it('drops null array items', function() {
+    expect(
+      sanitize(
+        {'obj': ['first', null]},
+        6
+      )
+    ).toEqual(
+      {'obj': ['first', '[object Null]']}
+    );
+  });
+
   it('enforces max depth in arrays', () => {
     expect(
       sanitize(

--- a/src/util/sanitize.js
+++ b/src/util/sanitize.js
@@ -16,6 +16,8 @@ export default function sanitize(obj, maxDepth) {
     // Functions are TMI and Symbols can't convert to strings.
     if (/function|symbol/.test(typeof(obj))) { return false; }
 
+    if (obj === null) { return false };
+
     // No prototype, likely created with `Object.create(null)`.
     if (typeof obj === 'object' && typeof obj.hasOwnProperty === 'undefined') { return false; }
 


### PR DESCRIPTION
Not sure if this is the right solution to nulls being included in sanitized arrays, but nulls are erroring because they are of an "object" type, yet don't implement `hasOwnProperty`