### PR TITLE
Catch unknown errors in data sanitizer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased][latest]
+### Fixed
+- Catch unknown errors in data sanitizer
 
 ## [3.2.7] - 2021-11-01
 ### Fixed

--- a/src/core/util.ts
+++ b/src/core/util.ts
@@ -117,7 +117,7 @@ export function sanitize(obj, maxDepth = 8) {
 
     // Serialize inside arrays
     if (Array.isArray(obj)) {
-      return obj.map(o => serialize(o, depth + 1))
+      return obj.map(o => safeSerialize(o, depth + 1))
     }
 
     // Serialize inside objects
@@ -126,7 +126,7 @@ export function sanitize(obj, maxDepth = 8) {
       for (const k in obj) {
         const v = obj[k]
         if (Object.prototype.hasOwnProperty.call(obj, k) && (k != null) && (v != null)) {
-          ret[k] = serialize(v, depth + 1)
+          ret[k] = safeSerialize(v, depth + 1)
         }
       }
       return ret
@@ -136,7 +136,15 @@ export function sanitize(obj, maxDepth = 8) {
     return obj
   }
 
-  return serialize(obj)
+  function safeSerialize(obj: unknown, depth = 0) {
+    try {
+      return serialize(obj, depth)
+    } catch(e) {
+      return `[ERROR] ${e}`
+    }
+  }
+
+  return safeSerialize(obj)
 }
 
 export function logger(client: Client): Logger {

--- a/test/unit/core/util.test.ts
+++ b/test/unit/core/util.test.ts
@@ -287,5 +287,16 @@ describe('utils', function () {
         ).toEqual({})
       })
     }
+
+    it('handles other errors', function () {
+      const obj = []
+      // This will cause the map operation to blow up
+      obj.map = () => { throw(new Error("expected error")) }
+      expect(
+        sanitize({ obj: obj })
+      ).toEqual(
+        { obj: `[ERROR] Error: expected error` }
+      )
+    })
   })
 })


### PR DESCRIPTION
This is for a customer issue where we can't reproduce the specific error, but I'm pretty sure something in the data passed to breadcrumbs (via `console.log`) is blowing up the sanitize function.

I created a v3-stable base branch so that I can release immediately. I'll also add it to the main (v4) branch after this is merged.