### PR TITLE
Fix shipjs config for conventional commits

### DIFF
--- a/ship.config.js
+++ b/ship.config.js
@@ -23,8 +23,6 @@ module.exports = {
 
     return true;
   },
-  formatCommitMessage: ({ version, _releaseType, _baseBranch }) => `ci(release): v${version}`,
-  formatPullRequestTitle: ({ version, _releaseType }) => `Release v${version}`,
   getNextVersion: ({ _revisionRange, _commitTitles, _commitBodies, currentVersion, dir }) => {
     const changelog = new Changelog(`${dir}/CHANGELOG.md`)
     return changelog.nextVersion(currentVersion)


### PR DESCRIPTION
Release was skipped because commit message did not match the expected format:
```
const correctCommitMessage = formatPullRequestTitle({
      version: currentVersion,
    });
    if (!commitMessage.trim().startsWith(correctCommitMessage)) {
      return (
        'The commit message should have started with the following:' +
        '\n' +
        `${correctCommitMessage}`
      );
    }
```

I removed the custom commit message and pull request title from `ship.config.js`. The default ones use the conventional commits specification:
```
formatCommitMessage: ({ version, releaseType, baseBranch }) =>
    `chore: release v${version}`,
formatPullRequestTitle: ({ version, releaseType }) =>
    `chore: release v${version}`,
```
I think this is the final fix.