### PR TITLE
Adds setter and getter for __pluginsExecuted

### DIFF
--- a/src/core/client.ts
+++ b/src/core/client.ts
@@ -102,7 +102,7 @@ export default class Client {
       this.config.reportData = false
     }
     if (!this.getPluginsExecuted()) {
-      this.setPluginsExecuted(true)
+      this.setPluginsExecuted = true
       this.config.__plugins.forEach((plugin) => plugin.load(this))
     }
     return this
@@ -125,9 +125,8 @@ export default class Client {
     return this
   }
 
-  setPluginsExecuted(pluginsExecuted: boolean): Client {
+  set setPluginsExecuted(pluginsExecuted: boolean) {
     this.__pluginsExecuted = pluginsExecuted
-    return this
   }
 
   getPluginsExecuted(): boolean {

--- a/src/core/client.ts
+++ b/src/core/client.ts
@@ -101,8 +101,8 @@ export default class Client {
       this.logger.log('Deprecation warning: instead of `disabled: true`, use `reportData: false` to explicitly disable Honeybadger reporting.')
       this.config.reportData = false
     }
-    if (!this.__pluginsExecuted) {
-      this.__pluginsExecuted = true
+    if (!this.getPluginsExecuted()) {
+      this.setPluginsExecuted(true)
       this.config.__plugins.forEach((plugin) => plugin.load(this))
     }
     return this
@@ -123,6 +123,15 @@ export default class Client {
       this.__context = merge(this.__context, context)
     }
     return this
+  }
+
+  setPluginsExecuted(pluginsExecuted: boolean): Client {
+    this.__pluginsExecuted = pluginsExecuted
+    return this
+  }
+
+  getPluginsExecuted(): boolean {
+    return this.__pluginsExecuted
   }
 
   resetContext(context?: Record<string, unknown>): Client {

--- a/test/unit/core/client.test.ts
+++ b/test/unit/core/client.test.ts
@@ -24,6 +24,16 @@ describe('client', function () {
     })
   })
 
+  describe('setPluginsExecuted', function() {
+    it('sets the value', function() {
+      client.setPluginsExecuted(true)
+      expect(client.getPluginsExecuted()).toEqual(true)
+
+      client.setPluginsExecuted(false)
+      expect(client.getPluginsExecuted()).toEqual(false)
+    })
+  })
+
   describe('getVersion', function () {
     it('returns the current version', function () {
       expect(client.getVersion()).toEqual('__VERSION__')

--- a/test/unit/core/client.test.ts
+++ b/test/unit/core/client.test.ts
@@ -26,10 +26,10 @@ describe('client', function () {
 
   describe('setPluginsExecuted', function() {
     it('sets the value', function() {
-      client.setPluginsExecuted(true)
+      client.setPluginsExecuted = true
       expect(client.getPluginsExecuted()).toEqual(true)
 
-      client.setPluginsExecuted(false)
+      client.setPluginsExecuted = false
       expect(client.getPluginsExecuted()).toEqual(false)
     })
   })


### PR DESCRIPTION
## Status
Adds setter and getter method for __pluginsExecuted

## Description
When wrapping lambda methods with `Honeybadger.lambdaHandler(fn)` and running in AWS the following error is shown in CloudWatch logs:

```
{
    "errorType": "Runtime.UnhandledPromiseRejection",
    "errorMessage": "TypeError: Cannot set property __pluginsExecuted of #<Honeybadger3> which has only a getter",
    "reason": {
        "errorType": "TypeError",
        "errorMessage": "Cannot set property __pluginsExecuted of #<Honeybadger3> which has only a getter",
        "stack": [
            "TypeError: Cannot set property __pluginsExecuted of #<Honeybadger3> which has only a getter",
            "    at Honeybadger3.Client2.configure (/var/task/src/functions/fn/handler.js:951:34)",
            "    at Object.<anonymous> (/var/task/src/functions/fn/handler.js:1562:13)",
            "    at Module._compile (internal/modules/cjs/loader.js:1085:14)",
            "    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1114:10)",
            "    at Module.load (internal/modules/cjs/loader.js:950:32)",
            "    at Function.Module._load (internal/modules/cjs/loader.js:790:12)",
            "    at Module.require (internal/modules/cjs/loader.js:974:19)",
            "    at Module.hook.require (/opt/nodejs/node_modules/dd-trace/packages/dd-trace/src/ritm.js:42:31)",
            "    at Module.require (/opt/nodejs/node_modules/dd-trace/packages/dd-trace/src/ritm.js:12:27)",
            "    at Module._require.i.require (/var/task/serverless_sdk/index.js:9:73397)",
            "    at Module._require.i.require (/var/task/serverless_sdk/index.js:9:73397)",
            "    at Module._require.i.require (/var/task/serverless_sdk/index.js:9:73397)",
            "    at require (internal/modules/cjs/helpers.js:93:18)",
            "    at Object.<anonymous> (/var/task/s_fn.js:25:23)",
            "    at Module._compile (internal/modules/cjs/loader.js:1085:14)",
            "    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1114:10)",
            "    at Module.load (internal/modules/cjs/loader.js:950:32)",
            "    at Function.Module._load (internal/modules/cjs/loader.js:790:12)",
            "    at Module.require (internal/modules/cjs/loader.js:974:19)",
            "    at Module.hook.require (/opt/nodejs/node_modules/dd-trace/packages/dd-trace/src/ritm.js:42:31)",
            "    at Module.require (/opt/nodejs/node_modules/dd-trace/packages/dd-trace/src/ritm.js:12:27)",
            "    at require (internal/modules/cjs/helpers.js:93:18)",
            "    at _tryRequire (/opt/nodejs/node_modules/datadog-lambda-js/runtime/user-function.js:85:16)",
            "    at _loadUserApp (/opt/nodejs/node_modules/datadog-lambda-js/runtime/user-function.js:104:16)",
            "    at load (/opt/nodejs/node_modules/datadog-lambda-js/runtime/user-function.js:148:19)",
            "    at Object.<anonymous> (/opt/nodejs/node_modules/datadog-lambda-js/handler.js:65:59)",
            "    at Module._compile (internal/modules/cjs/loader.js:1085:14)",
            "    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1114:10)",
            "    at Module.load (internal/modules/cjs/loader.js:950:32)",
            "    at Function.Module._load (internal/modules/cjs/loader.js:790:12)",
            "    at Module.require (internal/modules/cjs/loader.js:974:19)",
            "    at require (internal/modules/cjs/helpers.js:93:18)",
            "    at _tryRequireFile (/var/runtime/UserFunction.js:63:32)",
            "    at _tryRequire (/var/runtime/UserFunction.js:151:20)",
            "    at _loadUserApp (/var/runtime/UserFunction.js:197:12)",
            "    at Object.module.exports.load (/var/runtime/UserFunction.js:242:17)",
            "    at Object.<anonymous> (/var/runtime/index.js:43:30)",
            "    at Module._compile (internal/modules/cjs/loader.js:1085:14)",
            "    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1114:10)",
            "    at Module.load (internal/modules/cjs/loader.js:950:32)",
            "    at Function.Module._load (internal/modules/cjs/loader.js:790:12)",
            "    at Function.executeUserEntryPoint [as runMain] (internal/modules/run_main.js:76:12)",
            "    at internal/main/run_main_module.js:17:47"
        ]
    },
    "promise": {},
    "stack": [
        "Runtime.UnhandledPromiseRejection: TypeError: Cannot set property __pluginsExecuted of #<Honeybadger3> which has only a getter",
        "    at process.<anonymous> (/var/runtime/index.js:35:15)",
        "    at process.emit (events.js:400:28)",
        "    at process.emit (domain.js:475:12)",
        "    at processPromiseRejections (internal/process/promises.js:245:33)",
        "    at processTicksAndRejections (internal/process/task_queues.js:96:32)",
        "    at runNextTicks (internal/process/task_queues.js:64:3)",
        "    at listOnTimeout (internal/timers.js:526:9)",
        "    at processTimers (internal/timers.js:500:7)"
    ]
}

 "Runtime.UnhandledPromiseRejection: TypeError: Cannot set property __pluginsExecuted of #<Honeybadger3> which has only a getter",
        "    at process.<anonymous> (/var/runtime/index.js:35:15)",
        "    at process.emit (events.js:400:28)",
        "    at process.emit (domain.js:475:12)",
        "    at processPromiseRejections (internal/process/promises.js:245:33)",
        "    at processTicksAndRejections (internal/process/task_queues.js:96:32)",
        "    at runNextTicks (internal/process/task_queues.js:64:3)",
        "    at listOnTimeout (internal/timers.js:526:9)",
        "    at processTimers (internal/timers.js:500:7)"
```

Also I'm not sure if `this.setPluginsExecuted = true` could be completely removed given that's not being used anywhere else in the code.

## Related PRs
List related PRs against other branches:

branch | PR
------ | ------
other_pr_production | [link]()
other_pr_master | [link]()

## Todos
- [X] Tests
- [ ] Documentation
- [ ] Changelog Entry (unreleased)

## Steps to Test or Reproduce
Outline the steps to test or reproduce the PR here.
```bash
> git pull --prune
> git checkout <branch>
> grunt jasmine
```
1.
