### PR TITLE
Disable honeybadger.js in development environments

### DIFF
--- a/honeybadger.d.ts
+++ b/honeybadger.d.ts
@@ -17,13 +17,14 @@ declare namespace Honeybadger {
 
   interface Config {
     apiKey: string | undefined
-    developmentEnvironments: string[],
+    developmentEnvironments: string[]
     environment: string | undefined
     projectRoot: string | undefined
     component: string | undefined
     action: string | undefined
     revision: string | undefined
     disabled: boolean
+    reportData: boolean
     breadcrumbsEnabled: boolean | { dom: boolean, network: boolean, navigation: boolean, console: boolean }
     maxBreadcrumbs: number
     maxObjectDepth: number

--- a/honeybadger.d.ts
+++ b/honeybadger.d.ts
@@ -17,6 +17,7 @@ declare namespace Honeybadger {
 
   interface Config {
     apiKey: string | undefined
+    developmentEnvironments: string[],
     environment: string | undefined
     projectRoot: string | undefined
     component: string | undefined

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -1,6 +1,6 @@
 import Client from './core/client'
 import { Config, Notice } from './core/types'
-import { merge, sanitize, runAfterNotifyHandlers, objectIsExtensible } from './core/util'
+import { merge, sanitize, runAfterNotifyHandlers, objectIsExtensible, envVal, envBoolean, envNumber } from './core/util'
 import { encodeCookie, preferCatch } from './browser/util'
 import { onError, ignoreNextOnError } from './browser/integrations/onerror'
 import onUnhandlerRejection from './browser/integrations/onunhandledrejection'
@@ -39,9 +39,9 @@ class Honeybadger extends Client {
 
   constructor(opts: Partial<BrowserConfig> = {}) {
     super({
-      async: true,
-      maxErrors: null,
-      projectRoot: (window.location.protocol + '//' + window.location.host),
+      async: envBoolean('HONEYBADGER_ASYNC', true),
+      maxErrors: envNumber('HONEYBADGER_MAX_ERRORS'),
+      projectRoot: envVal('HONEYBADGER_PROJECT_ROOT') || (window.location.protocol + '//' + window.location.host),
       ...opts
     })
   }

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -17,6 +17,7 @@ export interface Config {
   action: string | undefined
   revision: string | undefined
   disabled: boolean
+  reportData: boolean
   breadcrumbsEnabled: boolean | { dom: boolean, network: boolean, navigation: boolean, console: boolean }
   maxBreadcrumbs: number
   maxObjectDepth: number

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -10,6 +10,7 @@ export interface Logger {
 
 export interface Config {
   apiKey: string | undefined
+  developmentEnvironments: string[],
   environment: string | undefined
   projectRoot: string | undefined
   component: string | undefined

--- a/src/core/util.ts
+++ b/src/core/util.ts
@@ -194,3 +194,38 @@ export function instrument(object, name, replacement) {
   object[name] = replacement(original)
   object[name].__hb_original = original
 }
+
+export function envVal(key: string): string | null {
+  const val = getProcess().env[key.toUpperCase()]?.trim()
+  if (!val) { return null }
+  return val
+}
+
+export function envBoolean(key: string, fallback = false): boolean {
+  const val = envVal(key)
+  if (val === 'false' || val === '0') { return false }
+  if (val === 'true' || val === '1') { return true }
+  return fallback
+}
+
+export function envNumber(key: string): number | null {
+  const val = envVal(key)
+  if (!val) { return null }
+  return parseInt(val)
+}
+
+export function envList(key: string): string[] | null {
+  const val = envVal(key)
+  if (!val) { return null }
+  return val.split(/\s*,\s*/).map((v) => v.trim())
+}
+
+function getProcess(): {env: Record<string, string>} {
+  if (typeof process !== 'undefined') {
+    return process
+  } else {
+    return {
+      env: {}
+    }
+  }
+}

--- a/test/unit/core/client.test.ts
+++ b/test/unit/core/client.test.ts
@@ -17,7 +17,8 @@ describe('client', function () {
 
   beforeEach(function () {
     client = new TestClient({
-      logger: nullLogger()
+      logger: nullLogger(),
+      environment: null
     })
   })
 
@@ -136,6 +137,14 @@ describe('client', function () {
       client.configure({
         apiKey: 'testing',
         disabled: true
+      })
+      expect(client.notify(new Error('test'))).toEqual(false)
+    })
+
+    it('doesn\'t send the notice when in a development environment', function () {
+      client.configure({
+        apiKey: 'testing',
+        environment: 'development'
       })
       expect(client.notify(new Error('test'))).toEqual(false)
     })

--- a/test/unit/core/client.test.ts
+++ b/test/unit/core/client.test.ts
@@ -149,6 +149,23 @@ describe('client', function () {
       expect(client.notify(new Error('test'))).toEqual(false)
     })
 
+    it('doesn\'t send the notice when reportData is false', function () {
+      client.configure({
+        apiKey: 'testing',
+        reportData: false
+      })
+      expect(client.notify(new Error('test'))).toEqual(false)
+    })
+
+    it('does send the notice from a development environment when reportData is true', function () {
+      client.configure({
+        apiKey: 'testing',
+        environment: 'development',
+        reportData: true
+      })
+      expect(client.notify(new Error('test'))).toEqual(expect.any(Object))
+    })
+
     it('does not send notice without arguments', function () {
       client.configure({
         apiKey: 'testing'

--- a/test/unit/server.test.ts
+++ b/test/unit/server.test.ts
@@ -9,7 +9,8 @@ describe('server client', function () {
 
   beforeEach(function () {
     client = Singleton.factory({
-      logger: nullLogger()
+      logger: nullLogger(),
+      environment: null
     })
   })
 


### PR DESCRIPTION
Fixes #71 

- [x] Rename the `disabled` config option to `reportData` to match Ruby config (keep legacy support, maybe?)