### PR TITLE
Remove public Honeybadger.wrap function

### DIFF
--- a/src/browser.ts
+++ b/src/browser.ts
@@ -50,10 +50,6 @@ class Honeybadger extends Client {
     return (this.__errorsSent = 0)
   }
 
-  wrap(func: (...args: unknown[]) => unknown): WrappedFunc {
-    return this.__wrap(func, { catch: true })
-  }
-
   factory(opts?: Partial<BrowserConfig>): Honeybadger {
     return new Honeybadger(opts)
   }

--- a/test/integration/test.js
+++ b/test/integration/test.js
@@ -101,20 +101,6 @@ describe('browser integration', function () {
       .catch(done);
   });
 
-  it('skips global onerror handler for wrapped errors', function (done) {
-    sandbox
-      .run(function () {
-        Honeybadger.wrap(function () {
-          throw (new Error('expected message'));
-        })();
-      })
-      .then(function (results) {
-        expect(results.notices.length).toEqual(1);
-        done();
-      })
-      .catch(done);
-  });
-
   it('reports multiple errors in the same process', function (done) {
     sandbox
       .run(function () {
@@ -392,34 +378,6 @@ describe('browser integration', function () {
         const errorBreadcrumbs = results.notices[0].__breadcrumbs.filter(function (c) { return c.category === 'error'; })
 
         expect(errorBreadcrumbs.length).toEqual(0);
-        done();
-      })
-      .catch(done);
-  });
-
-  it('sends Honeybadger.wrap breadcrumbs when onerror is disabled', function (done) {
-    sandbox
-      .run(function () {
-        Honeybadger.configure({ onerror: false });
-        results.error = new Error('expected message');
-        Honeybadger.wrap(function () {
-          throw (results.error);
-        })();
-      })
-      .then(function (results) {
-        expect(results.notices.length).toEqual(1);
-        expect(results.notices[0].__breadcrumbs).toBeArray();
-
-        const errorBreadcrumbs = results.notices[0].__breadcrumbs.filter(function (c) { return c.category === 'error'; })
-
-        expect(errorBreadcrumbs.length).toEqual(1);
-        expect(errorBreadcrumbs[0].message).toEqual('Error');
-        expect(errorBreadcrumbs[0].category).toEqual('error');
-        expect(errorBreadcrumbs[0].metadata).toEqual(jasmine.objectContaining({
-          message: 'expected message',
-          name: 'Error',
-          stack: results.error.stack
-        }));
         done();
       })
       .catch(done);


### PR DESCRIPTION
`Honeybadger.wrap` was [initially requested](https://github.com/honeybadger-io/honeybadger-js/issues/17) to wrap jquery callbacks, and has been a pain to support for various reasons—[especially for Node](https://github.com/honeybadger-io/honeybadger-node/pull/13).

Because the initial use case was so simple, it's not useful on Node, and I'm not sure how useful it is for browsers anymore, I'm going to try removing it in the new universal Honeybadger JS, and see what happens. ;)

For those who still want this feature, it's basically this:

```js
Honeybadger.wrap = function(func) {
  try {
    func.apply(this, arguments)
  } catch(error) {
    Honeybadger.notify(error)
    throw(error)
  }
}
```