### PR TITLE
Apply enableUncaught setting to timers and event listeners

### DIFF
--- a/src/browser.ts
+++ b/src/browser.ts
@@ -137,14 +137,13 @@ class Honeybadger extends Client {
         // eslint-disable-next-line @typescript-eslint/no-this-alias
         const client = this
         func.___hb = <WrappedFunc>function () {
-          const onErrorEnabled = client.config.enableUncaught
           // Catch if:
           //   1. We explicitly want to catch (i.e. if the error could be
           //      caught before reaching window.onerror)
           //   2. The browser provides less information via the window.onerror
           //      handler
           //   3. The window.onerror handler is unavailable
-          if (opts.catch || preferCatch || !onErrorEnabled) {
+          if (opts.catch || preferCatch || !client.config.enableUncaught) {
             try {
               // eslint-disable-next-line prefer-rest-params
               return func.apply(this, arguments)
@@ -163,7 +162,9 @@ class Honeybadger extends Client {
                   }
                 }
               )
-              client.notify(err)
+              if (client.config.enableUncaught) {
+                client.notify(err)
+              }
               throw (err)
             }
           } else {

--- a/src/browser/integrations/onerror.ts
+++ b/src/browser/integrations/onerror.ts
@@ -28,8 +28,6 @@ export function onError(_window: any = window): Plugin {
             return
           }
 
-          if (!client.config.enableUncaught) { return }
-
           if (line === 0 && /Script error\.?/.test(msg)) {
             // See https://developer.mozilla.org/en/docs/Web/API/GlobalEventHandlers/onerror#Notes
             client.logger.info('Ignoring cross-domain script error: enable CORS to track these types of errors', arguments)
@@ -56,7 +54,9 @@ export function onError(_window: any = window): Plugin {
             }
           )
 
-          client.notify(notice)
+          if (client.config.enableUncaught) {
+            client.notify(notice)
+          }
         }
 
         return function (msg, url, line, col, err) {


### PR DESCRIPTION
This should be enough, since both the timer and event listener plugins use `__wrap()`. This will still add the breadcrumbs, but skip reporting the errors if `enableUncaught === false`.

Fixes #635