### PR TITLE
Improve dev-mode logging

### DIFF
--- a/src/core/client.ts
+++ b/src/core/client.ts
@@ -145,12 +145,12 @@ export default class Client {
     let preConditionError: Error = null
     const notice = this.makeNotice(noticeable, name, extra)
     if (!notice) {
-      this.logger.debug('could not make notice')
-      preConditionError = new Error('could not make notice')
+      this.logger.debug('failed to build error report')
+      preConditionError = new Error('failed to build error report')
     }
 
     if (!preConditionError && this.config.reportData === false) {
-      this.logger.debug('skipping notice: honeybadger.js is disabled', notice)
+      this.logger.debug('skipping error report: honeybadger.js is disabled', notice)
       preConditionError = new Error('honeybadger.js is disabled')
     }
 
@@ -166,7 +166,7 @@ export default class Client {
 
     const beforeNotifyResult = runBeforeNotifyHandlers(notice, this.__beforeNotifyHandlers)
     if (!preConditionError && !beforeNotifyResult) {
-      this.logger.debug('skipping notice: beforeNotify handlers returned false', notice)
+      this.logger.debug('skipping error report: beforeNotify handlers returned false', notice)
       preConditionError = new Error('beforeNotify handlers returned false')
     }
 

--- a/src/core/client.ts
+++ b/src/core/client.ts
@@ -160,13 +160,13 @@ export default class Client {
     }
 
     if (!preConditionError && !this.config.apiKey) {
-      this.logger.warn('could not send error report: no API key has been configured')
+      this.logger.warn('could not send error report: no API key has been configured', notice)
       preConditionError = new Error('missing API key')
     }
 
     const beforeNotifyResult = runBeforeNotifyHandlers(notice, this.__beforeNotifyHandlers)
     if (!preConditionError && !beforeNotifyResult) {
-      this.logger.debug('skipping notice: beforeNotify handlers returned false')
+      this.logger.debug('skipping notice: beforeNotify handlers returned false', notice)
       preConditionError = new Error('beforeNotify handlers returned false')
     }
 

--- a/src/core/client.ts
+++ b/src/core/client.ts
@@ -82,7 +82,6 @@ export default class Client {
 
       ...opts,
     }
-
     this.logger = logger(this)
   }
 

--- a/src/core/util.ts
+++ b/src/core/util.ts
@@ -194,7 +194,10 @@ export function logger(client: Client): Logger {
   const log = (method: string) => {
     return function (...args: unknown[]) {
       if (method === 'debug' && !client.config.debug) {
-        return
+        if (!client.config.debug) { return }
+        // Log at default level so that you don't need to also enable verbose
+        // logging in Chrome.
+        method = 'log'
       }
       args.unshift('[Honeybadger]')
       client.config.logger[method](...args)

--- a/src/core/util.ts
+++ b/src/core/util.ts
@@ -193,7 +193,7 @@ export function sanitize(obj, maxDepth = 8) {
 export function logger(client: Client): Logger {
   const log = (method: string) => {
     return function (...args: unknown[]) {
-      if (method === 'debug' && !client.config.debug) {
+      if (method === 'debug') {
         if (!client.config.debug) { return }
         // Log at default level so that you don't need to also enable verbose
         // logging in Chrome.

--- a/test/unit/core/client.test.ts
+++ b/test/unit/core/client.test.ts
@@ -499,14 +499,14 @@ describe('client', function () {
 
       return new Promise<void>(resolve => {
         client.afterNotify((err) => {
-          expect(err.message).toEqual('Unable to send error report: no API key has been configured')
+          expect(err.message).toEqual('missing API key')
           resolve()
         })
 
         client.notify('should not report')
       })
     })
-    
+
     it('is called with error if beforeNotify handlers return false', function () {
       client.configure({
         apiKey: 'abc123',
@@ -515,7 +515,7 @@ describe('client', function () {
       return new Promise<void>(resolve => {
         client.beforeNotify(() => false)
         client.afterNotify((err) => {
-          expect(err.message).toEqual('Will not send error report, beforeNotify handlers returned false')
+          expect(err.message).toEqual('beforeNotify handlers returned false')
           resolve()
         })
 
@@ -549,7 +549,7 @@ describe('client', function () {
         let total = 0
         const expected = 2
         const handlerCalled = (err?: Error) => {
-          expect(err.message).toEqual('Will not send error report, beforeNotify handlers returned false')
+          expect(err.message).toEqual('beforeNotify handlers returned false')
           total++
           if (total === expected) {
             resolve()
@@ -581,7 +581,7 @@ describe('client', function () {
         }
 
         const afterNotifyHandler = (err: Error) => {
-          expect(err.message).toEqual('Unable to send error report: no API key has been configured')
+          expect(err.message).toEqual('missing API key')
           expect(totalBeforeNotify).toEqual(expectedBeforeNotify)
           resolve()
         }

--- a/test/unit/core/util.test.ts
+++ b/test/unit/core/util.test.ts
@@ -51,10 +51,10 @@ describe('utils', function () {
       expect(mockDebug.mock.calls.length).toBe(0)
     })
 
-    it('logs debug to console when enabled', function () {
+    it('logs to console when debug logging is enabled', function () {
       const mockDebug = jest.fn()
       const console = nullLogger()
-      console.debug = mockDebug
+      console.log = mockDebug
       const client = new Client({ logger: console, debug: true })
 
       logger(client).debug('expected')


### PR DESCRIPTION
Debug logs are now logged at the default level in Chrome, so that you
don't have to enable verbose logging to see them (you still need to
configure the `debug: true` option.

Also changed a few of the log/error messages and used separate messages
for the development mode notice vs. disabled via `reportData: false`.

Closes #661

Edit: this also includes the notice in log messages, when available:

<img width="1200" alt="image" src="https://user-images.githubusercontent.com/474649/145495527-5b51591a-5128-4fed-b9aa-c96b830ecb89.png">
