### PR TITLE
Allow special characters in tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased][beta]
+### Fixed
+- Allow special characters in tags. Also support space-delimited tags:
+  "one two three" and "one, two, three" are equivalent
 
 ## [4.0.0-beta.0] - 2022-02-08
 ### Added

--- a/src/core/client.ts
+++ b/src/core/client.ts
@@ -25,10 +25,10 @@ const notifier = {
 }
 
 // Split at commas
-const TAG_SEPARATOR = /,/
+const TAG_SEPARATOR = /,|\s/
 
 // Removes any non-word characters
-const TAG_SANITIZER = /[^\w]/g
+const TAG_SANITIZER = /\s/g
 
 // Checks for blank strings
 const STRING_EMPTY = ''

--- a/src/core/client.ts
+++ b/src/core/client.ts
@@ -24,10 +24,10 @@ const notifier = {
   version: '__VERSION__'
 }
 
-// Split at commas
+// Split at commas and spaces
 const TAG_SEPARATOR = /,|\s/
 
-// Removes any non-word characters
+// Removes extra whitespace from individual tags
 const TAG_SANITIZER = /\s/g
 
 // Checks for blank strings
@@ -246,7 +246,7 @@ export default class Client {
 
     if (name && !(typeof name === 'object')) {
       const n = String(name)
-      name = {name: n}
+      name = { name: n }
     }
 
     if (name) {

--- a/src/core/client.ts
+++ b/src/core/client.ts
@@ -25,13 +25,7 @@ const notifier = {
 }
 
 // Split at commas and spaces
-const TAG_SEPARATOR = /,|\s/
-
-// Removes extra whitespace from individual tags
-const TAG_SANITIZER = /\s/g
-
-// Checks for blank strings
-const STRING_EMPTY = ''
+const TAG_SEPARATOR = /,|\s+/
 
 // Checks for non-blank characters
 const NOT_BLANK = /\S/
@@ -374,8 +368,6 @@ export default class Client {
       return []
     }
 
-    return tags.toString().split(TAG_SEPARATOR).map((tag: string) => {
-      return tag.replace(TAG_SANITIZER, STRING_EMPTY)
-    }).filter((tag) => NOT_BLANK.test(tag))
+    return tags.toString().split(TAG_SEPARATOR).filter((tag) => NOT_BLANK.test(tag))
   }
 }

--- a/test/unit/core/client.test.ts
+++ b/test/unit/core/client.test.ts
@@ -247,7 +247,7 @@ describe('client', function () {
         }
       })
 
-      expect((payload.request.params as Record<string,string>).foo ).toEqual('bar')
+      expect((payload.request.params as Record<string, string>).foo).toEqual('bar')
     })
 
     it('reads default properties from error objects', function () {
@@ -394,7 +394,7 @@ describe('client', function () {
         })
       }
 
-      for (let i =0; i < 100; i++) {
+      for (let i = 0; i < 100; i++) {
         register(i)
       }
 
@@ -448,7 +448,7 @@ describe('client', function () {
 
     it('delivers notice when beforeNotify has no return', function () {
       // eslint-disable-next-line @typescript-eslint/no-empty-function
-      client.beforeNotify(function () {})
+      client.beforeNotify(function () { })
       expect(client.notify('testing')).toEqual(true)
     })
 
@@ -829,31 +829,40 @@ describe('client', function () {
       filters: ['secret']
     })
 
-    const payload = client.getPayload('testing', {url: 'https://www.example.com/?secret=value&foo=bar'})
+    const payload = client.getPayload('testing', { url: 'https://www.example.com/?secret=value&foo=bar' })
 
     expect(payload.request.url).toEqual('https://www.example.com/?secret=[FILTERED]&foo=bar')
   })
 
 
-  it('normalizes comma separated tags', function() {
+  it('normalizes comma separated tags', function () {
     client.configure({
       apiKey: 'testing'
     })
 
-    const payload = client.getPayload('testing', {tags: '  tag1, &%&@<$^tag2,tag3 , tag4,,tag5,'})
+    const payload = client.getPayload('testing', { tags: ' one,two   , three ,four' })
+    expect(payload.error.tags).toEqual(['one', 'two', 'three', 'four'])
+  })
+
+  it('normalizes arrays of tags', function () {
+    client.configure({
+      apiKey: 'testing'
+    })
+
+    const payload = client.getPayload('testing', { tags: ['  tag1,', ',tag2  ', 'tag3 ', 'tag4', 'tag5 '] })
     expect(payload.error.tags).toEqual(['tag1', 'tag2', 'tag3', 'tag4', 'tag5'])
   })
 
-  it('normalizes arrays of tags', function() {
+  it('allows non-word characters in tags while stripping whitespace', function () {
     client.configure({
       apiKey: 'testing'
     })
 
-    const payload = client.getPayload('testing', {tags: ['  tag1,', ',tag2 * /^&:', 'tag3 ', 'tag4', '<script> tag5 </script>']})
-    expect(payload.error.tags).toEqual(['tag1', 'tag2', 'tag3', 'tag4', 'scripttag5script'])
+    const payload = client.getPayload('testing', { tags: 'word,  with_underscore ,with space, with-dash,with$special*char' })
+    expect(payload.error.tags).toEqual(['word', 'with_underscore', 'with', 'space', 'with-dash', 'with$special*char'])
   })
 
-  it('sends configured tags to errors', function() {
+  it('sends configured tags to errors', function () {
     client.configure({
       apiKey: 'testing',
       tags: ['tag1']
@@ -863,35 +872,35 @@ describe('client', function () {
     expect(payload.error.tags).toEqual(['tag1'])
   })
 
-  it('sends context tags to errors', function() {
+  it('sends context tags to errors', function () {
     client.configure({
       apiKey: 'testing',
     })
 
-    client.setContext({tags: 'tag1, tag2'})
+    client.setContext({ tags: 'tag1, tag2' })
     const payload = client.getPayload('testing')
     expect(payload.error.tags).toEqual(['tag1', 'tag2'])
   })
 
-  it('sends config errors, context errors, and notice errors', function() {
+  it('sends config errors, context errors, and notice errors', function () {
     client.configure({
       apiKey: 'testing',
       tags: ['tag4']
     })
 
-    client.setContext({tags: 'tag3'})
+    client.setContext({ tags: 'tag3' })
 
-    const payload = client.getPayload('testing', {tags: ['tag1, tag2']})
+    const payload = client.getPayload('testing', { tags: ['tag1, tag2'] })
     expect(payload.error.tags).toEqual(['tag1', 'tag2', 'tag3', 'tag4'])
   })
 
-  it("should not send duplicate tags", function() {
+  it("should not send duplicate tags", function () {
     client.configure({
       apiKey: 'testing',
       tags: ['tag1']
     })
 
-    const payload = client.getPayload('testing', {tags: ['tag1']})
+    const payload = client.getPayload('testing', { tags: ['tag1'] })
     expect(payload.error.tags).toEqual(['tag1'])
   })
 })


### PR DESCRIPTION
Also adds support for space-delimited tags; these strings are
equivalent:

- "one, two, three"
- "one two three"
- "one, two three"

This is a change I recently made to honeybadger-ruby (https://github.com/honeybadger-io/honeybadger-ruby/pull/422) and I realized we did the same thing here. I don't know why we were being so strict with the tag sanitizer, but I think this is better.

eslint also made some formatting changes, sorry about the noise.