### PR TITLE
Add uncaughtException server plugin for node

### DIFF
--- a/honeybadger.d.ts
+++ b/honeybadger.d.ts
@@ -41,12 +41,12 @@ declare namespace Honeybadger {
     logger: Logger
     enableUncaught: boolean
     afterUncaught: (err: Error) => void
+    enableUnhandledRejection: boolean
     [x: string]: unknown
 
     // Browser
     async: boolean
     maxErrors: number
-    onunhandledrejection: boolean
   }
 
   interface BeforeNotifyHandler {

--- a/honeybadger.d.ts
+++ b/honeybadger.d.ts
@@ -39,8 +39,8 @@ declare namespace Honeybadger {
     maxObjectDepth: number
     ignorePatterns: RegExp[]
     logger: Logger
-    onerror: boolean
-    afterUncaughtException: (err: Error) => void
+    enableUncaught: boolean
+    afterUncaught: (err: Error) => void
     [x: string]: unknown
 
     // Browser

--- a/honeybadger.d.ts
+++ b/honeybadger.d.ts
@@ -39,11 +39,14 @@ declare namespace Honeybadger {
     maxObjectDepth: number
     ignorePatterns: RegExp[]
     logger: Logger
+    onerror: boolean
+    afterUncaughtException: (err: Error) => void
+    [x: string]: unknown
+
+    // Browser
     async: boolean
     maxErrors: number
-    onerror: boolean
     onunhandledrejection: boolean
-    [x: string]: unknown
   }
 
   interface BeforeNotifyHandler {

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -11,7 +11,6 @@ import eventListeners from './browser/integrations/event_listeners'
 interface BrowserConfig extends Config {
   async: boolean
   maxErrors: number
-  onunhandledrejection: boolean
 }
 
 interface WrappedFunc {

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -11,7 +11,6 @@ import eventListeners from './browser/integrations/event_listeners'
 interface BrowserConfig extends Config {
   async: boolean
   maxErrors: number
-  onerror: boolean
   onunhandledrejection: boolean
 }
 

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -131,14 +131,14 @@ class Honeybadger extends Client {
         // eslint-disable-next-line @typescript-eslint/no-this-alias
         const client = this
         func.___hb = <WrappedFunc>function () {
-          const onerror = client.config.onerror
+          const onErrorEnabled = client.config.enableUncaught
           // Catch if:
           //   1. We explicitly want to catch (i.e. if the error could be
           //      caught before reaching window.onerror)
           //   2. The browser provides less information via the window.onerror
           //      handler
           //   3. The window.onerror handler is unavailable
-          if (opts.catch || preferCatch || !onerror) {
+          if (opts.catch || preferCatch || !onErrorEnabled) {
             try {
               // eslint-disable-next-line prefer-rest-params
               return func.apply(this, arguments)

--- a/src/browser/integrations/onerror.ts
+++ b/src/browser/integrations/onerror.ts
@@ -14,6 +14,7 @@ export function ignoreNextOnError(): void {
   })
 }
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function onError(_window: any = window): Plugin {
   return {
     load: (client: typeof Client) => {
@@ -27,7 +28,7 @@ export function onError(_window: any = window): Plugin {
             return
           }
 
-          if (!client.config.onerror) { return }
+          if (!client.config.enableUncaught) { return }
 
           if (line === 0 && /Script error\.?/.test(msg)) {
             // See https://developer.mozilla.org/en/docs/Web/API/GlobalEventHandlers/onerror#Notes

--- a/src/browser/integrations/onerror.ts
+++ b/src/browser/integrations/onerror.ts
@@ -17,8 +17,6 @@ export function ignoreNextOnError(): void {
 export function onError(_window: any = window): Plugin {
   return {
     load: (client: typeof Client) => {
-      if (typeof client.config.onerror === 'undefined') { client.config.onerror = true }
-
       instrument(_window, 'onerror', function (original) {
         const onerror = function (msg, url, line, col, err) {
           client.logger.debug('window.onerror callback invoked', arguments)

--- a/src/browser/integrations/onunhandledrejection.ts
+++ b/src/browser/integrations/onunhandledrejection.ts
@@ -6,14 +6,14 @@ import Client from '../../browser'
 export default function (_window = window): Plugin {
   return {
     load: (client: typeof Client) => {
-      if (typeof client.config.onunhandledrejection === 'undefined') { client.config.onunhandledrejection = true }
+      if (!client.config.enableUnhandledRejection) { return }
 
       instrument(_window, 'onunhandledrejection', function (original) {
         // See https://developer.mozilla.org/en-US/docs/Web/API/Window/unhandledrejection_event
         function onunhandledrejection(promiseRejectionEvent) {
           client.logger.debug('window.onunhandledrejection callback invoked', arguments)
 
-          if (!client.config.onunhandledrejection) { return }
+          if (!client.config.enableUnhandledRejection) { return }
 
           const { reason } = promiseRejectionEvent
 

--- a/src/core/client.ts
+++ b/src/core/client.ts
@@ -37,6 +37,7 @@ export default class Client {
       disabled: false,
       debug: false,
       enableUncaught: true,
+      enableUnhandledRejection: true,
       afterUncaught: () => true,
       __plugins: [],
 

--- a/src/core/client.ts
+++ b/src/core/client.ts
@@ -36,8 +36,8 @@ export default class Client {
       developmentEnvironments: ['dev', 'development', 'test'],
       disabled: false,
       debug: false,
-      onerror: true,
-      afterUncaughtException: () => true,
+      enableUncaught: true,
+      afterUncaught: () => true,
       __plugins: [],
 
       ...opts,

--- a/src/core/client.ts
+++ b/src/core/client.ts
@@ -36,6 +36,8 @@ export default class Client {
       developmentEnvironments: ['dev', 'development', 'test'],
       disabled: false,
       debug: false,
+      onerror: true,
+      afterUncaughtException: () => true,
       __plugins: [],
 
       ...opts,

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -25,8 +25,8 @@ export interface Config {
   maxObjectDepth: number
   ignorePatterns: RegExp[]
   logger: Logger
-  onerror: boolean
-  afterUncaughtException: (err: Error) => void
+  enableUncaught: boolean
+  afterUncaught: (err: Error) => void
   __plugins: Plugin[],
   [x: string]: unknown
 }

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -24,7 +24,9 @@ export interface Config {
   maxBreadcrumbs: number
   maxObjectDepth: number
   ignorePatterns: RegExp[]
-  logger: Logger,
+  logger: Logger
+  onerror: boolean
+  afterUncaughtException: (err: Error) => void
   __plugins: Plugin[],
   [x: string]: unknown
 }

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -27,6 +27,7 @@ export interface Config {
   logger: Logger
   enableUncaught: boolean
   afterUncaught: (err: Error) => void
+  enableUnhandledRejection: boolean
   __plugins: Plugin[],
   [x: string]: unknown
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -5,15 +5,13 @@ import { URL } from 'url'
 import Client from './core/client'
 import { Config, Notice } from './core/types'
 import { merge, sanitize, runAfterNotifyHandlers, endpoint } from './core/util'
+import { fatallyLogAndExit } from './server/util'
 import uncaughtException from './server/integrations/uncaught_exception'
 
 class Honeybadger extends Client {
   constructor(opts: Partial<Config> = {}) {
     super({
-      afterUncaught: (err) => {
-        this.logger.error(err.stack || err)
-        process.exit(1)
-      },
+      afterUncaught: fatallyLogAndExit,
       ...opts,
     })
   }

--- a/src/server.ts
+++ b/src/server.ts
@@ -5,8 +5,19 @@ import { URL } from 'url'
 import Client from './core/client'
 import { Config, Notice } from './core/types'
 import { merge, sanitize, runAfterNotifyHandlers, endpoint } from './core/util'
+import uncaughtException from './server/integrations/uncaught_exception'
 
 class Honeybadger extends Client {
+  constructor(opts: Partial<Config> = {}) {
+    super({
+      afterUncaughtException: (err) => {
+        this.logger.error(err.stack || err)
+        process.exit(1)
+      },
+      ...opts,
+    })
+  }
+
   factory(opts?: Partial<Config>): Honeybadger {
     return new Honeybadger(opts)
   }
@@ -60,4 +71,8 @@ class Honeybadger extends Client {
   }
 }
 
-export default new Honeybadger({})
+export default new Honeybadger({
+  __plugins: [
+    uncaughtException()
+  ]
+})

--- a/src/server.ts
+++ b/src/server.ts
@@ -7,6 +7,7 @@ import { Config, Notice } from './core/types'
 import { merge, sanitize, runAfterNotifyHandlers, endpoint } from './core/util'
 import { fatallyLogAndExit } from './server/util'
 import uncaughtException from './server/integrations/uncaught_exception'
+import unhandledRejection from './server/integrations/unhandled_rejection'
 
 class Honeybadger extends Client {
   constructor(opts: Partial<Config> = {}) {
@@ -71,6 +72,7 @@ class Honeybadger extends Client {
 
 export default new Honeybadger({
   __plugins: [
-    uncaughtException()
+    uncaughtException(),
+    unhandledRejection()
   ]
 })

--- a/src/server.ts
+++ b/src/server.ts
@@ -10,7 +10,7 @@ import uncaughtException from './server/integrations/uncaught_exception'
 class Honeybadger extends Client {
   constructor(opts: Partial<Config> = {}) {
     super({
-      afterUncaughtException: (err) => {
+      afterUncaught: (err) => {
         this.logger.error(err.stack || err)
         process.exit(1)
       },

--- a/src/server/integrations/uncaught_exception.ts
+++ b/src/server/integrations/uncaught_exception.ts
@@ -1,0 +1,22 @@
+import { Plugin } from '../../core/types'
+import Client from '../../server'
+
+export default function (): Plugin {
+  return {
+    load: (client: typeof Client) => {
+      if (!client.config.onerror) { return }
+
+      process.on('uncaughtException', function (uncaughtError) {
+        if (client.config.onerror) {
+          client.notify(uncaughtError, {
+            afterNotify: (_err, _notice) => {
+              client.config.afterUncaughtException(uncaughtError)
+            }
+          })
+        } else {
+          client.config.afterUncaughtException(uncaughtError)
+        }
+      })
+    }
+  }
+}

--- a/src/server/integrations/uncaught_exception.ts
+++ b/src/server/integrations/uncaught_exception.ts
@@ -7,13 +7,13 @@ let count = 0
 export default function (): Plugin {
   return {
     load: (client: typeof Client) => {
-      if (!client.config.onerror) { return }
+      if (!client.config.enableUncaught) { return }
 
       process.on('uncaughtException', function (uncaughtError) {
         // Prevent recursive errors
         if (count > 1) { fatallyLogAndExit(uncaughtError) }
 
-        if (client.config.onerror) {
+        if (client.config.enableUncaught) {
           client.notify(uncaughtError, {
             afterNotify: (_err, _notice) => {
               count += 1

--- a/src/server/integrations/uncaught_exception.ts
+++ b/src/server/integrations/uncaught_exception.ts
@@ -10,11 +10,11 @@ export default function (): Plugin {
         if (client.config.onerror) {
           client.notify(uncaughtError, {
             afterNotify: (_err, _notice) => {
-              client.config.afterUncaughtException(uncaughtError)
+              client.config.afterUncaught(uncaughtError)
             }
           })
         } else {
-          client.config.afterUncaughtException(uncaughtError)
+          client.config.afterUncaught(uncaughtError)
         }
       })
     }

--- a/src/server/integrations/unhandled_rejection.ts
+++ b/src/server/integrations/unhandled_rejection.ts
@@ -1,0 +1,16 @@
+import { Plugin } from '../../core/types'
+import { fatallyLogAndExit } from '../../server/util'
+import Client from '../../server'
+
+export default function (): Plugin {
+  return {
+    load: (client: typeof Client) => {
+      if (!client.config.enableUnhandledRejection) { return }
+
+      process.on('unhandledRejection', function (reason, _promise) {
+        if (!client.config.enableUnhandledRejection) { return }
+        client.notify(reason, {component: 'unhandledRejection'})
+      })
+    }
+  }
+}

--- a/src/server/util.ts
+++ b/src/server/util.ts
@@ -1,0 +1,5 @@
+export function fatallyLogAndExit(err: Error): void {
+  console.error('[Honeybadger] Exiting process due to uncaught exception')
+  console.error(err.stack || err)
+  process.exit(1)
+}

--- a/test/unit/browser.test.ts
+++ b/test/unit/browser.test.ts
@@ -27,7 +27,7 @@ describe('browser client', function () {
   describe('Singleton', function () {
     it('implements the window.onerror plugin', function () {
       Singleton.configure()
-      expect(Singleton.config.onerror).toEqual(true)
+      expect(Singleton.config.enableUncaught).toEqual(true)
     })
 
     it('implements the breadcrumbs plugin', function () {

--- a/test/unit/browser/integrations/onerror.browser.test.ts
+++ b/test/unit/browser/integrations/onerror.browser.test.ts
@@ -17,7 +17,7 @@ describe('window.onerror integration', function () {
   it('adds config to client', function () {
     const window = {}
     onError(window).load(client)
-    expect(client.config.onerror).toEqual(true)
+    expect(client.config.enableUncaught).toEqual(true)
   })
 
   it('skips install if window.onerror isn\'t a property', function () {


### PR DESCRIPTION
This also renames the `onerror` config option to `enableUncaught`, which is more descriptive, and also makes more sense in node environments (which have a global `uncaughtException` event instead of `window.onerror`.)

Also adds `unhandledRejection` for node and renames the config option `onunhandledrejection` to `enableUnhandledRejection`.