### PR TITLE
#722 Respect toJSON in `breadrumb.metadata`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Node.js: Added the `hb.run(fn)` method, which runs a `fn` with a Honeybadger context, properly tracking the context across async chains and isolating it from other function invocations. The `Honeybadger.requestMiddleware` for Express is now a wrapper around this. (#711)
 
 ### Fixed
+- Respect object.toJSON() in breadcrumb.metadata  (#722)
 - Allow special characters in tags. Also support space-delimited tags:
   "one two three" and "one, two, three" are equivalent
 - Include reported error link in logs (#713)

--- a/src/core/client.ts
+++ b/src/core/client.ts
@@ -6,7 +6,6 @@ import {
   makeBacktrace,
   runBeforeNotifyHandlers,
   shallowClone,
-  getJson,
   logger,
   generateStackTrace,
   filter,
@@ -312,7 +311,7 @@ export default class Client {
 
     opts = opts || {}
 
-    const metadata = getJson(opts.metadata)
+    const metadata = shallowClone(opts.metadata)
     const category = opts.category || 'custom'
     const timestamp = new Date().toISOString()
 

--- a/src/core/client.ts
+++ b/src/core/client.ts
@@ -5,7 +5,8 @@ import {
   makeNotice,
   makeBacktrace,
   runBeforeNotifyHandlers,
-  newObject,
+  shallowClone,
+  getJson,
   logger,
   generateStackTrace,
   filter,
@@ -196,7 +197,7 @@ export default class Client {
 
     // we need to have the source file data before the beforeNotifyHandlers,
     // in case they modify them
-    const sourceCodeData = notice && notice.backtrace ? notice.backtrace.map(trace => newObject(trace) as BacktraceFrame) : null
+    const sourceCodeData = notice && notice.backtrace ? notice.backtrace.map(trace => shallowClone(trace) as BacktraceFrame) : null
 
     getSourceForBacktrace(sourceCodeData, this.__getSourceFileHandler, sourcePerTrace => {
       sourcePerTrace.forEach((source, index) => {
@@ -311,7 +312,7 @@ export default class Client {
 
     opts = opts || {}
 
-    const metadata = newObject(opts.metadata)
+    const metadata = getJson(opts.metadata)
     const category = opts.category || 'custom'
     const timestamp = new Date().toISOString()
 

--- a/src/core/client.ts
+++ b/src/core/client.ts
@@ -312,7 +312,7 @@ export default class Client {
 
     opts = opts || {}
 
-    const metadata = getJson(opts.metadata)
+    const metadata = shallowClone(opts.metadata)
     const category = opts.category || 'custom'
     const timestamp = new Date().toISOString()
 

--- a/src/core/client.ts
+++ b/src/core/client.ts
@@ -312,7 +312,7 @@ export default class Client {
 
     opts = opts || {}
 
-    const metadata = shallowClone(opts.metadata)
+    const metadata = getJson(opts.metadata)
     const category = opts.category || 'custom'
     const timestamp = new Date().toISOString()
 

--- a/src/core/util.ts
+++ b/src/core/util.ts
@@ -134,8 +134,16 @@ export function sanitize(obj, maxDepth = 8) {
   }
 
   function canSerialize(obj) {
-    // Functions are TMI and Symbols can't convert to strings.
-    if (/function|symbol/.test(typeof (obj))) {
+    const typeOfObj = typeof obj
+
+    // Functions are TMI
+    if (/function/.test(typeOfObj)) {
+      // Let special toJSON method pass as it's used by JSON.stringify (#722)
+      return obj.name === 'toJSON'
+    }
+
+    // Symbols can't convert to strings.
+    if (/symbol/.test(typeOfObj)) {
       return false
     }
 
@@ -189,11 +197,6 @@ export function sanitize(obj, maxDepth = 8) {
 
   function safeSerialize(obj: unknown, depth = 0) {
     try {
-      if (Object.prototype.hasOwnProperty.call(obj, 'toJSON')) {
-        // @ts-ignore
-        return obj.toJSON()
-      }
-
       return serialize(obj, depth)
     } catch(e) {
       return `[ERROR] ${e}`

--- a/src/core/util.ts
+++ b/src/core/util.ts
@@ -121,16 +121,18 @@ export function getJson(obj: unknown & { toJSON?: () => Record<string, unknown> 
     return {}
   }
 
-  if (typeof obj.toJSON === 'function') {
-    return obj.toJSON()
-  }
+  return JSON.parse(JSON.stringify(obj))
 
-  const result = {}
-  for (const k in obj) {
-    result[k] = typeof obj[k] === 'object' ? getJson(obj[k]) : obj[k]
-  }
-
-  return result
+  // if (typeof obj.toJSON === 'function') {
+  //   return obj.toJSON()
+  // }
+  //
+  // const result = {}
+  // for (const k in obj) {
+  //   result[k] = typeof obj[k] === 'object' ? getJson(obj[k]) : obj[k]
+  // }
+  //
+  // return result
 }
 
 export function sanitize(obj, maxDepth = 8) {

--- a/src/core/util.ts
+++ b/src/core/util.ts
@@ -122,17 +122,6 @@ export function getJson(obj: unknown & { toJSON?: () => Record<string, unknown> 
   }
 
   return JSON.parse(JSON.stringify(obj))
-
-  // if (typeof obj.toJSON === 'function') {
-  //   return obj.toJSON()
-  // }
-  //
-  // const result = {}
-  // for (const k in obj) {
-  //   result[k] = typeof obj[k] === 'object' ? getJson(obj[k]) : obj[k]
-  // }
-  //
-  // return result
 }
 
 export function sanitize(obj, maxDepth = 8) {

--- a/src/core/util.ts
+++ b/src/core/util.ts
@@ -116,14 +116,6 @@ export function shallowClone<T>(obj: T): T | Record<string, unknown> {
   return result
 }
 
-export function getJson(obj: unknown & { toJSON?: () => Record<string, unknown> }): Record<string, unknown> {
-  if (typeof (obj) !== 'object' || obj === null) {
-    return {}
-  }
-
-  return JSON.parse(JSON.stringify(obj))
-}
-
 export function sanitize(obj, maxDepth = 8) {
   const seenObjects = []
 
@@ -197,6 +189,11 @@ export function sanitize(obj, maxDepth = 8) {
 
   function safeSerialize(obj: unknown, depth = 0) {
     try {
+      if (Object.prototype.hasOwnProperty.call(obj, 'toJSON')) {
+        // @ts-ignore
+        return obj.toJSON()
+      }
+
       return serialize(obj, depth)
     } catch(e) {
       return `[ERROR] ${e}`

--- a/test/unit/core/client.test.ts
+++ b/test/unit/core/client.test.ts
@@ -797,6 +797,54 @@ describe('client', function () {
       expect(payload.breadcrumbs.enabled).toEqual(false)
       expect(payload.breadcrumbs.trail).toEqual([])
     })
+
+    it('respects toJSON() of metadata object', function () {
+      const metadata = {
+        ignored: true,
+        toJSON: () => {
+          return {
+            aProperty: 1,
+            bProperty: true,
+          }
+        }
+      }
+
+      client.addBreadcrumb('message', {
+        metadata
+      })
+
+      expect(client.getBreadcrumbs().length).toEqual(1)
+      expect(client.getBreadcrumbs()[0].metadata).toEqual({
+        aProperty: 1,
+        bProperty: true,
+      })
+    })
+
+    it('respects nested toJSON() of metadata object', function () {
+      const metadata = {
+        ignored: false,
+        aProperty: {
+          thisShouldBeIgnored: true,
+          toJSON: () => {
+            return {
+              bProperty: true
+            }
+          }
+        },
+      }
+
+      client.addBreadcrumb('message', {
+        metadata
+      })
+
+      expect(client.getBreadcrumbs().length).toEqual(1)
+      expect(client.getBreadcrumbs()[0].metadata).toEqual({
+        ignored: false,
+        aProperty: {
+          bProperty: true
+        }
+      })
+    })
   })
 
   it('has default filters', function () {

--- a/test/unit/core/client.test.ts
+++ b/test/unit/core/client.test.ts
@@ -798,59 +798,6 @@ describe('client', function () {
       expect(payload.breadcrumbs.enabled).toEqual(false)
       expect(payload.breadcrumbs.trail).toEqual([])
     })
-
-    it('respects toJSON() of metadata object', function () {
-      const metadata = {
-        ignored: true,
-        toJSON: () => {
-          return {
-            aProperty: 1,
-            bProperty: true,
-          }
-        }
-      }
-
-      client.addBreadcrumb('message', {
-        metadata
-      })
-      const breadcrumbs = client.getBreadcrumbs();
-      const sanitized = sanitize(breadcrumbs);
-
-      expect(sanitized.length).toEqual(1)
-      expect(sanitized[0].metadata).toEqual({
-        aProperty: 1,
-        bProperty: true,
-      })
-    })
-
-    it('respects nested toJSON() of metadata object', function () {
-      const metadata = {
-        ignored: false,
-        aProperty: {
-          thisShouldBeIgnored: true,
-          toJSON: () => {
-            return {
-              bProperty: true
-            }
-          }
-        },
-      }
-
-      client.addBreadcrumb('message', {
-        metadata
-      })
-
-      const breadcrumbs = client.getBreadcrumbs();
-      const sanitized = sanitize(breadcrumbs);
-
-      expect(sanitized.length).toEqual(1)
-      expect(sanitized[0].metadata).toEqual({
-        ignored: false,
-        aProperty: {
-          bProperty: true
-        }
-      })
-    })
   })
 
   it('has default filters', function () {

--- a/test/unit/core/client.test.ts
+++ b/test/unit/core/client.test.ts
@@ -1,6 +1,7 @@
 // @ts-ignore
 import { nullLogger, TestClient } from '../helpers'
 import { Notice } from '../../../src/core/types'
+import { sanitize } from "../../../src/core/util";
 
 class MyError extends Error {
   context = null
@@ -812,9 +813,11 @@ describe('client', function () {
       client.addBreadcrumb('message', {
         metadata
       })
+      const breadcrumbs = client.getBreadcrumbs();
+      const sanitized = sanitize(breadcrumbs);
 
-      expect(client.getBreadcrumbs().length).toEqual(1)
-      expect(client.getBreadcrumbs()[0].metadata).toEqual({
+      expect(sanitized.length).toEqual(1)
+      expect(sanitized[0].metadata).toEqual({
         aProperty: 1,
         bProperty: true,
       })
@@ -837,8 +840,11 @@ describe('client', function () {
         metadata
       })
 
-      expect(client.getBreadcrumbs().length).toEqual(1)
-      expect(client.getBreadcrumbs()[0].metadata).toEqual({
+      const breadcrumbs = client.getBreadcrumbs();
+      const sanitized = sanitize(breadcrumbs);
+
+      expect(sanitized.length).toEqual(1)
+      expect(sanitized[0].metadata).toEqual({
         ignored: false,
         aProperty: {
           bProperty: true

--- a/test/unit/core/util.test.ts
+++ b/test/unit/core/util.test.ts
@@ -229,6 +229,32 @@ describe('utils', function () {
       )
     })
 
+    it('supports toJSON() of objects', function () {
+      expect(
+          JSON.parse(JSON.stringify(sanitize(
+              {
+                ignored: false,
+                aProperty: {
+                  thisShouldBeIgnored: true,
+                  toJSON: () => {
+                    return {
+                      bProperty: true
+                    }
+                  }
+                },
+              },
+              6
+          )))
+      ).toEqual(
+          {
+            ignored: false,
+            aProperty: {
+              bProperty: true
+            }
+          }
+      )
+    })
+
     if (typeof Object.create === 'function') {
       it('handles objects without prototypes as values', function () {
         const obj = Object.create(null)

--- a/test/unit/core/util.test.ts
+++ b/test/unit/core/util.test.ts
@@ -1,6 +1,6 @@
 import {fake} from 'sinon'
 import Client from '../../../src/core/client'
-import { merge, mergeNotice, objectIsEmpty, runBeforeNotifyHandlers, runAfterNotifyHandlers, newObject, sanitize, logger, filter, filterUrl } from '../../../src/core/util'
+import { merge, mergeNotice, objectIsEmpty, runBeforeNotifyHandlers, runAfterNotifyHandlers, shallowClone, sanitize, logger, filter, filterUrl } from '../../../src/core/util'
 // @ts-ignore
 import { nullLogger } from '../helpers'
 
@@ -152,8 +152,8 @@ describe('utils', function () {
   describe('newObject', function () {
     it('returns a new object', function () {
       const obj = { expected: 'value' }
-      expect(newObject(obj)).toEqual(obj)
-      expect(newObject(obj)).not.toBe(obj)
+      expect(shallowClone(obj)).toEqual(obj)
+      expect(shallowClone(obj)).not.toBe(obj)
     })
   })
 


### PR DESCRIPTION
## Status
**READY**

## Description
Fixes #722.
Respects `toJSON()` in `util.sanitize()`.

## Todos
- [x] Tests
- [x] getJson() method that respects toJSON of objects  
- [x] Changelog Entry (unreleased)
