### PR TITLE
Do not prepare PR if no commits

### DIFF
--- a/ship.config.js
+++ b/ship.config.js
@@ -33,6 +33,9 @@ module.exports = {
       return `${yyyy}-${mm}-${dd}`
     }
   },
+  shouldPrepare: ({ commitNumbersPerType }) => {
+    return Object.keys(commitNumbersPerType).length > 0
+  },
   afterPublish: ({ exec }) => {
     exec(`./scripts/release-cdn.sh`)
   }


### PR DESCRIPTION
## Status
**READY?**

## Related issues
https://github.com/honeybadger-io/honeybadger-js/issues/530

## Description
If commits are ready to release, the `commitNumbersPerType` object will have properties like `{ feat: 2, fix: 4, chore: 8 }`. If there are no changes, the object is empty. 

This took a little longer than expected to sort out since ShipJS was not running the `shouldPrepare` callback when `--dry-run` flag was used. I checked with the maintainers and have submitted a PR to change this behavior.

I haven't managed to generate a "positive" test (i.e. have commits to push), but all the tests run fine!