### PR TITLE
adds check to prevent an error when a null error is passed with argum…

### DIFF
--- a/spec/main.spec.js
+++ b/spec/main.spec.js
@@ -227,6 +227,19 @@ describe('Honeybadger', function() {
       });
     });
 
+    it('does deliver notice with arguments when using ignore patterns and error is null', function(done) {
+      Honeybadger.configure({
+        api_key: 'asdf',
+        ignorePatterns: [/care/i],
+      });
+
+      Honeybadger.notify(null, 'custom class name');
+
+      afterNotify(done, function() {
+        expect(requests.length).toEqual(1);
+      });
+    });
+
     it('does not deliver notice for ignored message', function(done) {
       Honeybadger.configure({
         api_key: 'asdf',

--- a/src/builder.js
+++ b/src/builder.js
@@ -47,6 +47,8 @@ export default function builder() {
   function isIgnored(err, patterns) {
     var msg = err.message;
 
+    if (!msg)  { return false; }
+
     for (var p in patterns) {
       if (msg.match(patterns[p])) { return true; }
     }


### PR DESCRIPTION
…ents and ignore patterns to notify fixes #266

## Status
**READY**

## Description
 - prevents an error that occurs when a null error is passed with arguments and ignore patterns

## Todos
- [X] Tests
- [ ] Documentation
- [ ] Changelog Entry (unreleased)

## Steps to Test or Reproduce
Outline the steps to test or reproduce the PR here.
```bash
> git pull --prune
> git checkout null-error
> npm test
```
1. Call Honeybadger.notify(undefined, 'DescriptiveClass'); or Honeybadger.notify(null, 'DescriptiveClass');
