### PR TITLE
Improve TypeScript usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased][latest]
-### Modified
-- Internal: Fixed TypeScript types, added null checks, automated type declaration files
 ### Fixed
 - TypeScript: Add missing methods typedefs (#611)
+- Internal: Fixed TypeScript types, added null checks, automated type declaration files
 
 ## [3.2.1] - 2021-05-17
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased][latest]
+### Modified
+- Internal: Fixed TypeScript types, added null checks, automated type declaration files
 ### Fixed
 - TypeScript: Add missing methods typedefs (#611)
 

--- a/README.md
+++ b/README.md
@@ -27,9 +27,20 @@ See https://github.com/honeybadger-io/honeybadger-js/blob/master/CHANGELOG.md
 ## Development
 
 1. Run `npm install`.
-2. To run the test suite by itself, use `npm test`.
-3. To run the tests across all supported platforms, set up a [BrowserStack](https://www.browserstack.com/)
+2. To run unit tests for both browser and server builds: `npm test`. Or separately: `npm run test:browser`, `npm run test:server`.
+3. To run integration tests across all supported platforms, set up a [BrowserStack](https://www.browserstack.com/)
 account and use `BROWSERSTACK_USERNAME=your_username BROWSERSTACK_ACCESS_KEY=your-access-key npm run test:integration`.
+4. To test the TypeScript type definitions: `npm run tsd`.
+   
+### Bundling and types
+This project is _isomorphic_, meaning it's a single library which contains both browser and server builds. It's written in TypeScript, and transpiled and bundled with Rollup. Our Rollup config generates three main files:
+1. The server build, which transpiles `src/server.ts` and its dependencies into `dist/server/honeybadger.js`.
+2. The browser build, which transpiles `src/browser.ts` and its dependencies into `dist/browser/honeybadger.js`.
+3. The minified browser build, which transpiles `src/browser.ts` and its dependencies into `dist/browser/honeybadger.min.js` (+ source maps).
+
+In addition, the TypeScript type declaration for each build is generated into its `types/` directory (ie `dist/browser/types/browser.d.ts` and `dist/server/types/server.d.ts`).
+
+However, since the package is isomorphic, TypeScript users will likely be writing `import * as Honeybadger from '@honeybadger-io/js'` or `import Honeybadger = require('@honeybadger-io/js')` in their IDE. Our `package.json` has ` main` and `browser` fields that determine which build they get, but [there can only be a single type declaration file](https://github.com/Microsoft/TypeScript/issues/29128). So we use an extra file in the project root, `honeybadger.d.ts`, that combines the types from both builds.
 
 ## Releasing
 

--- a/honeybadger.d.ts
+++ b/honeybadger.d.ts
@@ -2,31 +2,6 @@
 // Project: https://github.com/honeybadger-io/honeybadger-js
 import Server from './dist/server/types/server'
 import Browser from './dist/browser/types/browser'
-import {
-    Logger as BaseLogger,
-    Config as BaseConfig,
-    BeforeNotifyHandler as BaseBeforeNotifyHandler,
-    AfterNotifyHandler as BaseAfterNotifyHandler,
-    Notice as BaseNotice,
-    BacktraceFrame as BaseBacktraceFrame,
-    BreadcrumbRecord as BaseBreadcrumbRecord,
-} from './dist/server/types/core/types'
 
-declare namespace Honeybadger {
-    type Logger = BaseLogger
-
-    type Config = BaseConfig
-
-    type BeforeNotifyHandler = BaseBeforeNotifyHandler
-
-    type AfterNotifyHandler = BaseAfterNotifyHandler
-
-    type Notice = BaseNotice
-
-    type BacktraceFrame = BaseBacktraceFrame
-
-    type BreadcrumbRecord = BaseBreadcrumbRecord
-}
-
-declare const singleton: typeof Server & typeof Browser
-export = singleton
+declare const Honeybadger: typeof Server & typeof Browser
+export = Honeybadger

--- a/honeybadger.d.ts
+++ b/honeybadger.d.ts
@@ -1,109 +1,32 @@
 // Type definitions for honeybadger.js
 // Project: https://github.com/honeybadger-io/honeybadger-js
-import { NextFunction, Request, Response } from 'express'
-
-declare class Honeybadger {
-  public getVersion(): string
-  public factory(opts?: Partial<Honeybadger.Config>): Honeybadger
-  public notify(notice: Error | string | Partial<Honeybadger.Notice>, name?: string | Partial<Honeybadger.Notice>, extra?: string | Partial<Honeybadger.Notice>): Honeybadger.Notice | false
-  public configure(opts: Partial<Honeybadger.Config>): Honeybadger
-  public beforeNotify(func: Honeybadger.BeforeNotifyHandler): Honeybadger
-  public afterNotify(func: Honeybadger.AfterNotifyHandler): Honeybadger
-  public setContext(context: Record<string, unknown>): Honeybadger
-  public resetContext(context?: Record<string, unknown>): Honeybadger
-  public clear(): Honeybadger
-  public addBreadcrumb(message: string, opts?: Partial<Honeybadger.BreadcrumbRecord>): Honeybadger
-
-  // Server middleware
-  public requestHandler(req: Request, res: Response, next: NextFunction): void
-  public errorHandler(err: any, req: Request, _res: Response, next: NextFunction): unknown
-  public lambdaHandler(handler: any): (event: any, context: any, callback: any) => void
-}
+import Server from './dist/server/types/server'
+import Browser from './dist/browser/types/browser'
+import {
+    Logger as BaseLogger,
+    Config as BaseConfig,
+    BeforeNotifyHandler as BaseBeforeNotifyHandler,
+    AfterNotifyHandler as BaseAfterNotifyHandler,
+    Notice as BaseNotice,
+    BacktraceFrame as BaseBacktraceFrame,
+    BreadcrumbRecord as BaseBreadcrumbRecord,
+} from './src/core/types'
 
 declare namespace Honeybadger {
-  interface Logger {
-    log(...args: unknown[]): unknown
-    info(...args: unknown[]): unknown
-    debug(...args: unknown[]): unknown
-    warn(...args: unknown[]): unknown
-    error(...args: unknown[]): unknown
-  }
+    type Logger = BaseLogger
 
-  interface Config {
-    apiKey: string | undefined
-    endpoint: string,
-    developmentEnvironments: string[]
-    environment: string | undefined
-    hostname: string | undefined
-    projectRoot: string | undefined
-    component: string | undefined
-    action: string | undefined
-    revision: string | undefined
-    disabled: boolean
-    debug: boolean
-    reportData: boolean
-    breadcrumbsEnabled: boolean | Partial<{ dom: boolean, network: boolean, navigation: boolean, console: boolean }>
-    maxBreadcrumbs: number
-    maxObjectDepth: number
-    logger: Logger
-    enableUncaught: boolean
-    afterUncaught: (err: Error) => void
-    enableUnhandledRejection: boolean
-    tags: string | string[] | unknown
-    filters: string[]
-    [x: string]: unknown
+    type Config = BaseConfig
 
-    // Browser
-    async: boolean
-    maxErrors: number
-  }
+    type BeforeNotifyHandler = BaseBeforeNotifyHandler
 
-  interface BeforeNotifyHandler {
-    (notice: Notice): boolean | void
-  }
+    type AfterNotifyHandler = BaseAfterNotifyHandler
 
-  interface AfterNotifyHandler {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (error: any, notice: Notice): boolean | void
-  }
+    type Notice = BaseNotice
 
-  interface Notice {
-    id: string | undefined,
-    name: string,
-    message: string,
-    stack: string,
-    backtrace: BacktraceFrame[],
-    fingerprint?: string | undefined,
-    url?: string | undefined,
-    component?: string | undefined,
-    action?: string | undefined,
-    context: Record<string, unknown>,
-    cgiData: Record<string, unknown>,
-    params: Record<string, unknown>,
-    session: Record<string, unknown>,
-    headers: Record<string, unknown>,
-    cookies: Record<string, unknown> | string,
-    projectRoot?: string | undefined,
-    environment?: string | undefined,
-    revision?: string | undefined,
-    afterNotify?: AfterNotifyHandler
-    tags: string | string[]
-  }
+    type BacktraceFrame = BaseBacktraceFrame
 
-  interface BacktraceFrame {
-    file: string,
-    method: string,
-    number: number,
-    column: number
-  }
-
-  interface BreadcrumbRecord {
-    category: string,
-    message: string,
-    metadata: Record<string, unknown>,
-    timestamp: string
-  }
+    type BreadcrumbRecord = BaseBreadcrumbRecord
 }
 
-declare const singleton: Honeybadger
-export = singleton
+declare const singleton: typeof Server & typeof Browser
+export default singleton

--- a/honeybadger.d.ts
+++ b/honeybadger.d.ts
@@ -10,7 +10,7 @@ import {
     Notice as BaseNotice,
     BacktraceFrame as BaseBacktraceFrame,
     BreadcrumbRecord as BaseBreadcrumbRecord,
-} from './src/core/types'
+} from './dist/server/types/core/types'
 
 declare namespace Honeybadger {
     type Logger = BaseLogger
@@ -29,4 +29,4 @@ declare namespace Honeybadger {
 }
 
 declare const singleton: typeof Server & typeof Browser
-export default singleton
+export = singleton

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "3.2.1",
       "license": "MIT",
       "dependencies": {
+        "@types/express": "^4.17.13",
         "stacktrace-parser": "^0.1.10"
       },
       "devDependencies": {
@@ -2193,11 +2194,49 @@
         "@babel/types": "^7.3.0"
       }
     },
+    "node_modules/@types/body-parser": {
+      "version": "1.19.1",
+      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.1.tgz",
+      "integrity": "sha512-a6bTJ21vFOGIkwM0kzh9Yr89ziVxq4vYH2fQ6N8AeipEzai/cFK6aGMArIkUeIdRIgpwQa+2bXiLuUJCpSf2Cg==",
+      "dependencies": {
+        "@types/connect": "*",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/connect": {
+      "version": "3.4.35",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.35.tgz",
+      "integrity": "sha512-cdeYyv4KWoEgpBISTxWvqYsVy444DOqehiF3fM3ne10AmJ62RSyNkUnxMJXHQWRQQX2eR94m5y1IZyDwBjV9FQ==",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/estree": {
       "version": "0.0.39",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
       "integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==",
       "dev": true
+    },
+    "node_modules/@types/express": {
+      "version": "4.17.13",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.13.tgz",
+      "integrity": "sha512-6bSZTPaTIACxn48l50SR+axgrqm6qXFIxrdAKaG6PaJk3+zuUr35hBlgT7vOmJcum+OEaIBLtHV/qloEAFITeA==",
+      "dependencies": {
+        "@types/body-parser": "*",
+        "@types/express-serve-static-core": "^4.17.18",
+        "@types/qs": "*",
+        "@types/serve-static": "*"
+      }
+    },
+    "node_modules/@types/express-serve-static-core": {
+      "version": "4.17.24",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.24.tgz",
+      "integrity": "sha512-3UJuW+Qxhzwjq3xhwXm2onQcFHn76frIYVbTu+kn24LFxI+dEhdfISDFovPB8VpEgW8oQCTpRuCe+0zJxB7NEA==",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/qs": "*",
+        "@types/range-parser": "*"
+      }
     },
     "node_modules/@types/glob": {
       "version": "7.1.3",
@@ -2264,6 +2303,11 @@
       "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4=",
       "dev": true
     },
+    "node_modules/@types/mime": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.2.tgz",
+      "integrity": "sha512-YATxVxgRqNH6nHEIsvg6k2Boc1JHI9ZbH5iWFFv/MTkchz3b1ieGDa5T0a9RznNdI0KhVbdbWSN+KWWrQZRxTw=="
+    },
     "node_modules/@types/minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.4.tgz",
@@ -2279,8 +2323,7 @@
     "node_modules/@types/node": {
       "version": "14.0.19",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-14.0.19.tgz",
-      "integrity": "sha512-yf3BP/NIXF37BjrK5klu//asUWitOEoUP5xE1mhSUjazotwJ/eJDgEmMQNlOeWOVv72j24QQ+3bqXHE++CFGag==",
-      "dev": true
+      "integrity": "sha512-yf3BP/NIXF37BjrK5klu//asUWitOEoUP5xE1mhSUjazotwJ/eJDgEmMQNlOeWOVv72j24QQ+3bqXHE++CFGag=="
     },
     "node_modules/@types/normalize-package-data": {
       "version": "2.4.0",
@@ -2294,12 +2337,31 @@
       "integrity": "sha512-hkc1DATxFLQo4VxPDpMH1gCkPpBbpOoJ/4nhuXw4n63/0R6bCpQECj4+K226UJ4JO/eJQz+1mC2I7JsWanAdQw==",
       "dev": true
     },
+    "node_modules/@types/qs": {
+      "version": "6.9.7",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.7.tgz",
+      "integrity": "sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw=="
+    },
+    "node_modules/@types/range-parser": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.4.tgz",
+      "integrity": "sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw=="
+    },
     "node_modules/@types/resolve": {
       "version": "1.17.1",
       "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.17.1.tgz",
       "integrity": "sha512-yy7HuzQhj0dhGpD8RLXSZWEkLsV9ibvxvi6EiJ3bkqLAO1RGo0WbkWQiwpRlSFymTJRz0d3k5LM3kkx8ArDbLw==",
       "dev": true,
       "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/serve-static": {
+      "version": "1.13.10",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.13.10.tgz",
+      "integrity": "sha512-nCkHGI4w7ZgAdNkrEu0bv+4xNV/XDqW+DydknebMOQwkpDGx8G+HTlj7R7ABI8i8nKxVw0wtKPi1D+lPOkh4YQ==",
+      "dependencies": {
+        "@types/mime": "^1",
         "@types/node": "*"
       }
     },
@@ -15648,11 +15710,49 @@
         "@babel/types": "^7.3.0"
       }
     },
+    "@types/body-parser": {
+      "version": "1.19.1",
+      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.1.tgz",
+      "integrity": "sha512-a6bTJ21vFOGIkwM0kzh9Yr89ziVxq4vYH2fQ6N8AeipEzai/cFK6aGMArIkUeIdRIgpwQa+2bXiLuUJCpSf2Cg==",
+      "requires": {
+        "@types/connect": "*",
+        "@types/node": "*"
+      }
+    },
+    "@types/connect": {
+      "version": "3.4.35",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.35.tgz",
+      "integrity": "sha512-cdeYyv4KWoEgpBISTxWvqYsVy444DOqehiF3fM3ne10AmJ62RSyNkUnxMJXHQWRQQX2eR94m5y1IZyDwBjV9FQ==",
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/estree": {
       "version": "0.0.39",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
       "integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==",
       "dev": true
+    },
+    "@types/express": {
+      "version": "4.17.13",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.13.tgz",
+      "integrity": "sha512-6bSZTPaTIACxn48l50SR+axgrqm6qXFIxrdAKaG6PaJk3+zuUr35hBlgT7vOmJcum+OEaIBLtHV/qloEAFITeA==",
+      "requires": {
+        "@types/body-parser": "*",
+        "@types/express-serve-static-core": "^4.17.18",
+        "@types/qs": "*",
+        "@types/serve-static": "*"
+      }
+    },
+    "@types/express-serve-static-core": {
+      "version": "4.17.24",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.24.tgz",
+      "integrity": "sha512-3UJuW+Qxhzwjq3xhwXm2onQcFHn76frIYVbTu+kn24LFxI+dEhdfISDFovPB8VpEgW8oQCTpRuCe+0zJxB7NEA==",
+      "requires": {
+        "@types/node": "*",
+        "@types/qs": "*",
+        "@types/range-parser": "*"
+      }
     },
     "@types/glob": {
       "version": "7.1.3",
@@ -15719,6 +15819,11 @@
       "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4=",
       "dev": true
     },
+    "@types/mime": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.2.tgz",
+      "integrity": "sha512-YATxVxgRqNH6nHEIsvg6k2Boc1JHI9ZbH5iWFFv/MTkchz3b1ieGDa5T0a9RznNdI0KhVbdbWSN+KWWrQZRxTw=="
+    },
     "@types/minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.4.tgz",
@@ -15734,8 +15839,7 @@
     "@types/node": {
       "version": "14.0.19",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-14.0.19.tgz",
-      "integrity": "sha512-yf3BP/NIXF37BjrK5klu//asUWitOEoUP5xE1mhSUjazotwJ/eJDgEmMQNlOeWOVv72j24QQ+3bqXHE++CFGag==",
-      "dev": true
+      "integrity": "sha512-yf3BP/NIXF37BjrK5klu//asUWitOEoUP5xE1mhSUjazotwJ/eJDgEmMQNlOeWOVv72j24QQ+3bqXHE++CFGag=="
     },
     "@types/normalize-package-data": {
       "version": "2.4.0",
@@ -15749,12 +15853,31 @@
       "integrity": "sha512-hkc1DATxFLQo4VxPDpMH1gCkPpBbpOoJ/4nhuXw4n63/0R6bCpQECj4+K226UJ4JO/eJQz+1mC2I7JsWanAdQw==",
       "dev": true
     },
+    "@types/qs": {
+      "version": "6.9.7",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.7.tgz",
+      "integrity": "sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw=="
+    },
+    "@types/range-parser": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.4.tgz",
+      "integrity": "sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw=="
+    },
     "@types/resolve": {
       "version": "1.17.1",
       "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.17.1.tgz",
       "integrity": "sha512-yy7HuzQhj0dhGpD8RLXSZWEkLsV9ibvxvi6EiJ3bkqLAO1RGo0WbkWQiwpRlSFymTJRz0d3k5LM3kkx8ArDbLw==",
       "dev": true,
       "requires": {
+        "@types/node": "*"
+      }
+    },
+    "@types/serve-static": {
+      "version": "1.13.10",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.13.10.tgz",
+      "integrity": "sha512-nCkHGI4w7ZgAdNkrEu0bv+4xNV/XDqW+DydknebMOQwkpDGx8G+HTlj7R7ABI8i8nKxVw0wtKPi1D+lPOkh4YQ==",
+      "requires": {
+        "@types/mime": "^1",
         "@types/node": "*"
       }
     },

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "release": "shipjs prepare"
   },
   "dependencies": {
+    "@types/express": "^4.17.13",
     "stacktrace-parser": "^0.1.10"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "test:integration:browserstack": "npm run test:integration",
     "test:integration:headless": "HEADLESS=1 npm run test:integration",
     "tsd": "npm run build && tsd",
-    "build": "rollup -c && cp honeybadger.d.ts dist/server && cp honeybadger.d.ts dist/browser",
+    "build": "rollup -c && node ./scripts/copy-typedefs.js",
     "release": "shipjs prepare"
   },
   "dependencies": {
@@ -74,5 +74,10 @@
     "dist",
     "honeybadger.d.ts"
   ],
+  "tsd": {
+    "compilerOptions": {
+      "strict": false
+    }
+  },
   "types": "./honeybadger.d.ts"
 }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -7,6 +7,7 @@ import pkg from './package.json'
 // These plugins are used for all builds
 const sharedPlugins = [
   replace({
+    preventAssignment: false,
     exclude: 'node_modules/**',
     __VERSION__: pkg.version
   }),
@@ -16,13 +17,25 @@ const sharedPlugins = [
 // These plugins are used for UMD builds
 const umdPlugins = [
   ...sharedPlugins,
-  typescript()
+  typescript({
+    tsconfig: './tsconfig.json',
+    exclude: [
+      "./src/server.ts",
+      "./src/server/**"
+    ]
+  })
 ]
 
 // These plugins are used for Node builds
 const nodePlugins = [
   ...sharedPlugins,
-  typescript()
+  typescript({
+    tsconfig: './tsconfig.json',
+    exclude: [
+      "./src/browser.ts",
+      "./src/browser/**"
+    ]
+  })
 ]
 
 export default [

--- a/scripts/copy-typedefs.js
+++ b/scripts/copy-typedefs.js
@@ -3,7 +3,13 @@
 /* eslint-disable */
 
 const fs = require('fs');
-fs.copyFileSync('honeybadger.d.ts', 'dist/browser/honeybadger.d.ts');
-fs.copyFileSync('honeybadger.d.ts', 'dist/server/honeybadger.d.ts');
+fs.writeFileSync(
+    'dist/browser/honeybadger.d.ts',
+    fs.readFileSync('dist/browser/types/browser.d.ts', 'utf8').replace(/'\.\//g, `'./types/`)
+);
+fs.writeFileSync(
+    'dist/server/honeybadger.d.ts',
+    fs.readFileSync('dist/server/types/server.d.ts', 'utf8').replace(/'\.\//g, `'./types/`)
+);
 
 console.info("Copied declaration files");

--- a/scripts/copy-typedefs.js
+++ b/scripts/copy-typedefs.js
@@ -1,0 +1,9 @@
+// Copy type declaration files for backwards compatibility with earlier versions of Honeybadger
+
+/* eslint-disable */
+
+const fs = require('fs');
+fs.copyFileSync('honeybadger.d.ts', 'dist/browser/honeybadger.d.ts');
+fs.copyFileSync('honeybadger.d.ts', 'dist/server/honeybadger.d.ts');
+
+console.info("Copied declaration files");

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -19,11 +19,14 @@ interface WrappedFunc {
 }
 
 class Honeybadger extends Client {
+  /** @internal */
   private __errorsSent = 0
+  /** @internal */
   private __lastWrapErr = undefined
 
   config: BrowserConfig
 
+  /** @internal */
   protected __beforeNotifyHandlers: BeforeNotifyHandler[] = [
     (notice: Notice) => {
       if (this.__exceedsMaxErrors()) {
@@ -58,6 +61,7 @@ class Honeybadger extends Client {
     return new Honeybadger(opts)
   }
 
+  /** @internal */
   protected __buildPayload(notice:Notice): Record<string, Record<string, unknown>> {
     const cgiData = {
       HTTP_USER_AGENT: undefined,
@@ -86,6 +90,7 @@ class Honeybadger extends Client {
     return payload
   }
 
+  /** @internal */
   protected __send(notice) {
     this.__incrementErrorsCount()
 
@@ -121,8 +126,11 @@ class Honeybadger extends Client {
     return true
   }
 
-  // wrap always returns the same function so that callbacks can be removed via
-  // removeEventListener.
+  /**
+   * wrap always returns the same function so that callbacks can be removed via
+   * removeEventListener.
+   * @internal
+   */
   __wrap(f:unknown, opts:Record<string, unknown> = {}):WrappedFunc {
     const func = f as WrappedFunc
     if (!opts) { opts = {} }
@@ -175,10 +183,12 @@ class Honeybadger extends Client {
     }
   }
 
+  /** @internal */
   private __incrementErrorsCount(): number {
     return this.__errorsSent++
   }
 
+  /** @internal */
   private __exceedsMaxErrors(): boolean {
     return this.config.maxErrors && this.__errorsSent >= this.config.maxErrors
   }

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -21,7 +21,7 @@ export interface Config {
   disabled: boolean
   debug: boolean
   reportData: boolean
-  breadcrumbsEnabled: boolean | Partial<{ dom: boolean, network: boolean, navigation: boolean, console: boolean }>
+  breadcrumbsEnabled: boolean | { dom?: boolean, network?: boolean, navigation?: boolean, console?: boolean}
   maxBreadcrumbs: number
   maxObjectDepth: number
   logger: Logger
@@ -30,7 +30,7 @@ export interface Config {
   enableUnhandledRejection: boolean
   filters: string[]
   __plugins: Plugin[],
-  [x: string]: unknown,
+  tags: any,
 }
 
 export interface BeforeNotifyHandler {
@@ -69,6 +69,8 @@ export interface Notice {
   __breadcrumbs: BreadcrumbRecord[],
   afterNotify?: AfterNotifyHandler
 }
+
+export type Noticeable = string | Error | Partial<Notice>
 
 export interface BacktraceFrame {
   file: string,

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -9,15 +9,15 @@ export interface Logger {
 }
 
 export interface Config {
-  apiKey: string | undefined
+  apiKey?: string,
   endpoint: string,
   developmentEnvironments: string[],
-  environment: string | undefined
-  hostname: string | undefined
-  projectRoot: string | undefined
-  component: string | undefined
-  action: string | undefined
-  revision: string | undefined
+  environment?: string
+  hostname?: string
+  projectRoot?: string
+  component?: string
+  action?: string
+  revision?: string
   disabled: boolean
   debug: boolean
   reportData: boolean

--- a/src/server.ts
+++ b/src/server.ts
@@ -12,6 +12,7 @@ import unhandledRejection from './server/integrations/unhandled_rejection'
 import { errorHandler, requestHandler, lambdaHandler } from './server/middleware'
 
 class Honeybadger extends Client {
+  /** @internal */
   protected __beforeNotifyHandlers: BeforeNotifyHandler[] = [
     (notice: Notice) => {
       notice.backtrace.forEach((line) => {
@@ -44,6 +45,7 @@ class Honeybadger extends Client {
     return new Honeybadger(opts)
   }
 
+  /** @internal */
   protected __send(notice) {
     const { protocol } = new URL(this.config.endpoint)
     const transport = (protocol === "http:" ? http : https)

--- a/src/server.ts
+++ b/src/server.ts
@@ -4,7 +4,7 @@ import { URL } from 'url'
 import os from 'os'
 
 import Client from './core/client'
-import { Config, Notice } from './core/types'
+import { Config, Notice, BeforeNotifyHandler } from './core/types'
 import { merge, sanitize, runAfterNotifyHandlers, endpoint } from './core/util'
 import { fatallyLogAndExit, getStats } from './server/util'
 import uncaughtException from './server/integrations/uncaught_exception'
@@ -12,7 +12,7 @@ import unhandledRejection from './server/integrations/unhandled_rejection'
 import { errorHandler, requestHandler, lambdaHandler } from './server/middleware'
 
 class Honeybadger extends Client {
-  protected __beforeNotifyHandlers = [
+  protected __beforeNotifyHandlers: BeforeNotifyHandler[] = [
     (notice: Notice) => {
       notice.backtrace.forEach((line) => {
         if (line.file) {
@@ -24,6 +24,10 @@ class Honeybadger extends Client {
     }
   ]
 
+  public errorHandler: typeof errorHandler;
+  public requestHandler: typeof requestHandler;
+  public lambdaHandler: typeof lambdaHandler;
+
   constructor(opts: Partial<Config> = {}) {
     super({
       afterUncaught: fatallyLogAndExit,
@@ -31,17 +35,16 @@ class Honeybadger extends Client {
       hostname: os.hostname(),
       ...opts,
     })
+    this.errorHandler = errorHandler.bind(this)
+    this.requestHandler = requestHandler.bind(this)
+    this.lambdaHandler = lambdaHandler.bind(this)
   }
-
-  errorHandler = errorHandler.bind(this)
-  requestHandler = requestHandler.bind(this)
-  lambdaHandler = lambdaHandler.bind(this)
 
   factory(opts?: Partial<Config>): Honeybadger {
     return new Honeybadger(opts)
   }
 
-  protected __send(notice: Notice): boolean {
+  protected __send(notice) {
     const { protocol } = new URL(this.config.endpoint)
     const transport = (protocol === "http:" ? http : https)
 

--- a/src/server/integrations/unhandled_rejection.ts
+++ b/src/server/integrations/unhandled_rejection.ts
@@ -1,5 +1,4 @@
 import { Plugin } from '../../core/types'
-import { fatallyLogAndExit } from '../../server/util'
 import Client from '../../server'
 
 export default function (): Plugin {

--- a/src/server/middleware.ts
+++ b/src/server/middleware.ts
@@ -5,8 +5,10 @@ import { NextFunction, Request, Response } from 'express'
 function fullUrl(req: Request): string {
   const connection = req.connection
   const address = connection && connection.address()
+  // @ts-ignore The old @types/node incorrectly defines `address` as string|Address
   const port = address ? address.port : undefined
 
+  // @ts-ignore
   return url.format({
     protocol: req.protocol,
     hostname: req.hostname,
@@ -27,6 +29,7 @@ function errorHandler(err: any, req: Request, _res: Response, next: NextFunction
   this.notify(err, {
     url:     fullUrl(req),
     params:  req.body,    // http://expressjs.com/en/api.html#req.body
+    // @ts-ignore
     session: req.session, // https://github.com/expressjs/session#reqsession
     headers: req.headers, // https://nodejs.org/api/http.html#http_message_headers
     cgiData: {

--- a/src/server/middleware.ts
+++ b/src/server/middleware.ts
@@ -1,7 +1,8 @@
 import url from 'url'
 import domain from 'domain'
+import { NextFunction, Request, Response } from 'express'
 
-function fullUrl(req) {
+function fullUrl(req: Request): string {
   const connection = req.connection
   const address = connection && connection.address()
   const port = address ? address.port : undefined
@@ -15,14 +16,14 @@ function fullUrl(req) {
   })
 }
 
-function requestHandler(req, res, next) {
+function requestHandler(req: Request, res: Response, next: NextFunction): void {
   this.clear()
   const dom = domain.create()
   dom.on('error', next)
   dom.run(next)
 }
 
-function errorHandler(err, req, _res, next) {
+function errorHandler(err: any, req: Request, _res: Response, next: NextFunction): unknown {
   this.notify(err, {
     url:     fullUrl(req),
     params:  req.body,    // http://expressjs.com/en/api.html#req.body
@@ -35,7 +36,9 @@ function errorHandler(err, req, _res, next) {
   return next(err)
 }
 
-function lambdaHandler(handler) {
+type LambdaHandler = (event: unknown, context: unknown, callback: unknown) => void|Promise<unknown>
+
+function lambdaHandler(handler: LambdaHandler): LambdaHandler {
   return function lambdaHandler(event, context, callback) {
     // eslint-disable-next-line prefer-rest-params
     const args = arguments

--- a/src/server/util.ts
+++ b/src/server/util.ts
@@ -1,7 +1,7 @@
 import os from 'os'
 import fs from 'fs'
 
-export function fatallyLogAndExit(err: Error): void {
+export function fatallyLogAndExit(err: Error): never {
   console.error('[Honeybadger] Exiting process due to uncaught exception')
   console.error(err.stack || err)
   process.exit(1)

--- a/test-d/browser.test-d.tsx
+++ b/test-d/browser.test-d.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import Honeybadger from '../dist/browser/types/browser'
+import Honeybadger from '../honeybadger'
 
 Honeybadger.configure({
   debug: false,

--- a/test-d/browser.test-d.tsx
+++ b/test-d/browser.test-d.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import Honeybadger from '../honeybadger'
+import Honeybadger from '../dist/browser/honeybadger'
 
 Honeybadger.configure({
   debug: false,

--- a/test-d/browser.test-d.tsx
+++ b/test-d/browser.test-d.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import Honeybadger from '../dist/browser/honeybadger'
+import Honeybadger from '../dist/browser/types/browser'
 
 Honeybadger.configure({
   debug: false,
@@ -12,8 +12,6 @@ Honeybadger.configure({
   revision: 'git SHA/project version',
   component: 'example_comonent',
   action: 'example_action',
-  onerror: true,
-  onunhandledrejection: true,
   async: true,
   maxErrors: 20,
   breadcrumbsEnabled: true

--- a/test-d/server.test-d.tsx
+++ b/test-d/server.test-d.tsx
@@ -1,4 +1,4 @@
-import Honeybadger from '../honeybadger'
+import Honeybadger from '../dist/server/honeybadger'
 
 Honeybadger.configure({
     debug: false,

--- a/test-d/server.test-d.tsx
+++ b/test-d/server.test-d.tsx
@@ -1,5 +1,22 @@
-import Honeybadger from '../dist/server/honeybadger'
+import Honeybadger from '../dist/server/types/server'
 
+Honeybadger.configure({
+    debug: false,
+    disabled: true,
+    endpoint: 'https://api.honeybadger.io',
+    projectRoot: 'webpack:///./',
+    apiKey: 'project api key',
+    environment: 'production',
+    hostname: 'badger01',
+    revision: 'git SHA/project version',
+    component: 'example_comonent',
+    action: 'example_action',
+    breadcrumbsEnabled: true
+})
+
+Honeybadger.resetContext({
+    user_id: 123
+})
 Honeybadger.notify('test')
 Honeybadger.notify(new Error('test'))
 Honeybadger.notify({ message: 'test' })

--- a/test-d/server.test-d.tsx
+++ b/test-d/server.test-d.tsx
@@ -1,4 +1,4 @@
-import Honeybadger from '../dist/server/types/server'
+import Honeybadger from '../honeybadger'
 
 Honeybadger.configure({
     debug: false,

--- a/test/unit/core/util.test.ts
+++ b/test/unit/core/util.test.ts
@@ -71,8 +71,8 @@ describe('utils', function () {
   })
 
   describe('mergeNotice', function () {
-    it('combines two objects', function () {
-      expect(mergeNotice({ foo: 'foo' }, { bar: 'bar' })).toEqual({ foo: 'foo', bar: 'bar' })
+    it('combines two notice objects', function () {
+      expect(mergeNotice({ name: 'foo' }, { message: 'bar' })).toEqual({ name: 'foo', message: 'bar' })
     })
 
     it('combines context properties', function () {

--- a/test/unit/helpers.ts
+++ b/test/unit/helpers.ts
@@ -12,7 +12,8 @@ export function nullLogger (): Logger {
 }
 
 export class TestClient extends BaseClient {
-  protected __send (notice: Notice): unknown {
+  // @ts-ignore
+  protected __send(notice) {
     return this.__buildPayload(notice)
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,9 @@
     "allowJs": false,
     "target": "es5",
     "esModuleInterop": true,
-    "noImplicitAny": false
+    "noImplicitAny": false,
+    "declaration": true,
+    "declarationDir": "types"
   },
   "include": [
     "./src/**/*"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,8 @@
     "esModuleInterop": true,
     "noImplicitAny": false,
     "declaration": true,
-    "declarationDir": "types"
+    "declarationDir": "types",
+    "stripInternal": true
   },
   "include": [
     "./src/**/*"


### PR DESCRIPTION
(Apologies for the size of the PR; the changes involved turned out to be a little more than anticipated.)

This PR:
1. Adds `@types/express` to our dependencies, fixing #604 
2. Adds some missing null checks. A number of places had a check for `if (typeof thing === 'object')`, with the subtle bug that `null` in JS also returns `object`.
3. Improves typing. A number of types (some of which were user-facing) were incorrect or incomplete. I've fixed them so they're (mostly) correct, providing better IDE suggestions.
4. Switches to (mostly) automated generation of type declarations. This is done by enabling declarations in our `tsconfig.json`, then updating our Rollup config to point to the right paths for each build. However, this generates separate type decl files for the two builds, so there's a manual `honeybadger.d.ts` file that re-exports them as one file as before. Additionally, users can still import the `browser/honeybadger.d.ts` or `server/honeybadger.d.ts` files like before (with the added advantage of accurate types for the build).
5. Updated the README to explain this for first-time contributors.