### PR TITLE
Add server middleware signatures to type declarations

### DIFF
--- a/honeybadger.d.ts
+++ b/honeybadger.d.ts
@@ -11,6 +11,11 @@ declare class Honeybadger {
   public resetContext(context?: Record<string, unknown>): Honeybadger
   public addBreadcrumb(message: string, opts?: Partial<Honeybadger.BreadcrumbRecord>): Honeybadger
   public wrap(func: (...args: unknown[]) => unknown): (...args: unknown[]) => unknown
+
+  // Server middleware
+  public requestHandler(req, res, next): void
+  public errorHandler(err, req, _res, next): unknown
+  public lambdaHandler(handler): (event, context, callback) => void
 }
 
 declare namespace Honeybadger {


### PR DESCRIPTION
## Status
**READY**

## Description
Fixes https://github.com/honeybadger-io/honeybadger-js/issues/539.

We're using a TypeScript-based Node framework ([Nest](nestjs.com)) and we need to use Honeybadger as the error reporting lib. However we can't set up the Honeybadger middleware `requestHandler` and `errorHandler` functions due to no types for them.

We don't actually need the `lambdaHandler` type but figured I'd go ahead and add that in here as well while I was at it.

## Todos
- [x] ~~Tests~~ N/A, only touches the type declarations file
- [x] Documentation
- [ ] Changelog Entry (unreleased)

## Steps to Test or Reproduce
I tested this out by linking locally to our project and ensuring the app compiled.