### PR TITLE
feat(after-notify): hook to execute handlers after the request was sent

### DIFF
--- a/spec/main.spec.js
+++ b/spec/main.spec.js
@@ -795,6 +795,53 @@ describe('Honeybadger', function() {
     });
   });
 
+  describe('afterNotify', function() {
+    beforeEach(function() {
+      Honeybadger.configure({
+        apiKey: 'asdf',
+        environment: 'config environment',
+        component: 'config component',
+        action: 'config action',
+        revision: 'config revision',
+        projectRoot: 'config projectRoot',
+        afterNotifyHandlers: []
+      });
+    });
+
+    it('success', function(done) {
+      const id = '48b98609-dd3b-48ee-bffc-d51f309a2dfa';
+      Honeybadger.afterNotify(function(err, res) {
+        expect(res.id).toBe(id);
+        expect(err).toBeUndefined();
+        done();
+      });
+      Honeybadger.notify('testing');
+
+      setTimeout(function() {
+        expect(requests.length).toEqual(1);
+        request.respond(201, {}, JSON.stringify({id}));
+      }, 50);
+    });
+
+    it('error', function(done) {
+      const payload = {
+        error:
+          'Either the API key is incorrect or the account has been deactivated.'
+      };
+      Honeybadger.afterNotify(function(err, res) {
+        expect(res).toBeUndefined();
+        expect(err.error).toBe(payload.error);
+        done();
+      });
+      Honeybadger.notify('testing');
+
+      setTimeout(function() {
+        expect(requests.length).toEqual(1);
+        request.respond(403, {}, JSON.stringify(payload));
+      }, 50);
+    });
+  });
+
   describe('window.onerror callback', function() {
     describe('default behavior', function() {
       beforeEach(function() {


### PR DESCRIPTION
## Status
<!--- **WIP** --->
**WIP**

## Description
Add a hook to execute handlers after the request was sent.
#86  

I used the onload callback from XMLHttpRequest but I'm not sure If that's what you want?

I also pass the response to the handler but maybe we should also pass the payload sent?

## Todos
- [x] Implementation
- [x] Tests
- [ ] Documentation
