### PR TITLE
Properly handle Error-prototype objects

### DIFF
--- a/src/core/util.ts
+++ b/src/core/util.ts
@@ -229,7 +229,7 @@ export function makeNotice(thing: Noticeable): Partial<Notice> {
 
   if (!thing) {
     notice = {}
-  } else if (Object.prototype.toString.call(thing) === '[object Error]') {
+  } else if (thing instanceof Error || Object.prototype.toString.call(thing) === '[object Error]') {
     const e = thing as Error
     notice = merge(thing as Record<string, unknown>, {name: e.name, message: e.message, stack: e.stack})
   } else if (typeof thing === 'object') {

--- a/test/unit/core/client.test.ts
+++ b/test/unit/core/client.test.ts
@@ -295,6 +295,22 @@ describe('client', function () {
       expect(payload.request.context).toEqual({ foo: 'foo', bar: 'bar' })
     })
 
+    it('properly handles Error-prototype objects', function () {
+      client.configure({
+        apiKey: 'testing'
+      })
+
+      const error = {};
+      Object.setPrototypeOf(error, new TypeError("Some error message"))
+
+      expect(client.notify(error)).toEqual(true)
+      const payload = client.getPayload(error)
+      expect(payload.error.class).toEqual('TypeError')
+      expect(payload.error.message).toEqual('Some error message')
+      // @ts-ignore
+      expect(payload.error.backtrace.length).toBeGreaterThan(0)
+    })
+
     it('generates a backtrace when there isn\'t one', function () {
       client.configure({
         apiKey: 'testing'


### PR DESCRIPTION
## Status
READY

## Description
While working with Hapi, I noticed errors were simply being reported as `Error` with an empty message, even though they were actually instances of TypeError:

![image](https://user-images.githubusercontent.com/14361073/157116279-84b7ad75-3b69-4ceb-a979-e1c1a2cbadad.png)

Turned out the `Object.prototype.toString.call()` check was returning `[object Object]` because Hapi instantiates errors in some weird ways, so we were treating it as a regular object, not an error. Adding a check for instanceof fixes it.

