### PR TITLE
Fix n.match is not a function error w/ ignorePatterns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ CHANGELOG](http://keepachangelog.com/) for how to update this file. This project
 adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Fixed
+- Fix `n.match` is not a function error w/ ignorePatterns.
 
 ## [2.1.1] - 2020-02-03
 ### Fixed

--- a/spec/main.spec.js
+++ b/spec/main.spec.js
@@ -227,19 +227,6 @@ describe('Honeybadger', function() {
       });
     });
 
-    it('does deliver notice with arguments when using ignore patterns and error is null', function(done) {
-      Honeybadger.configure({
-        api_key: 'asdf',
-        ignorePatterns: [/care/i],
-      });
-
-      Honeybadger.notify(null, 'custom class name');
-
-      afterNotify(done, function() {
-        expect(requests.length).toEqual(1);
-      });
-    });
-
     it('does not deliver notice for ignored message', function(done) {
       Honeybadger.configure({
         api_key: 'asdf',
@@ -532,6 +519,32 @@ describe('Honeybadger', function() {
 
       afterNotify(done, function() {
         expect(url).toEqual('global');
+      });
+    });
+
+    it('delivers notice with arguments when using ignore patterns and error is null', function(done) {
+      Honeybadger.configure({
+        api_key: 'asdf',
+        ignorePatterns: [/care/i],
+      });
+
+      Honeybadger.notify(null, 'custom class name');
+
+      afterNotify(done, function() {
+        expect(requests.length).toEqual(1);
+      });
+    });
+
+    it('delivers notice when using ignore patterns and message does not respond to match', function(done) {
+      Honeybadger.configure({
+        api_key: 'asdf',
+        ignorePatterns: [/care/i],
+      });
+
+      Honeybadger.notify({ message: {} });
+
+      afterNotify(done, function() {
+        expect(requests.length).toEqual(1);
       });
     });
   });

--- a/src/builder.js
+++ b/src/builder.js
@@ -47,10 +47,8 @@ export default function builder() {
   function isIgnored(err, patterns) {
     var msg = err.message;
 
-    if (!msg)  { return false; }
-
     for (var p in patterns) {
-      if (msg.match(patterns[p])) { return true; }
+      if (patterns[p].test(msg)) { return true; }
     }
 
     return false;


### PR DESCRIPTION
See https://github.com/honeybadger-io/honeybadger-js/issues/266

This adds an additional check to make sure that the err.message object
can be tested against a regexp.