### PR TITLE
Use express types for middleware

### DIFF
--- a/honeybadger.d.ts
+++ b/honeybadger.d.ts
@@ -1,5 +1,6 @@
 // Type definitions for honeybadger.js
 // Project: https://github.com/honeybadger-io/honeybadger-js
+import { NextFunction, Request, Response } from 'express'
 
 declare class Honeybadger {
   public factory(opts?: Partial<Honeybadger.Config>): Honeybadger
@@ -12,9 +13,9 @@ declare class Honeybadger {
   public addBreadcrumb(message: string, opts?: Partial<Honeybadger.BreadcrumbRecord>): Honeybadger
 
   // Server middleware
-  public requestHandler(req, res, next): void
-  public errorHandler(err, req, _res, next): unknown
-  public lambdaHandler(handler): (event, context, callback) => void
+  public requestHandler(req: Request, res: Response, next: NextFunction): void
+  public errorHandler(err: any, req: Request, _res: Response, next: NextFunction): unknown
+  public lambdaHandler(handler: any): (event: any, context: any, callback: any) => void
 }
 
 declare namespace Honeybadger {


### PR DESCRIPTION
## Status
<!--- **READY/WIP/HOLD** --->
**WIP**

## Description
#540 added server middleware, but didn't add types to those functions.  In projects where TypeScript has `"noImplicitAny": true`, the compiler errors on those functions.

This PR:
- adds the `express` types to the parameters for those middleware functions
- explicitly sets `any` to types I didn't know offhand.

## Todos
- [X] Tests
- [X] ~Documentation~ n/a
- [ ] Changelog Entry (unreleased)

## Steps to Test or Reproduce
Outline the steps to test or reproduce the PR here.
1. Create a new TypesScript project with `"noImplicitAny": true`.
2. `yarn add @honeybadger/js`
3. import Honeybadger into a module and use it
4. Run `./node_modules/.bin/tsc --noEmit`, with this branch, you should receive no errors.
