### PR TITLE
Add missing methods to typedefs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased][latest]
+### Fixed
+- TypeScript: Add missing methods typedefs (#611)
 
 ## [3.2.1] - 2021-05-17
 ### Fixed

--- a/honeybadger.d.ts
+++ b/honeybadger.d.ts
@@ -3,6 +3,7 @@
 import { NextFunction, Request, Response } from 'express'
 
 declare class Honeybadger {
+  public getVersion(): string
   public factory(opts?: Partial<Honeybadger.Config>): Honeybadger
   public notify(notice: Error | string | Partial<Honeybadger.Notice>, name?: string | Partial<Honeybadger.Notice>, extra?: string | Partial<Honeybadger.Notice>): Honeybadger.Notice | false
   public configure(opts: Partial<Honeybadger.Config>): Honeybadger
@@ -10,6 +11,7 @@ declare class Honeybadger {
   public afterNotify(func: Honeybadger.AfterNotifyHandler): Honeybadger
   public setContext(context: Record<string, unknown>): Honeybadger
   public resetContext(context?: Record<string, unknown>): Honeybadger
+  public clear(): Honeybadger
   public addBreadcrumb(message: string, opts?: Partial<Honeybadger.BreadcrumbRecord>): Honeybadger
 
   // Server middleware

--- a/test-d/browser.test-d.tsx
+++ b/test-d/browser.test-d.tsx
@@ -95,4 +95,9 @@ Honeybadger.notify('Example message', {
   afterNotify: (err, notice) => console.log(err || notice.id)
 })
 
-Honeybadger.factory()
+const client = Honeybadger.factory()
+client.setContext({a: 2}).notify({ message: 'test' })
+client.resetContext()
+client.addBreadcrumb("testing")
+client.notify(new Error('test'))
+client.clear()

--- a/test-d/server.test-d.tsx
+++ b/test-d/server.test-d.tsx
@@ -4,4 +4,15 @@ Honeybadger.notify('test')
 Honeybadger.notify(new Error('test'))
 Honeybadger.notify({ message: 'test' })
 
-Honeybadger.factory()
+const client = Honeybadger.factory()
+client.setContext({a: 2}).notify({ message: 'test' })
+client.resetContext()
+client.addBreadcrumb("testing")
+client.notify(new Error('test'))
+client.clear()
+
+const client2 = Honeybadger.factory()
+client2.beforeNotify(() => {
+    console.log("Notifying")
+})
+client2.notify('test')


### PR DESCRIPTION
Fixes #609 

Addendum: Any reason why we manually write the typedefs? Methinks we could use tsc to generate them. thereby keeping them in sync with any code changes.