### PR TITLE
#327 notifyAsync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased][latest]
 ### Added
 - Nodejs: Include source snippet in backtraces when available (#624)
+- `notifyAsync`: Async version of `notify` that returns a promise (#327)
 
 ### Changed
 - Call afterNotify handlers with error if notify preconditions fail (#654)

--- a/src/core/client.ts
+++ b/src/core/client.ts
@@ -206,39 +206,12 @@ export default class Client {
    */
   notifyAsync(noticeable: Noticeable, name: string | Partial<Notice> = undefined, extra: Partial<Notice> = undefined): Promise<void> {
     return new Promise((resolve, reject) => {
-      const applyAfterNotify = (partialNotice: Partial<Notice>) => {
-        const originalAfterNotify = partialNotice.afterNotify
-        partialNotice.afterNotify = (err?: Error) => {
-          originalAfterNotify?.call(this, err)
-          if (err) {
-            return reject(err)
-          }
-          resolve()
+      this.afterNotify(err => {
+        if (err) {
+          return reject(err)
         }
-      }
-
-      // We have to respect any afterNotify hooks that come from the arguments
-      let objectToOverride: Partial<Notice>
-      if ((noticeable as Partial<Notice>).afterNotify) {
-        objectToOverride = noticeable as Partial<Notice>
-      }
-      else if (name && (name as Partial<Notice>).afterNotify) {
-        objectToOverride = name as Partial<Notice>
-      }
-      else if (extra && extra.afterNotify) {
-        objectToOverride = extra
-      }
-      else if (name && typeof name === 'object') {
-        objectToOverride = name
-      }
-      else if (extra) {
-        objectToOverride = extra
-      }
-      else {
-        objectToOverride = name = {}
-      }
-
-      applyAfterNotify(objectToOverride)
+        resolve()
+      })
       this.notify(noticeable, name, extra)
     })
   }

--- a/src/core/client.ts
+++ b/src/core/client.ts
@@ -198,6 +198,51 @@ export default class Client {
     return true
   }
 
+  /**
+   * An async version of {@link notify} that resolves only after the notice has been reported to Honeybadger.
+   * Implemented using the {@link afterNotify} hook.
+   * Rejects if for any reason the report failed to be reported.
+   * Useful in serverless environments (AWS Lambda).
+   */
+  notifyAsync(noticeable: Noticeable, name: string | Partial<Notice> = undefined, extra: Partial<Notice> = undefined): Promise<void> {
+    return new Promise((resolve, reject) => {
+      const applyAfterNotify = (partialNotice: Partial<Notice>) => {
+        const originalAfterNotify = partialNotice.afterNotify
+        partialNotice.afterNotify = (err?: Error) => {
+          originalAfterNotify?.call(this, err)
+          if (err) {
+            return reject(err)
+          }
+          resolve()
+        }
+      }
+
+      // We have to respect any afterNotify hooks that come from the arguments
+      let objectToOverride: Partial<Notice>
+      if ((noticeable as Partial<Notice>).afterNotify) {
+        objectToOverride = noticeable as Partial<Notice>
+      }
+      else if (name && (name as Partial<Notice>).afterNotify) {
+        objectToOverride = name as Partial<Notice>
+      }
+      else if (extra && extra.afterNotify) {
+        objectToOverride = extra
+      }
+      else if (name && typeof name === 'object') {
+        objectToOverride = name
+      }
+      else if (extra) {
+        objectToOverride = extra
+      }
+      else {
+        objectToOverride = name = {}
+      }
+
+      applyAfterNotify(objectToOverride)
+      this.notify(noticeable, name, extra)
+    })
+  }
+
   protected makeNotice(noticeable: Noticeable, name: string | Partial<Notice> = undefined, extra: Partial<Notice> = undefined): Notice | null {
     let notice = makeNotice(noticeable)
 

--- a/src/core/client.ts
+++ b/src/core/client.ts
@@ -206,12 +206,39 @@ export default class Client {
    */
   notifyAsync(noticeable: Noticeable, name: string | Partial<Notice> = undefined, extra: Partial<Notice> = undefined): Promise<void> {
     return new Promise((resolve, reject) => {
-      this.afterNotify(err => {
-        if (err) {
-          return reject(err)
+      const applyAfterNotify = (partialNotice: Partial<Notice>) => {
+        const originalAfterNotify = partialNotice.afterNotify
+        partialNotice.afterNotify = (err?: Error) => {
+          originalAfterNotify?.call(this, err)
+          if (err) {
+            return reject(err)
+          }
+          resolve()
         }
-        resolve()
-      })
+      }
+
+      // We have to respect any afterNotify hooks that come from the arguments
+      let objectToOverride: Partial<Notice>
+      if ((noticeable as Partial<Notice>).afterNotify) {
+        objectToOverride = noticeable as Partial<Notice>
+      }
+      else if (name && (name as Partial<Notice>).afterNotify) {
+        objectToOverride = name as Partial<Notice>
+      }
+      else if (extra && extra.afterNotify) {
+        objectToOverride = extra
+      }
+      else if (name && typeof name === 'object') {
+        objectToOverride = name
+      }
+      else if (extra) {
+        objectToOverride = extra
+      }
+      else {
+        objectToOverride = name = {}
+      }
+
+      applyAfterNotify(objectToOverride)
       this.notify(noticeable, name, extra)
     })
   }

--- a/test/unit/core/client.test.ts
+++ b/test/unit/core/client.test.ts
@@ -342,6 +342,17 @@ describe('client', function () {
       await client.notifyAsync(new Error('test'))
     })
 
+    it('calls afterNotify from client.afterNotify', async () => {
+      let called = false
+      client.afterNotify((_err) => {
+        called = true
+      })
+
+      await client.notifyAsync('test test')
+
+      expect(called).toBeTruthy()
+    })
+
     it('calls afterNotify in noticeable', async () => {
       let called = false
       const afterNotify = () => {

--- a/test/unit/core/client.test.ts
+++ b/test/unit/core/client.test.ts
@@ -389,6 +389,28 @@ describe('client', function () {
       expect(called).toBeTruthy()
     })
 
+    it('calls afterNotify and then resolves promise', async () => {
+      // the afterNotify hook that resolves the promise is called first
+      // however, the loop continues to call all handlers before it gives back
+      // control to the event loop
+      // which means: all afterNotify hooks will be called and then the promise will resolve
+      const called: boolean[] = [];
+      function register(i: number) {
+        called[i] = false
+        client.afterNotify(() => {
+          called[i] = true
+        })
+      }
+
+      for (let i =0; i < 100; i++) {
+        register(i)
+      }
+
+      await client.notifyAsync(new Error('test'))
+
+      expect(called.every(val => val === true)).toBeTruthy()
+    })
+
     it('rejects with error if not configured correctly', async () => {
       client.configure({
         apiKey: null

--- a/test/unit/core/client.test.ts
+++ b/test/unit/core/client.test.ts
@@ -331,6 +331,70 @@ describe('client', function () {
     })
   })
 
+  describe('notifyAsync', function () {
+    beforeEach(() => {
+      client.configure({
+        apiKey: 'testing'
+      })
+    })
+
+    it('resolves when configured', async () => {
+      await client.notifyAsync(new Error('test'))
+    })
+
+    it('calls afterNotify in noticeable', async () => {
+      let called = false
+      const afterNotify = () => {
+        called = true
+      }
+
+      await client.notifyAsync({
+        message: 'test',
+        afterNotify
+      })
+
+      expect(called).toBeTruthy()
+    })
+
+    it('calls afterNotify in name', async () => {
+      let called = false
+      const afterNotify = () => {
+        called = true
+      }
+
+      await client.notifyAsync(new Error('test'), { afterNotify })
+
+      expect(called).toBeTruthy()
+    })
+
+    it('calls afterNotify in extra', async () => {
+      let called = false
+      const afterNotify = () => {
+        called = true
+      }
+
+      await client.notifyAsync(new Error('test'), 'an error', { afterNotify })
+
+      expect(called).toBeTruthy()
+    })
+
+    it('rejects with error if not configured correctly', async () => {
+      client.configure({
+        apiKey: null
+      })
+      await expect(client.notifyAsync(new Error('test'))).rejects.toThrow(new Error('Unable to send error report: no API key has been configured'))
+    })
+
+    it('rejects on pre-condition error', async () => {
+      client.configure({
+        apiKey: 'testing',
+        reportData: false
+      })
+
+      await expect(client.notifyAsync(new Error('test'))).rejects.toThrow(new Error('Dropping notice: honeybadger.js is in development mode'))
+    })
+  })
+
   describe('beforeNotify', function () {
     beforeEach(function () {
       client.configure({

--- a/test/unit/server.test.ts
+++ b/test/unit/server.test.ts
@@ -164,4 +164,32 @@ describe('server client', function () {
       })
     })
   })
+
+  describe('notifyAsync', function () {
+    beforeEach(() => {
+      client.configure({
+        apiKey: 'testing'
+      })
+    })
+
+    it('resolves after the http request is done', async () => {
+      const request = nock('https://api.honeybadger.io')
+          .post('/v1/notices/js')
+          .reply(201, {
+            id: '48b98609-dd3b-48ee-bffc-d51f309a2dfa'
+          })
+
+      await client.notifyAsync('testing')
+      expect(request.isDone()).toBe(true)
+    })
+
+    it('rejects on http error', async () => {
+      const request = nock('https://api.honeybadger.io')
+          .post('/v1/notices/js')
+          .reply(400)
+
+      await expect(client.notifyAsync('testing')).rejects.toThrow(/Bad HTTP response/)
+      expect(request.isDone()).toBe(true)
+    })
+  })
 })


### PR DESCRIPTION
## Status
**READY**

## Description
Related Issue: #327 

I came up with a simple implementation of notify that returns a promise (notifyAsync).
It all became simple because now we always call the `afterNotify` hook, so I used it to know when to resolve/reject the promise.
I decided to go for this because of our recent work on AWS Lambda (see [here](https://github.com/honeybadger-io/honeybadger-js/issues/682#issuecomment-1013654404) and [here](https://github.com/honeybadger-io/honeybadger-js/pull/680#issuecomment-1008439277)). The _fire-and-forget_ approach does not work well with Lambda functions.

Let me know what you think.

Note: The target branch is [aws_lambda_async_#677](https://github.com/honeybadger-io/honeybadger-js/tree/aws_lambda_async_%23677)

## Todos
- [x] Tests
- [ ] Documentation
- [x] Changelog Entry (unreleased)