### PR TITLE
#736 Fix typescript error with private variable

### DIFF
--- a/src/core/client.ts
+++ b/src/core/client.ts
@@ -41,7 +41,7 @@ const TAG_SEPARATOR = /,|\s+/
 const NOT_BLANK = /\S/
 
 export default class Client {
-  private __pluginsExecuted = false
+  protected __pluginsExecuted = false
 
   protected __store: HoneybadgerStore<{ context: Record<string, unknown>; breadcrumbs: BreadcrumbRecord[] }> = null;
   protected __beforeNotifyHandlers: BeforeNotifyHandler[] = []

--- a/test-d/honeybadger.test-d.ts
+++ b/test-d/honeybadger.test-d.ts
@@ -1,0 +1,5 @@
+import Honeybadger from '../'
+
+Honeybadger.configure({
+    apiKey: 'project api key',
+})


### PR DESCRIPTION
## Status
**READY**

## Description
Fixes #736.

We are generating two sets of `.d.ts` files. It appears that when using the intersection type (`typeof Server & typeof Browser`) to export a Honeybadger typed singleton that supports both contexts, Typescript is complaining about the private variables because they come from different classes. These classes are the same but they come from different folders (`dist/browser/core/client.d.ts` and `dist/server/core/client.d.ts`). I think Typescript can't see that the variable is the same for both types, and assumes each type has their own unique private variable.

The easy solution without going too deep was to make this variable as `protected`, which is OK. The extending classes could use that variable (they don't use it now).

I feel that there may be a better way to generate types (and ultimately we wouldn't have to deal with issues like the above), but the fact that we have one variable to export with different types based on the context (nodejs vs browser) complicates things.

- [x] Change private to protected
- [x] Add test file for `Honeybadger.d.ts`