### PR TITLE
Add onunhandledrejection to Config interface type definition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ CHANGELOG](http://keepachangelog.com/) for how to update this file. This project
 adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Added
+- Fix TypeScript definition for Config interface to include onunhandledrejection as boolean. @tojofo
 
 ## [2.1.3] - 2020-02-17
 ### Fixed

--- a/honeybadger-js.d.ts
+++ b/honeybadger-js.d.ts
@@ -15,6 +15,7 @@ declare module "honeybadger-js" {
         ignorePatterns?: RegExp[];
         async?: boolean;
         breadcrumbsEnabled?: boolean;
+        onunhandledrejection?: boolean;
     }
 
     interface Notice {


### PR DESCRIPTION
Typescript compiler fails with an error if trying to use `onunhandledrejection`

## Status
**READY**

## Description
Allow `onunhandledrejection` to be used in Typescript projects when calling `Honeybadger.configure`
