### PR TITLE
types: Make sure every breadcrumb prop is optional

### DIFF
--- a/honeybadger.d.ts
+++ b/honeybadger.d.ts
@@ -35,7 +35,7 @@ declare namespace Honeybadger {
     disabled: boolean
     debug: boolean
     reportData: boolean
-    breadcrumbsEnabled: boolean | { dom: boolean, network: boolean, navigation: boolean, console: boolean }
+    breadcrumbsEnabled: boolean | Partial<{ dom: boolean, network: boolean, navigation: boolean, console: boolean }>
     maxBreadcrumbs: number
     maxObjectDepth: number
     logger: Logger

--- a/test-d/browser.test-d.tsx
+++ b/test-d/browser.test-d.tsx
@@ -21,6 +21,12 @@ Honeybadger.configure({
 
 Honeybadger.configure({
   breadcrumbsEnabled: {
+    dom: false
+  }
+})
+
+Honeybadger.configure({
+  breadcrumbsEnabled: {
     dom: true,
     network: true,
     navigation: true,


### PR DESCRIPTION
## Status
<!--- **READY/WIP/HOLD** --->
**READY**

## Description
This PR updates the types for the `breadcrumbsEnabled` prop to make all members optional.

For example —

```javascript
Honeybadger.configure({
        apiKey: HONEYBADGER_API_KEY,
        environment: HONEYBADGER_ENVIRONMENT,
        revision: RELEASE_ID,
        breadcrumbsEnabled: {
            console: true,
        },
    });
```

is a valid configuration, but the latest version complains about this, expecting all other members of `breadcrumbsEnabled` to be defined as well.

<img width="771" alt="Screenshot 2021-02-01 at 6 54 09 PM" src="https://user-images.githubusercontent.com/5381764/106464621-e399bf80-64be-11eb-8877-3ec3d71a1ef6.png">

## Related PRs
List related PRs against other branches:

branch | PR
------ | ------
NA | NA

## Todos
- [x] Tests
- [ ] Documentation
- [ ] Changelog Entry (unreleased)

## Steps to Test or Reproduce
Outline the steps to test or reproduce the PR here.
```bash
> git pull --prune
> git checkout <branch>
> grunt jasmine
```
1. See above.
