### PR TITLE
Add definition for Honeybadger.addBreadcrumb

### DIFF
--- a/honeybadger-js.d.ts
+++ b/honeybadger-js.d.ts
@@ -31,6 +31,11 @@ declare module "honeybadger-js" {
         context: any;
         cookies?: string;
     }
+    
+    interface BreadcrumbOptions {
+        category?: string;
+        metadata?: { [s: string]: boolean | number | string };
+    }
 
     class Honeybadger {
         static apiKey: string;
@@ -44,6 +49,7 @@ declare module "honeybadger-js" {
         static resetContext<T extends Object>(context?: T): Honeybadger;
         static beforeNotify(func: (notice?: Notice) => void): Honeybadger;
         static beforeNotifyHandlers: ((notice?: Notice) => void)[];
+        static addBreadcrumb(message: string, opts?: BreadcrumbOptions): Honeybadger;
         static factory(config: Config): Honeybadger;
     }
 


### PR DESCRIPTION
## Status
<!--- **READY** --->
**READY**

## Description
Fixes the following error when running type checks on a project that uses Honeybadger:

    TS2339: Property 'addBreadcrumb' does not exist on type 'typeof Honeybadger'.
