### PR TITLE
feat: add support for tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,11 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add tagging to errors with 3 possible API's
 
-```bash
-Honeybadger.configure({tags: string | string[] | undefined})
-Honeybadger.configure().setContext({tags: string | string[] | undefined})
-Honeybadger.configure().notify('error', {tags: string | string[] | undefined})
-```
+    ```bash
+    Honeybadger.configure({tags: string | string[] | undefined})
+    Honeybadger.configure().setContext({tags: string | string[] | undefined})
+    Honeybadger.configure().notify('error', {tags: string | string[] | undefined})
+    ```
 
 ## [3.1.0] - 2021-03-04
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased][latest]
 
+### Added
+
+- Add tagging to errors with 3 possible API's
+
+```bash
+Honeybadger.configure({tags: string | string[] | undefined})
+Honeybadger.configure().setContext({tags: string | string[] | undefined})
+Honeybadger.configure().notify('error', {tags: string | string[] | undefined})
+```
+
 ## [3.1.0] - 2021-03-04
 ### Fixed
 - Add default reason for unhandled promises (previously reason was "undefined") (#546)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased][latest]
-
 ### Added
-
 - Add tagging to errors with 3 possible API's
-
     ```bash
     Honeybadger.configure({tags: string | string[] | undefined})
     Honeybadger.configure().setContext({tags: string | string[] | undefined})

--- a/honeybadger.d.ts
+++ b/honeybadger.d.ts
@@ -47,6 +47,7 @@ declare namespace Honeybadger {
     enableUncaught: boolean
     afterUncaught: (err: Error) => void
     enableUnhandledRejection: boolean
+    tags: string | string[] | unknown
     filters: string[]
     [x: string]: unknown
 
@@ -84,6 +85,7 @@ declare namespace Honeybadger {
     environment?: string | undefined,
     revision?: string | undefined,
     afterNotify?: AfterNotifyHandler
+    tags: string | string[]
   }
 
   interface BacktraceFrame {

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -65,6 +65,7 @@ export interface Notice {
   projectRoot?: string | undefined,
   environment?: string | undefined,
   revision?: string | undefined,
+  tags: string | string[]
   __breadcrumbs: BreadcrumbRecord[],
   afterNotify?: AfterNotifyHandler
 }


### PR DESCRIPTION
## Status

READY

## Description

Adds support for tags. I wasnt sure how to add to the honeybadger docs to reflect these changes.

You can now add tags 3 ways:

```js
Honeybadger.configure({
  tags: "1, 2, 3"
})

const client = Honeybadger.configure()
client.setContext({tags: ["1", "2", "3"]})

client.notify("testing", {tags: "1, 2, 3"})
```


## Todos

- [x] Tests
- [x] Documentation (updated the typings)
- [x] Changelog Entry (unreleased)

## Steps to Test or Reproduce

Outline the steps to test or reproduce the PR here.
```bash
> git pull --prune
> git checkout <branch>
> npm run test
```