### PR TITLE
Include reported error link in logs

### DIFF
--- a/src/browser.ts
+++ b/src/browser.ts
@@ -115,7 +115,7 @@ class Honeybadger extends Client {
         runAfterNotifyHandlers(merge(notice, {
           id: uuid
         }), this.__afterNotifyHandlers)
-        this.logger.debug(`Success ⚡ https://app.honeybadger.io/notice/${uuid}`)
+        this.logger.debug(`Error report sent ⚡ https://app.honeybadger.io/notice/${uuid}`)
       }
     } catch (err) {
       runAfterNotifyHandlers(notice, this.__afterNotifyHandlers, err)

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -111,10 +111,11 @@ class Honeybadger extends Client {
           this.logger.debug(`Unable to send error report: ${x.status}: ${x.statusText}`, x, notice)
           return
         }
+        const uuid = JSON.parse(x.response).id
         runAfterNotifyHandlers(merge(notice, {
-          id: JSON.parse(x.response).id
+          id: uuid
         }), this.__afterNotifyHandlers)
-        this.logger.debug('Error report sent', notice)
+        this.logger.debug(`Success ⚡ https://app.honeybadger.io/notice/${uuid}`)
       }
     } catch (err) {
       runAfterNotifyHandlers(notice, this.__afterNotifyHandlers, err)

--- a/src/core/client.ts
+++ b/src/core/client.ts
@@ -143,6 +143,8 @@ export default class Client {
   }
 
   notify(noticeable: Noticeable, name: string | Partial<Notice> = undefined, extra: Partial<Notice> = undefined): boolean {
+    this.logger.info("Reporting error")
+
     let preConditionError: Error = null
     const notice = this.makeNotice(noticeable, name, extra)
     if (!notice) {

--- a/src/core/client.ts
+++ b/src/core/client.ts
@@ -143,8 +143,6 @@ export default class Client {
   }
 
   notify(noticeable: Noticeable, name: string | Partial<Notice> = undefined, extra: Partial<Notice> = undefined): boolean {
-    this.logger.info("Reporting error")
-
     let preConditionError: Error = null
     const notice = this.makeNotice(noticeable, name, extra)
     if (!notice) {

--- a/src/server.ts
+++ b/src/server.ts
@@ -90,7 +90,7 @@ class Honeybadger extends Client {
           runAfterNotifyHandlers(merge(notice, {
             id: uuid
           }), this.__afterNotifyHandlers)
-          this.logger.info('Error report sent.', `id=${uuid}`)
+          this.logger.info(`Success ⚡ https://app.honeybadger.io/notice/${uuid}`)
         })
       })
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -90,7 +90,7 @@ class Honeybadger extends Client {
           runAfterNotifyHandlers(merge(notice, {
             id: uuid
           }), this.__afterNotifyHandlers)
-          this.logger.info(`Success ⚡ https://app.honeybadger.io/notice/${uuid}`)
+          this.logger.info(`Error report sent ⚡ https://app.honeybadger.io/notice/${uuid}`)
         })
       })
 


### PR DESCRIPTION
## Status
READY

## Description
Tiny logging improvement: print the full link to the reported error in the logs, like the Ruby library does.