### PR TITLE
#648 Callback not called on lambda handler if notify returns false

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased][latest]
+### Fixed
+- Call lambda handler callback if notify preconditions fail (#648)
 
 ## [3.2.5] - 2021-09-22
 ### Fixed

--- a/src/server/middleware.ts
+++ b/src/server/middleware.ts
@@ -49,27 +49,25 @@ function lambdaHandler(handler: LambdaHandler): LambdaHandler {
     // eslint-disable-next-line @typescript-eslint/no-this-alias
     const hb = this
 
-    dom.on('error', function(err) {
-      hb.notify(err, {
+    const hbHandler = function (err?: Error) {
+      const willNotify = hb.notify(err, {
         afterNotify: function() {
           hb.clear()
           callback(err)
         }
       })
-    })
+      if (!willNotify) {
+        callback(err)
+      }
+    }
+
+    dom.on('error', hbHandler)
 
     dom.run(function() {
       process.nextTick(function() {
         Promise.resolve(handler.apply(this, args))
           .then(() => { hb.clear() })
-          .catch(function(err) {
-            hb.notify(err, {
-              afterNotify: function() {
-                hb.clear()
-                callback(err)
-              }
-            })
-          })
+          .catch(hbHandler)
       })
     })
   }.bind(this)

--- a/test/unit/core/client.test.ts
+++ b/test/unit/core/client.test.ts
@@ -194,15 +194,6 @@ describe('client', function () {
       expect(client.notify({})).toEqual(false)
     })
 
-    it('does not send notice when message is ignored', function () {
-      client.configure({
-        api_key: 'testing',
-        ignorePatterns: [/ignore/i]
-      })
-
-      expect(client.notify('you should ignore me')).toEqual(false)
-    })
-
     it('accepts options as first argument', function () {
       client.configure({
         apiKey: 'testing'
@@ -306,24 +297,6 @@ describe('client', function () {
       const payload = client.notify(err, { context: { bar: 'bar' } })
 
       expect(payload.request.context).toEqual({ foo: 'foo', bar: 'bar' })
-    })
-
-    it('sends the notice with arguments when using ignore patterns and error is null', function () {
-      client.configure({
-        apiKey: 'testing',
-        ignorePatterns: [/ignore/i]
-      })
-
-      expect(client.notify(null, 'custom class name')).toEqual(expect.any(Object))
-    })
-
-    it('sends the notice when using ignore patterns and message does not respond to match', function () {
-      client.configure({
-        apiKey: 'testing',
-        ignorePatterns: [/care/i]
-      })
-
-      expect(client.notify({ message: {} })).toEqual(expect.any(Object))
     })
 
     it('generates a backtrace when there isn\'t one', function () {

--- a/test/unit/server.test.ts
+++ b/test/unit/server.test.ts
@@ -295,6 +295,28 @@ describe('server client', function () {
     })
 
     describe('async handlers', function() {
+
+      beforeEach(() => {
+        client.configure({
+          apiKey: 'testgin'
+        })
+      })
+
+      it('calls handler if notify exits on preconditions', function (done) {
+        client.configure({
+          apiKey: null
+        })
+
+        const handler = client.lambdaHandler(async function(_event) {
+          throw new Error("Badgers!")
+        })
+
+        handler({}, {}, (err) => {
+          expect(err).toBeDefined()
+          done()
+        })
+      })
+
       // eslint-disable-next-line jest/expect-expect
       it('reports errors to Honeybadger', function() {
         nock.cleanAll()

--- a/test/unit/server.test.ts
+++ b/test/unit/server.test.ts
@@ -296,12 +296,6 @@ describe('server client', function () {
 
     describe('async handlers', function() {
 
-      beforeEach(() => {
-        client.configure({
-          apiKey: 'testgin'
-        })
-      })
-
       it('calls handler if notify exits on preconditions', function (done) {
         client.configure({
           apiKey: null
@@ -318,7 +312,11 @@ describe('server client', function () {
       })
 
       // eslint-disable-next-line jest/expect-expect
-      it('reports errors to Honeybadger', function() {
+      it('reports errors to Honeybadger', function(done) {
+        client.configure({
+          apiKey: 'testing'
+        })
+
         nock.cleanAll()
 
         const api = nock("https://api.honeybadger.io")
@@ -327,17 +325,22 @@ describe('server client', function () {
 
         const callback = function(_err) {
           api.done()
+          done()
         }
 
         const handler = client.lambdaHandler(async function(_event) {
           throw new Error("Badgers!")
         })
 
-        return handler({}, {}, callback)
+        handler({}, {}, callback)
       })
 
       // eslint-disable-next-line jest/expect-expect
-      it('reports async errors to Honeybadger', function() {
+      it('reports async errors to Honeybadger', function(done) {
+        client.configure({
+          apiKey: 'testing'
+        })
+
         nock.cleanAll()
 
         const api = nock("https://api.honeybadger.io")
@@ -346,6 +349,7 @@ describe('server client', function () {
 
         const callback = function(_err) {
           api.done()
+          done()
         }
 
         const handler = client.lambdaHandler(async function(_event) {
@@ -354,40 +358,72 @@ describe('server client', function () {
           }, 0)
         })
 
-        return handler({}, {}, callback)
+        handler({}, {}, callback)
       })
     })
 
     describe('non-async handlers', function() {
+
+      it('calls handler if notify exits on preconditions', function (done) {
+        client.configure({
+          apiKey: null
+        })
+
+        const handler = client.lambdaHandler(function(_event, _context, _callback) {
+          throw new Error("Badgers!")
+        })
+
+        handler({}, {}, (err) => {
+          expect(err).toBeDefined()
+
+          //revert the client to use a key
+          client.configure({
+            apiKey: 'testing'
+          })
+
+          done()
+        })
+      })
+
       // eslint-disable-next-line jest/expect-expect
-      it('reports errors to Honeybadger', function() {
+      it('reports errors to Honeybadger', function(done) {
+        client.configure({
+          apiKey: 'testing'
+        })
+
         nock.cleanAll()
 
         const api = nock("https://api.honeybadger.io")
-          .post("/v1/notices/js")
-          .reply(201, '{"id":"1a327bf6-e17a-40c1-ad79-404ea1489c7a"}')
+            .post("/v1/notices/js")
+            .reply(201, '{"id":"1a327bf6-e17a-40c1-ad79-404ea1489c7a"}')
 
         const callback = function(_err) {
           api.done()
+          done()
         }
 
         const handler = client.lambdaHandler(function(_event, _context, _callback) {
           throw new Error("Badgers!")
         })
 
-        return handler({}, {}, callback)
+        handler({}, {}, callback)
       })
 
       // eslint-disable-next-line jest/expect-expect
-      it('reports async errors to Honeybadger', function() {
+      it('reports async errors to Honeybadger', function(done) {
+        client.configure({
+          apiKey: 'testing'
+        })
+
         nock.cleanAll()
 
         const api = nock("https://api.honeybadger.io")
-          .post("/v1/notices/js")
-          .reply(201, '{"id":"1a327bf6-e17a-40c1-ad79-404ea1489c7a"}')
+            .post("/v1/notices/js")
+            .reply(201, '{"id":"1a327bf6-e17a-40c1-ad79-404ea1489c7a"}')
 
         const callback = function(_err) {
           api.done()
+          done()
         }
 
         const handler = client.lambdaHandler(function(_event, _context, _callback) {
@@ -396,8 +432,9 @@ describe('server client', function () {
           }, 0)
         })
 
-        return handler({}, {}, callback)
+        handler({}, {}, callback)
       })
+
     })
   })
 })


### PR DESCRIPTION
## Status
**READY**

## Description
Our lambda handler implementation relies on `afterNotify` to call `callback(err)`.
`afterNotify` will not be called if the precondition checks fail in `notify()`.
Please see [ticket](https://github.com/honeybadger-io/honeybadger-js/issues/648) for more details.

## Related PRs
n/a

## Todos
- [x] Fix bug
- [x] Tests 
- [x] Changelog Entry (unreleased)

## Steps to Test or Reproduce
Create a lambda handler and test without providing an apiKey.
More info on this [ticket](https://github.com/honeybadger-io/honeybadger-js/issues/648).
