### PR TITLE
Instrument on first Honeybadger.configure call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ CHANGELOG](http://keepachangelog.com/) for how to update this file. This project
 adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Added
+- Perform breadcrumbs instrumentation on first `Honeybadger.configure` call (#406)
+- Add config option to disable auto breadcrumbs by type
 
 ## [2.2.2] - 2020-05-22
 ### Fixed

--- a/spec/main.spec.js
+++ b/spec/main.spec.js
@@ -1124,6 +1124,24 @@ describe('Honeybadger', function() {
       });
     });
 
+    it('sends breadcrumbs when partially enabled', function(done) {
+      Honeybadger.configure({
+        breadcrumbsEnabled: {
+          console: true
+        },
+      });
+
+      Honeybadger.addBreadcrumb('expected message');
+      Honeybadger.notify('message');
+
+      afterNotify(done, function() {
+        expect(requests.length).toBe(1);
+        expect(request.payload.breadcrumbs.enabled).toBe(true);
+        expect(request.payload.breadcrumbs.trail.length).toBe(2);
+        expect(request.payload.breadcrumbs.trail[0].message).toEqual('expected message');
+      });
+    });
+
     it('sends empty breadcrumbs when disabled', function(done) {
       Honeybadger.configure({
         breadcrumbsEnabled: false,

--- a/src/builder.js
+++ b/src/builder.js
@@ -159,9 +159,9 @@ export default function builder() {
       errorsSent: 0,
       breadcrumbsEnabled: {
         dom: true,
-        console: true,
         network: true,
-        navigation: true
+        navigation: true,
+        console: true
       }
     };
     if (typeof opts === 'object') {


### PR DESCRIPTION
This makes two important changes:

1. Breadcrumbs auto-instrumentation is now performed on first `Honeybadger.configure` call, instead of on import.

   For now, `window.onerror` and other pre-breadcrumbs instrumentation is still performed on import due to architectural limitations. This is something we may be able to change in the next version of the library which is currently in-progress.

2. The `breadcrumbsEnabled` option has been enhanced to support an object syntax so that individual breadcrumbs instrumentation types (such as "console") may be disabled. `breadcrumbsEnabled: true` and `breadcrumbsEnabled: false` will also continue to work.

Fixes #397 