### PR TITLE
Add referrer and userAgent to notice object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ CHANGELOG](http://keepachangelog.com/) for how to update this file. This project
 adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Fixed
+- Add `referrer` and `userAgent` to notice object to support filtering
 
 ## [2.3.0-beta.0] - 2020-07-28
 ### Added

--- a/src/builder.js
+++ b/src/builder.js
@@ -262,7 +262,7 @@ export default function builder() {
     function buildPayload(err) {
       const data = {};
       if (err.userAgent) { data['HTTP_USER_AGENT'] = err.userAgent; }
-      if (err.referrer) { data['HTTP_REFERER'] = document.referrer; }
+      if (err.referrer) { data['HTTP_REFERER'] = err.referrer; }
       if (typeof err.cookies === 'string') {
         data['HTTP_COOKIE'] = err.cookies;
       } else if (typeof err.cookies === 'object') {

--- a/src/builder.js
+++ b/src/builder.js
@@ -57,15 +57,6 @@ export default function builder() {
     return patterns.some((p) => p.test(err.message));
   }
 
-  function cgiData() {
-    var data = {};
-    data['HTTP_USER_AGENT'] = navigator.userAgent;
-    if (document.referrer.match(/\S/)) {
-      data['HTTP_REFERER'] = document.referrer;
-    }
-    return data;
-  }
-
   function encodeCookie(object) {
     if (typeof object !== 'object') {
       return undefined;
@@ -269,7 +260,9 @@ export default function builder() {
     }
 
     function buildPayload(err) {
-      let data = cgiData();
+      const data = {};
+      if (err.userAgent) { data['HTTP_USER_AGENT'] = err.userAgent; }
+      if (err.referrer) { data['HTTP_REFERER'] = document.referrer; }
       if (typeof err.cookies === 'string') {
         data['HTTP_COOKIE'] = err.cookies;
       } else if (typeof err.cookies === 'object') {
@@ -342,7 +335,9 @@ export default function builder() {
         environment: err.environment || config('environment'),
         component: err.component || config('component'),
         action: err.action || config('action'),
-        revision: err.revision || config('revision')
+        revision: err.revision || config('revision'),
+        userAgent: err.userAgent || navigator.userAgent,
+        referrer: err.referrer || document.referrer
       });
 
       self.addBreadcrumb('Honeybadger Notice', {


### PR DESCRIPTION
This allows the referrer and userAgent strings to be filtered in `beforeNotify` handlers:

https://docs.honeybadger.io/lib/javascript/guides/filtering-sensitive-data.html