### PR TITLE
#725 Honeybadger.checkIn()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `notifyAsync`: Async version of `notify` that returns a promise (#327)
 - AsyncLocalStorage for AWS Lambda Handler (#688)
 - Node.js: Added the `hb.withRequest(req, fn)` method for webserver apps, which runs a `fn`, isolating its context to the request `req` and tracking it across async chains. The `Honeybadger.requestMiddleware` for Express is now a wrapper around this. (#711, #717)
+- `Honeybadger.checkIn()` (#725)
 
 ### Fixed
 - Respect object.toJSON() in breadcrumb.metadata  (#722)

--- a/examples/browserify/index.html
+++ b/examples/browserify/index.html
@@ -9,6 +9,7 @@
 
 <body>
   <button id="btn">Throw an error.</button>
+  <button id="btn-check-in">CheckIn</button>
   <!-- See README.md for instructions -->
 	<script type="text/javascript" src="bundle.js" ></script>
 </body>

--- a/examples/browserify/main.js
+++ b/examples/browserify/main.js
@@ -17,5 +17,10 @@ hb.configure({
       log("Failing in event listener...");
       throw new Error("This is a test error raised from an addEventListener callback.");
     });
+
+    document.getElementById('btn-check-in').addEventListener("click", function(){
+      const checkInId = prompt("Enter check-in id:")
+      hb.checkIn(checkInId)
+    });
   };
 })();

--- a/examples/express/index.js
+++ b/examples/express/index.js
@@ -2,7 +2,7 @@ const express = require('express')
 const app = express()
 const port = 3000
 
-const Honeybadger = require('@honeybadger-io/js');
+const Honeybadger = require('@honeybadger-io/js')
 Honeybadger.configure({
   apiKey: process.env.HONEYBADGER_API_KEY,
   reportData: true
@@ -27,6 +27,13 @@ app.get('/fail', (req, res) => {
   })
 
   throw new Error('Badgers!')
+})
+
+app.get('/checkin/:id', (req, res) => {
+  Honeybadger.checkIn(req.params.id)
+    .then(() => {
+      res.send('Done!')
+    })
 })
 
 app.use(Honeybadger.errorHandler)

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -1,12 +1,13 @@
 import Client from './core/client'
-import { Config, Notice, BeforeNotifyHandler } from './core/types'
-import { merge, sanitize, filter, runAfterNotifyHandlers, objectIsExtensible, endpoint } from './core/util'
+import { Config, Notice, BeforeNotifyHandler, TransportPayload } from './core/types'
+import { merge, filter, objectIsExtensible } from './core/util'
 import { encodeCookie, decodeCookie, preferCatch } from './browser/util'
 import { onError, ignoreNextOnError } from './browser/integrations/onerror'
 import onUnhandledRejection from './browser/integrations/onunhandledrejection'
 import breadcrumbs from './browser/integrations/breadcrumbs'
 import timers from './browser/integrations/timers'
 import eventListeners from './browser/integrations/event_listeners'
+import { BrowserTransport } from "./browser/transport";
 
 interface BrowserConfig extends Config {
   async: boolean
@@ -36,6 +37,8 @@ class Honeybadger extends Client {
 
       if (!notice.url) { notice.url = document.URL }
 
+      this.__incrementErrorsCount()
+
       return true
     }
   ]
@@ -46,7 +49,7 @@ class Honeybadger extends Client {
       maxErrors: null,
       projectRoot: window.location.protocol + '//' + window.location.host,
       ...opts
-    })
+    }, new BrowserTransport())
   }
 
   configure(opts: Partial<BrowserConfig> = {}) {
@@ -57,12 +60,12 @@ class Honeybadger extends Client {
     return (this.__errorsSent = 0)
   }
 
-  factory(opts?: Partial<BrowserConfig>): Honeybadger {
+  public factory(opts?: Partial<BrowserConfig>): Honeybadger {
     return new Honeybadger(opts)
   }
 
   /** @internal */
-  protected __buildPayload(notice:Notice): Record<string, Record<string, unknown>> {
+  protected __buildPayload(notice:Notice): TransportPayload {
     const cgiData = {
       HTTP_USER_AGENT: undefined,
       HTTP_REFERER: undefined,
@@ -88,39 +91,6 @@ class Honeybadger extends Client {
     payload.request.cgi_data = merge(cgiData, payload.request.cgi_data as Record<string, unknown>)
 
     return payload
-  }
-
-  /** @internal */
-  protected __send(notice): void {
-    this.__incrementErrorsCount()
-
-    const payload = this.__buildPayload(notice)
-
-    try {
-      const x = new XMLHttpRequest()
-      x.open('POST', endpoint(this.config, '/v1/notices/js'), this.config.async)
-
-      x.setRequestHeader('X-API-Key', this.config.apiKey)
-      x.setRequestHeader('Content-Type', 'application/json')
-      x.setRequestHeader('Accept', 'text/json, application/json')
-
-      x.send(JSON.stringify(sanitize(payload, this.config.maxObjectDepth)))
-      x.onload = () => {
-        if (x.status !== 201) {
-          runAfterNotifyHandlers(notice, this.__afterNotifyHandlers, new Error(`Bad HTTP response: ${x.status}`))
-          this.logger.debug(`Unable to send error report: ${x.status}: ${x.statusText}`, x, notice)
-          return
-        }
-        const uuid = JSON.parse(x.response).id
-        runAfterNotifyHandlers(merge(notice, {
-          id: uuid
-        }), this.__afterNotifyHandlers)
-        this.logger.debug(`Error report sent ⚡ https://app.honeybadger.io/notice/${uuid}`)
-      }
-    } catch (err) {
-      runAfterNotifyHandlers(notice, this.__afterNotifyHandlers, err)
-      this.logger.error('Unable to send error report: error while initializing request', err, notice)
-    }
   }
 
   /**

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -1,5 +1,5 @@
 import Client from './core/client'
-import { Config, Notice, BeforeNotifyHandler, TransportPayload } from './core/types'
+import { Notice, BeforeNotifyHandler, NoticeTransportPayload, BrowserConfig } from './core/types'
 import { merge, filter, objectIsExtensible } from './core/util'
 import { encodeCookie, decodeCookie, preferCatch } from './browser/util'
 import { onError, ignoreNextOnError } from './browser/integrations/onerror'
@@ -8,11 +8,6 @@ import breadcrumbs from './browser/integrations/breadcrumbs'
 import timers from './browser/integrations/timers'
 import eventListeners from './browser/integrations/event_listeners'
 import { BrowserTransport } from "./browser/transport";
-
-interface BrowserConfig extends Config {
-  async: boolean
-  maxErrors: number
-}
 
 interface WrappedFunc {
   (): (...args: unknown[]) => unknown
@@ -65,7 +60,7 @@ class Honeybadger extends Client {
   }
 
   /** @internal */
-  protected __buildPayload(notice:Notice): TransportPayload {
+  protected __buildPayload(notice:Notice): NoticeTransportPayload {
     const cgiData = {
       HTTP_USER_AGENT: undefined,
       HTTP_REFERER: undefined,

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -59,6 +59,10 @@ class Honeybadger extends Client {
     return new Honeybadger(opts)
   }
 
+  public checkIn(_id: string): Promise<void> {
+    throw new Error('Honeybadger.checkIn() is not supported on the browser')
+  }
+
   /** @internal */
   protected __buildPayload(notice:Notice): NoticeTransportPayload {
     const cgiData = {

--- a/src/browser/transport.ts
+++ b/src/browser/transport.ts
@@ -1,18 +1,22 @@
-import { Transport, TransportOptions, TransportPayload } from "../core/types";
-import { endpoint, sanitize } from "../core/util";
+import { Transport, TransportOptions, NoticeTransportPayload } from "../core/types";
+import { sanitize } from "../core/util";
 
 export class BrowserTransport implements Transport {
-    send(payload: TransportPayload, options: TransportOptions): Promise<{ statusCode: number; body: string; }> {
+    send(options: TransportOptions, payload?: NoticeTransportPayload | undefined): Promise<{ statusCode: number; body: string; }> {
         return new Promise((resolve, reject) => {
             try {
                 const x = new XMLHttpRequest()
-                x.open('POST', endpoint(options.endpoint, '/v1/notices/js'), options.async)
+                x.open(options.method, options.endpoint, options.async)
 
-                x.setRequestHeader('X-API-Key', options.apiKey)
-                x.setRequestHeader('Content-Type', 'application/json')
-                x.setRequestHeader('Accept', 'text/json, application/json')
+                if (Object.keys(options.headers).length) {
+                    for (const i in options.headers) {
+                        if (typeof options.headers !== 'undefined') {
+                            x.setRequestHeader(i, String(options.headers[i]))
+                        }
+                    }
+                }
 
-                x.send(JSON.stringify(sanitize(payload, options.maxObjectDepth)))
+                x.send(payload ? JSON.stringify(sanitize(payload, options.maxObjectDepth)) : undefined)
                 x.onload = () => resolve({ statusCode: x.status, body: x.response })
             } catch (err) {
                 reject(err)

--- a/src/browser/transport.ts
+++ b/src/browser/transport.ts
@@ -1,0 +1,22 @@
+import { Transport, TransportOptions, TransportPayload } from "../core/types";
+import { endpoint, sanitize } from "../core/util";
+
+export class BrowserTransport implements Transport {
+    send(payload: TransportPayload, options: TransportOptions): Promise<{ statusCode: number; body: string; }> {
+        return new Promise((resolve, reject) => {
+            try {
+                const x = new XMLHttpRequest()
+                x.open('POST', endpoint(options.endpoint, '/v1/notices/js'), options.async)
+
+                x.setRequestHeader('X-API-Key', options.apiKey)
+                x.setRequestHeader('Content-Type', 'application/json')
+                x.setRequestHeader('Accept', 'text/json, application/json')
+
+                x.send(JSON.stringify(sanitize(payload, options.maxObjectDepth)))
+                x.onload = () => resolve({ statusCode: x.status, body: x.response })
+            } catch (err) {
+                reject(err)
+            }
+        })
+    }
+}

--- a/src/browser/transport.ts
+++ b/src/browser/transport.ts
@@ -8,7 +8,7 @@ export class BrowserTransport implements Transport {
                 const x = new XMLHttpRequest()
                 x.open(options.method, options.endpoint, options.async)
 
-                if (Object.keys(options.headers).length) {
+                if (Object.keys(options.headers || []).length) {
                     for (const i in options.headers) {
                         if (typeof options.headers !== 'undefined') {
                             x.setRequestHeader(i, String(options.headers[i]))

--- a/src/browser/transport.ts
+++ b/src/browser/transport.ts
@@ -10,7 +10,7 @@ export class BrowserTransport implements Transport {
 
                 if (Object.keys(options.headers || []).length) {
                     for (const i in options.headers) {
-                        if (typeof options.headers !== 'undefined') {
+                        if (typeof options.headers[i] !== 'undefined') {
                             x.setRequestHeader(i, String(options.headers[i]))
                         }
                     }

--- a/src/core/client.ts
+++ b/src/core/client.ts
@@ -284,11 +284,7 @@ export default abstract class Client {
     })
   }
 
-  checkIn(id: string): void {
-    this.checkInAsync(id).then()
-  }
-
-  checkInAsync(id: string): Promise<void> {
+  checkIn(id: string): Promise<void> {
     return this.__transport
         .send({
           method: 'GET',

--- a/src/core/client.ts
+++ b/src/core/client.ts
@@ -87,7 +87,9 @@ export default abstract class Client {
     this.logger = logger(this)
   }
 
-  protected abstract factory(opts: Partial<Config>): void;
+  protected abstract factory(opts: Partial<Config>): void
+
+  protected abstract checkIn(id: string): Promise<void>
 
   getVersion(): string {
     return notifier.version
@@ -217,6 +219,7 @@ export default abstract class Client {
             endpoint: endpoint(this.config.endpoint, '/v1/notices/js'),
             maxObjectDepth: this.config.maxObjectDepth,
             logger: this.logger,
+            async: isBrowserConfig(this.config) ? this.config.async : undefined,
           }, payload)
           .then(res => {
             if (res.statusCode !== 201) {
@@ -282,23 +285,6 @@ export default abstract class Client {
       applyAfterNotify(objectToOverride)
       this.notify(noticeable, name, extra)
     })
-  }
-
-  checkIn(id: string): Promise<void> {
-    return this.__transport
-        .send({
-          method: 'GET',
-          endpoint: endpoint(this.config.endpoint, `v1/check_in/${id}`),
-          logger: this.logger,
-          async: isBrowserConfig(this.config) ? this.config.async : false,
-        })
-        .then(() => {
-          this.logger.info(`CheckIn sent`)
-          return Promise.resolve()
-        })
-        .catch(err => {
-          this.logger.error('CheckIn failed: an unknown error occurred.', `message=${err.message}`)
-        })
   }
 
   protected makeNotice(noticeable: Noticeable, name: string | Partial<Notice> = undefined, extra: Partial<Notice> = undefined): Notice | null {

--- a/src/core/client.ts
+++ b/src/core/client.ts
@@ -48,7 +48,7 @@ export default abstract class Client {
   protected __afterNotifyHandlers: AfterNotifyHandler[] = []
   protected __getSourceFileHandler: (path: string, cb: (fileContent: string) => void) => void
 
-  protected readonly transport: Transport;
+  protected readonly __transport: Transport;
 
   config: Config
   logger: Logger
@@ -83,8 +83,8 @@ export default abstract class Client {
     // First, we go with the global (shared) store.
     // Webserver middleware can then switch to the AsyncStore for async context tracking.
     this.__store = new GlobalStore({ context: {}, breadcrumbs: [] })
+    this.__transport = transport
     this.logger = logger(this)
-    this.transport = transport
   }
 
   protected abstract factory(opts: Partial<Config>): void;
@@ -206,7 +206,7 @@ export default abstract class Client {
       })
 
       const payload = this.__buildPayload(notice)
-      this.transport
+      this.__transport
           .send({
             headers: {
               'X-API-Key': this.config.apiKey,
@@ -289,7 +289,7 @@ export default abstract class Client {
   }
 
   checkInAsync(id: string): Promise<void> {
-    return this.transport
+    return this.__transport
         .send({
           method: 'GET',
           endpoint: endpoint(this.config.endpoint, `v1/check_in/${id}`),

--- a/src/core/client.ts
+++ b/src/core/client.ts
@@ -216,7 +216,7 @@ export default abstract class Client {
             method: 'POST',
             endpoint: endpoint(this.config.endpoint, '/v1/notices/js'),
             maxObjectDepth: this.config.maxObjectDepth,
-            logger: this.config.logger,
+            logger: this.logger,
           }, payload)
           .then(res => {
             if (res.statusCode !== 201) {
@@ -284,12 +284,12 @@ export default abstract class Client {
     })
   }
 
-  checkIn(id: number): Promise<void> {
+  checkIn(id: string): Promise<void> {
     return this.transport
         .send({
           method: 'GET',
           endpoint: endpoint(this.config.endpoint, `v1/check_in/${id}`),
-          logger: this.config.logger,
+          logger: this.logger,
           async: isBrowserConfig(this.config) ? this.config.async : false,
         })
         .then(() => Promise.resolve())

--- a/src/core/client.ts
+++ b/src/core/client.ts
@@ -284,7 +284,11 @@ export default abstract class Client {
     })
   }
 
-  checkIn(id: string): Promise<void> {
+  checkIn(id: string): void {
+    this.checkInAsync(id).then()
+  }
+
+  checkInAsync(id: string): Promise<void> {
     return this.transport
         .send({
           method: 'GET',
@@ -292,7 +296,13 @@ export default abstract class Client {
           logger: this.logger,
           async: isBrowserConfig(this.config) ? this.config.async : false,
         })
-        .then(() => Promise.resolve())
+        .then(() => {
+          this.logger.info(`CheckIn sent`)
+          return Promise.resolve()
+        })
+        .catch(err => {
+          this.logger.error('CheckIn failed: an unknown error occurred.', `message=${err.message}`)
+        })
   }
 
   protected makeNotice(noticeable: Noticeable, name: string | Partial<Notice> = undefined, extra: Partial<Notice> = undefined): Notice | null {

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -72,6 +72,11 @@ export interface Notice {
   [key: string]: unknown
 }
 
+export interface BrowserConfig extends Config {
+  async: boolean
+  maxErrors: number
+}
+
 export type Noticeable = string | Error | Partial<Notice>
 
 export interface BacktraceFrame {
@@ -112,14 +117,15 @@ export type ProcessStats = {
 }
 
 export type TransportOptions = {
-  apiKey: string,
+  method: 'GET' | 'POST',
+  headers?: Record<string, number | string | string[] | undefined>,
   endpoint: string,
-  maxObjectDepth: number,
+  maxObjectDepth?: number,
   logger: Logger
   async?: boolean // don't like this here because it's only for browser
 }
 
-export type TransportPayload = {
+export type NoticeTransportPayload = {
   notifier: {
     name: string,
     url: string,
@@ -147,7 +153,7 @@ export type TransportPayload = {
 }
 
 export interface Transport {
-  send(payload: TransportPayload, options: TransportOptions): Promise<{ statusCode: number; body: string; }>
+  send(options: TransportOptions, payload?: NoticeTransportPayload | undefined): Promise<{ statusCode: number; body: string; }>
 }
 
 export type HoneybadgerStore<T> = Pick<AsyncLocalStorage<T>, 'getStore' | 'run'>

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -96,5 +96,59 @@ export interface CGIData {
   [x: string]: unknown
 }
 
+export type ProcessStats = {
+ load: {
+   one: number,
+   five: number,
+   fifteen: number
+ };
+ mem: {
+   total?: number,
+   free?: number,
+   buffers?: number,
+   cached?: number,
+   free_total?: number
+ }
+}
+
+export type TransportOptions = {
+  apiKey: string,
+  endpoint: string,
+  maxObjectDepth: number,
+  logger: Logger
+  async?: boolean // don't like this here because it's only for browser
+}
+
+export type TransportPayload = {
+  notifier: {
+    name: string,
+    url: string,
+    version: string
+  },
+  breadcrumbs: {
+    enabled: boolean,
+    trail: BreadcrumbRecord[]
+  },
+  error: Pick<Notice, 'message' | 'backtrace' | 'fingerprint' | 'tags'> & {
+    class: string
+  },
+  request: Pick<Notice, 'url' | 'component' | 'action' | 'context' | 'params' | 'session'> & {
+    cgi_data: unknown
+  },
+  server: Pick<Notice, 'revision'> & {
+    pid?: number | undefined,
+    project_root?: string | undefined,
+    environment_name?: string | undefined,
+    hostname: string,
+    time: string,
+    stats?: ProcessStats | undefined
+  },
+  details: Record<string, Record<string, unknown>>
+}
+
+export interface Transport {
+  send(payload: TransportPayload, options: TransportOptions): Promise<{ statusCode: number; body: string; }>
+}
+
 export type HoneybadgerStore<T> = Pick<AsyncLocalStorage<T>, 'getStore' | 'run'>
 export type DefaultStoreContents = {context: Record<string, unknown>, breadcrumbs: BreadcrumbRecord[]}

--- a/src/core/util.ts
+++ b/src/core/util.ts
@@ -1,7 +1,7 @@
 import * as stackTraceParser from 'stacktrace-parser'
 import Client from '../core/client'
 import {
-  Logger, BacktraceFrame, Notice, Noticeable, BeforeNotifyHandler, AfterNotifyHandler
+  Logger, BacktraceFrame, Notice, Noticeable, BeforeNotifyHandler, AfterNotifyHandler, Config, BrowserConfig
 } from './types'
 
 export function merge<T1 extends Record<string, unknown>, T2 extends Record<string, unknown>>(obj1: T1, obj2: T2): T1 & T2 {
@@ -430,4 +430,8 @@ function getSourceCodeSnippet(fileData: string, lineNumber: number, sourceRadius
     }
   }
   return result
+}
+
+export function isBrowserConfig(config: BrowserConfig | Config): config is BrowserConfig {
+  return (config as BrowserConfig).async !== undefined
 }

--- a/src/core/util.ts
+++ b/src/core/util.ts
@@ -1,7 +1,7 @@
 import * as stackTraceParser from 'stacktrace-parser'
 import Client from '../core/client'
 import {
-  Logger, Config, BacktraceFrame, Notice, Noticeable, BeforeNotifyHandler, AfterNotifyHandler
+  Logger, BacktraceFrame, Notice, Noticeable, BeforeNotifyHandler, AfterNotifyHandler
 } from './types'
 
 export function merge<T1 extends Record<string, unknown>, T2 extends Record<string, unknown>>(obj1: T1, obj2: T2): T1 & T2 {
@@ -277,8 +277,8 @@ export function instrument(object: Record<string, any>, name: string, replacemen
   }
 }
 
-export function endpoint(config: Config, path: string): string {
-  const endpoint = config.endpoint.trim().replace(/\/$/, '')
+export function endpoint(base: string, path: string): string {
+  const endpoint = base.trim().replace(/\/$/, '')
   path = path.trim().replace(/(^\/|\/$)/g, '')
   return `${endpoint}/${path}`;
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,15 +1,10 @@
-import https from 'https'
-import http from 'http'
-import { URL } from 'url'
 import os from 'os'
 import domain from 'domain'
 
 import Client from './core/client'
 import { Config, Notice, BeforeNotifyHandler, DefaultStoreContents } from './core/types'
-import { merge, sanitize, runAfterNotifyHandlers, endpoint } from './core/util'
 import {
   fatallyLogAndExit,
-  getStats,
   getSourceFile
 } from './server/util'
 import uncaughtException from './server/integrations/uncaught_exception'
@@ -17,6 +12,7 @@ import unhandledRejection from './server/integrations/unhandled_rejection'
 import { errorHandler, requestHandler } from './server/middleware'
 import { lambdaHandler } from './server/aws_lambda'
 import { AsyncStore } from './server/async_store'
+import { ServerTransport } from "./server/transport";
 
 const kHoneybadgerStore = Symbol.for("kHoneybadgerStore");
 class Honeybadger extends Client {
@@ -43,7 +39,7 @@ class Honeybadger extends Client {
       projectRoot: process.cwd(),
       hostname: os.hostname(),
       ...opts,
-    })
+    }, new ServerTransport())
     this.__getSourceFileHandler = getSourceFile.bind(this)
     this.errorHandler = errorHandler.bind(this)
     this.requestHandler = requestHandler.bind(this)
@@ -52,59 +48,6 @@ class Honeybadger extends Client {
 
   factory(opts?: Partial<Config>): Honeybadger {
     return new Honeybadger(opts)
-  }
-
-  /** @internal */
-  protected __send(notice): void {
-    const {protocol} = new URL(this.config.endpoint)
-    const transport = (protocol === "http:" ? http : https)
-
-    const payload = this.__buildPayload(notice)
-    payload.server.pid = process.pid
-
-    getStats((stats: Record<string, unknown>) => {
-      payload.server.stats = stats
-
-      const data = Buffer.from(JSON.stringify(sanitize(payload, this.config.maxObjectDepth)), 'utf8')
-      const options = {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          'Content-Length': data.length,
-          'X-API-Key': this.config.apiKey
-        }
-      }
-
-      const req = transport.request(endpoint(this.config, '/v1/notices/js'), options, (res) => {
-        this.logger.debug(`statusCode: ${res.statusCode}`)
-
-        let body = ''
-        res.on('data', (chunk) => {
-          body += chunk
-        })
-
-        res.on('end', () => {
-          if (res.statusCode !== 201) {
-            runAfterNotifyHandlers(notice, this.__afterNotifyHandlers, new Error(`Bad HTTP response: ${res.statusCode}`))
-            this.logger.warn(`Error report failed: unknown response from server. code=${res.statusCode}`)
-            return
-          }
-          const uuid = JSON.parse(body).id
-          runAfterNotifyHandlers(merge(notice, {
-            id: uuid
-          }), this.__afterNotifyHandlers)
-          this.logger.info(`Error report sent ⚡ https://app.honeybadger.io/notice/${uuid}`)
-        })
-      })
-
-      req.on('error', (err) => {
-        this.logger.error('Error report failed: an unknown error occurred.', `message=${err.message}`)
-        runAfterNotifyHandlers(notice, this.__afterNotifyHandlers, err)
-      })
-
-      req.write(data)
-      req.end()
-    })
   }
 
   // This method is intended for web frameworks.
@@ -117,7 +60,7 @@ class Honeybadger extends Client {
   public withRequest<R>(
       request: Record<symbol, unknown>,
       handler: (...args: never[]) => R,
-      onError?: (...args: any[]) => any
+      onError?: (...args: unknown[]) => unknown
   ): R|void {
     const storeObject = (request[kHoneybadgerStore] || this.__getStoreContentsOrDefault()) as DefaultStoreContents;
     this.__setStore(AsyncStore);

--- a/src/server.ts
+++ b/src/server.ts
@@ -13,6 +13,7 @@ import { errorHandler, requestHandler } from './server/middleware'
 import { lambdaHandler } from './server/aws_lambda'
 import { AsyncStore } from './server/async_store'
 import { ServerTransport } from "./server/transport";
+import { endpoint } from "./core/util";
 
 const kHoneybadgerStore = Symbol.for("kHoneybadgerStore");
 class Honeybadger extends Client {
@@ -48,6 +49,22 @@ class Honeybadger extends Client {
 
   factory(opts?: Partial<Config>): Honeybadger {
     return new Honeybadger(opts)
+  }
+
+  checkIn(id: string): Promise<void> {
+    return this.__transport
+        .send({
+          method: 'GET',
+          endpoint: endpoint(this.config.endpoint, `v1/check_in/${id}`),
+          logger: this.logger,
+        })
+        .then(() => {
+          this.logger.info(`CheckIn sent`)
+          return Promise.resolve()
+        })
+        .catch(err => {
+          this.logger.error('CheckIn failed: an unknown error occurred.', `message=${err.message}`)
+        })
   }
 
   // This method is intended for web frameworks.

--- a/src/server/transport.ts
+++ b/src/server/transport.ts
@@ -1,32 +1,40 @@
-import { Transport, TransportOptions, TransportPayload } from "../core/types"
+import { Transport, TransportOptions, NoticeTransportPayload } from "../core/types"
 import { URL } from "url";
 import http from "http";
 import https from "https";
 import { getStats } from "./util";
-import { endpoint, sanitize } from "../core/util";
+import { sanitize } from "../core/util";
 
 export class ServerTransport implements Transport {
-    send(payload: TransportPayload, options: TransportOptions): Promise<{ statusCode: number; body: string; }> {
+    send(options: TransportOptions, payload?: NoticeTransportPayload | undefined): Promise<{ statusCode: number; body: string; }> {
         const {protocol} = new URL(options.endpoint)
         const transport = (protocol === "http:" ? http : https)
 
-        payload.server.pid = process.pid
-
         return new Promise((resolve, reject) => {
-            getStats((stats) => {
-                payload.server.stats = stats
+            let promise: Promise<void>;
 
-                const data = Buffer.from(JSON.stringify(sanitize(payload, options.maxObjectDepth)), 'utf8')
+            // this should not be here. it should be done before reaching the transport layer
+            // it could be inside a beforeNotifyHandler, but is not possible at the moment because those handlers are synchronous
+            if (this.isNoticePayload(payload)) {
+                promise = this.appendMetadata(payload)
+            }
+            else {
+                promise = Promise.resolve()
+            }
+
+            promise.then(() => {
                 const httpOptions = {
-                    method: 'POST',
-                    headers: {
-                        'Content-Type': 'application/json',
-                        'Content-Length': data.length,
-                        'X-API-Key': options.apiKey
-                    }
+                    method: options.method,
+                    headers: options.headers,
                 }
 
-                const req = transport.request(endpoint(options.endpoint, '/v1/notices/js'), httpOptions, (res) => {
+                let data: Buffer | undefined = undefined
+                if (payload) {
+                    data = Buffer.from(JSON.stringify(sanitize(payload, options.maxObjectDepth)), 'utf8')
+                    httpOptions.headers['Content-Length'] = data.length
+                }
+
+                const req = transport.request(options.endpoint, httpOptions, (res) => {
                     options.logger.debug(`statusCode: ${res.statusCode}`)
 
                     let body = ''
@@ -39,8 +47,24 @@ export class ServerTransport implements Transport {
 
                 req.on('error', (err) => reject(err))
 
-                req.write(data)
+                if (data) {
+                    req.write(data)
+                }
                 req.end()
+            })
+        })
+    }
+
+    private isNoticePayload(payload?: NoticeTransportPayload | undefined): payload is NoticeTransportPayload {
+        return payload && (payload as NoticeTransportPayload).error !== undefined
+    }
+
+    private appendMetadata(payload: NoticeTransportPayload): Promise<void> {
+        payload.server.pid = process.pid
+        return new Promise<void>(resolve => {
+            getStats((stats) => {
+                payload.server.stats = stats
+                resolve()
             })
         })
     }

--- a/src/server/transport.ts
+++ b/src/server/transport.ts
@@ -1,0 +1,47 @@
+import { Transport, TransportOptions, TransportPayload } from "../core/types"
+import { URL } from "url";
+import http from "http";
+import https from "https";
+import { getStats } from "./util";
+import { endpoint, sanitize } from "../core/util";
+
+export class ServerTransport implements Transport {
+    send(payload: TransportPayload, options: TransportOptions): Promise<{ statusCode: number; body: string; }> {
+        const {protocol} = new URL(options.endpoint)
+        const transport = (protocol === "http:" ? http : https)
+
+        payload.server.pid = process.pid
+
+        return new Promise((resolve, reject) => {
+            getStats((stats) => {
+                payload.server.stats = stats
+
+                const data = Buffer.from(JSON.stringify(sanitize(payload, options.maxObjectDepth)), 'utf8')
+                const httpOptions = {
+                    method: 'POST',
+                    headers: {
+                        'Content-Type': 'application/json',
+                        'Content-Length': data.length,
+                        'X-API-Key': options.apiKey
+                    }
+                }
+
+                const req = transport.request(endpoint(options.endpoint, '/v1/notices/js'), httpOptions, (res) => {
+                    options.logger.debug(`statusCode: ${res.statusCode}`)
+
+                    let body = ''
+                    res.on('data', (chunk) => {
+                        body += chunk
+                    })
+
+                    res.on('end', () => resolve({ statusCode: res.statusCode, body }))
+                })
+
+                req.on('error', (err) => reject(err))
+
+                req.write(data)
+                req.end()
+            })
+        })
+    }
+}

--- a/src/server/util.ts
+++ b/src/server/util.ts
@@ -1,5 +1,6 @@
 import os from 'os'
 import fs from 'fs'
+import { ProcessStats } from '../core/types';
 
 export function fatallyLogAndExit(err: Error): never {
   console.error('[Honeybadger] Exiting process due to uncaught exception')
@@ -7,9 +8,9 @@ export function fatallyLogAndExit(err: Error): never {
   process.exit(1)
 }
 
-export function getStats(cb: (stats: Record<string, unknown>) => void): void {
+export function getStats(cb: (stats: ProcessStats) => void): void {
   const load = os.loadavg(),
-    stats = {
+    stats: ProcessStats = {
       load: {
         one: load[0],
         five: load[1],

--- a/test/integration/sandbox.html
+++ b/test/integration/sandbox.html
@@ -21,9 +21,10 @@
       apiKey: 'integration sandbox'
     });
 
-    Honeybadger.__send = (function(notice) {
-      results.notices.push(notice);
-    });
+    Honeybadger.__transport.send = function (options, payload) {
+      results.notices.push(payload);
+      return Promise.resolve({ statusCode: 201, body: JSON.stringify({id: 'test'}) })
+    };
   </script>
 </head>
 

--- a/test/integration/test.js
+++ b/test/integration/test.js
@@ -82,7 +82,7 @@ describe('browser integration', function () {
       })
       .then(function (results) {
         expect(results.notices.length).toEqual(1);
-        expect(results.notices[0].message).toEqual('unhandled exception');
+        expect(results.notices[0].error.message).toEqual('unhandled exception');
         done();
       })
       .catch(done);
@@ -95,7 +95,7 @@ describe('browser integration', function () {
       })
       .then(function (results) {
         expect(results.notices.length).toEqual(1);
-        expect(results.notices[0].message).toEqual('expected message');
+        expect(results.notices[0].error.message).toEqual('expected message');
         done();
       })
       .catch(done);
@@ -142,9 +142,9 @@ describe('browser integration', function () {
       })
       .then(function (results) {
         expect(results.notices.length).toEqual(1);
-        expect(results.notices[0].__breadcrumbs.length).toEqual(2);
-        expect(results.notices[0].__breadcrumbs[0].message).toEqual('expected message');
-        expect(results.notices[0].__breadcrumbs[0].category).toEqual('log');
+        expect(results.notices[0].breadcrumbs.trail.length).toEqual(2);
+        expect(results.notices[0].breadcrumbs.trail[0].message).toEqual('expected message');
+        expect(results.notices[0].breadcrumbs.trail[0].category).toEqual('log');
         done();
       })
       .catch(done);
@@ -158,9 +158,9 @@ describe('browser integration', function () {
       })
       .then(function (results) {
         expect(results.notices.length).toEqual(1);
-        expect(results.notices[0].__breadcrumbs.length).toEqual(2);
-        expect(results.notices[0].__breadcrumbs[0].message).toEqual('null');
-        expect(results.notices[0].__breadcrumbs[0].category).toEqual('log');
+        expect(results.notices[0].breadcrumbs.trail.length).toEqual(2);
+        expect(results.notices[0].breadcrumbs.trail[0].message).toEqual('null');
+        expect(results.notices[0].breadcrumbs.trail[0].category).toEqual('log');
         done();
       })
       .catch(done);
@@ -175,11 +175,11 @@ describe('browser integration', function () {
       })
       .then(function (results) {
         expect(results.notices.length).toEqual(1);
-        expect(results.notices[0].__breadcrumbs.length).toEqual(2);
-        expect(results.notices[0].__breadcrumbs[0].message).toEqual('button#buttonId');
-        expect(results.notices[0].__breadcrumbs[0].category).toEqual('ui.click');
-        expect(results.notices[0].__breadcrumbs[0].metadata.selector).toEqual('body > div#buttonDivId > button#buttonId');
-        expect(results.notices[0].__breadcrumbs[0].metadata.text).toEqual('button text');
+        expect(results.notices[0].breadcrumbs.trail.length).toEqual(2);
+        expect(results.notices[0].breadcrumbs.trail[0].message).toEqual('button#buttonId');
+        expect(results.notices[0].breadcrumbs.trail[0].category).toEqual('ui.click');
+        expect(results.notices[0].breadcrumbs.trail[0].metadata.selector).toEqual('body > div#buttonDivId > button#buttonId');
+        expect(results.notices[0].breadcrumbs.trail[0].metadata.text).toEqual('button text');
         done();
       })
       .catch(done);
@@ -200,11 +200,11 @@ describe('browser integration', function () {
       })
       .then(function (results) {
         expect(results.notices.length).toEqual(1);
-        expect(results.notices[0].__breadcrumbs.length).toEqual(2);
-        expect(results.notices[0].__breadcrumbs[0].message).toEqual('GET /example/path');
-        expect(results.notices[0].__breadcrumbs[0].category).toEqual('request');
-        expect(results.notices[0].__breadcrumbs[0].metadata.type).toEqual('xhr');
-        expect('message' in results.notices[0].__breadcrumbs[0].metadata).toBe(false);
+        expect(results.notices[0].breadcrumbs.trail.length).toEqual(2);
+        expect(results.notices[0].breadcrumbs.trail[0].message).toEqual('GET /example/path');
+        expect(results.notices[0].breadcrumbs.trail[0].category).toEqual('request');
+        expect(results.notices[0].breadcrumbs.trail[0].metadata.type).toEqual('xhr');
+        expect('message' in results.notices[0].breadcrumbs.trail[0].metadata).toBe(false);
         done();
       })
       .catch(done);
@@ -225,11 +225,11 @@ describe('browser integration', function () {
       })
       .then(function (results) {
         expect(results.notices.length).toEqual(1);
-        expect(results.notices[0].__breadcrumbs.length).toEqual(2);
-        expect(results.notices[0].__breadcrumbs[0].message).toEqual('GET https://example.com/example/path');
-        expect(results.notices[0].__breadcrumbs[0].category).toEqual('request');
-        expect(results.notices[0].__breadcrumbs[0].metadata.type).toEqual('xhr');
-        expect('message' in results.notices[0].__breadcrumbs[0].metadata).toBe(false);
+        expect(results.notices[0].breadcrumbs.trail.length).toEqual(2);
+        expect(results.notices[0].breadcrumbs.trail[0].message).toEqual('GET https://example.com/example/path');
+        expect(results.notices[0].breadcrumbs.trail[0].category).toEqual('request');
+        expect(results.notices[0].breadcrumbs.trail[0].metadata.type).toEqual('xhr');
+        expect('message' in results.notices[0].breadcrumbs.trail[0].metadata).toBe(false);
         done();
       })
       .catch(done);
@@ -247,11 +247,11 @@ describe('browser integration', function () {
       })
       .then(function (results) {
         expect(results.notices.length).toEqual(1);
-        expect(results.notices[0].__breadcrumbs.length).toEqual(2);
-        expect(results.notices[0].__breadcrumbs[0].message).toEqual('GET /example/path');
-        expect(results.notices[0].__breadcrumbs[0].category).toEqual('request');
+        expect(results.notices[0].breadcrumbs.trail.length).toEqual(2);
+        expect(results.notices[0].breadcrumbs.trail[0].message).toEqual('GET /example/path');
+        expect(results.notices[0].breadcrumbs.trail[0].category).toEqual('request');
         // fetch polyfill uses XHR.
-        expect(results.notices[0].__breadcrumbs[0].metadata.type).toEqual(isIE ? 'xhr' : 'fetch');
+        expect(results.notices[0].breadcrumbs.trail[0].metadata.type).toEqual(isIE ? 'xhr' : 'fetch');
         done();
       })
       .catch(done);
@@ -265,10 +265,10 @@ describe('browser integration', function () {
       })
       .then(function (results) {
         expect(results.notices.length).toEqual(1);
-        expect(results.notices[0].__breadcrumbs.length).toEqual(2);
-        expect(results.notices[0].__breadcrumbs[0].message).toEqual('Page changed');
-        expect(results.notices[0].__breadcrumbs[0].category).toEqual('navigation');
-        expect(results.notices[0].__breadcrumbs[0].metadata).toEqual({
+        expect(results.notices[0].breadcrumbs.trail.length).toEqual(2);
+        expect(results.notices[0].breadcrumbs.trail[0].message).toEqual('Page changed');
+        expect(results.notices[0].breadcrumbs.trail[0].category).toEqual('navigation');
+        expect(results.notices[0].breadcrumbs.trail[0].metadata).toEqual({
           // The hostname is different when running locally vs. in CI.
           from: jasmine.stringMatching(/http:\/\/.+:9876\/base\/test\/integration\/sandbox\.html/),
           to: 'foo.html'
@@ -285,15 +285,15 @@ describe('browser integration', function () {
       })
       .then(function (results) {
         expect(results.notices.length).toEqual(1);
-        expect(results.notices[0].__breadcrumbs.length).toEqual(1);
-        expect(results.notices[0].__breadcrumbs[0].message).toEqual('Honeybadger Notice');
-        expect(results.notices[0].__breadcrumbs[0].category).toEqual('notice');
-        expect(results.notices[0].__breadcrumbs[0].metadata).toEqual(jasmine.objectContaining({
+        expect(results.notices[0].breadcrumbs.trail.length).toEqual(1);
+        expect(results.notices[0].breadcrumbs.trail[0].message).toEqual('Honeybadger Notice');
+        expect(results.notices[0].breadcrumbs.trail[0].category).toEqual('notice');
+        expect(results.notices[0].breadcrumbs.trail[0].metadata).toEqual(jasmine.objectContaining({
           name: 'expected name',
           message: 'expected message',
           stack: jasmine.any(String)
         }));
-        expect(results.notices[0].__breadcrumbs[0].metadata).not.toEqual(jasmine.objectContaining({
+        expect(results.notices[0].breadcrumbs.trail[0].metadata).not.toEqual(jasmine.objectContaining({
           context: jasmine.anything()
         }));
         done();
@@ -309,9 +309,9 @@ describe('browser integration', function () {
       })
       .then(function (results) {
         expect(results.notices.length).toEqual(1);
-        expect(results.notices[0].__breadcrumbs).toBeArray();
+        expect(results.notices[0].breadcrumbs.trail).toBeArray();
 
-        const errorBreadcrumbs = results.notices[0].__breadcrumbs.filter(function (c) { return c.category === 'error'; })
+        const errorBreadcrumbs = results.notices[0].breadcrumbs.trail.filter(function (c) { return c.category === 'error'; })
         console.log(errorBreadcrumbs)
 
         expect(errorBreadcrumbs.length).toEqual(1)
@@ -342,9 +342,9 @@ describe('browser integration', function () {
       })
       .then(function (results) {
         expect(results.notices.length).toEqual(1);
-        expect(results.notices[0].__breadcrumbs).toBeArray();
+        expect(results.notices[0].breadcrumbs.trail).toBeArray();
 
-        const errorBreadcrumbs = results.notices[0].__breadcrumbs.filter(function (c) { return c.category === 'error'; })
+        const errorBreadcrumbs = results.notices[0].breadcrumbs.trail.filter(function (c) { return c.category === 'error'; })
 
         expect(errorBreadcrumbs.length).toEqual(1);
         expect(errorBreadcrumbs[0].message).toEqual('window.onunhandledrejection: Error');
@@ -373,9 +373,9 @@ describe('browser integration', function () {
       })
       .then(function (results) {
         expect(results.notices.length).toEqual(1);
-        expect(results.notices[0].__breadcrumbs).toBeArray();
+        expect(results.notices[0].breadcrumbs.trail).toBeArray();
 
-        const errorBreadcrumbs = results.notices[0].__breadcrumbs.filter(function (c) { return c.category === 'error'; })
+        const errorBreadcrumbs = results.notices[0].breadcrumbs.trail.filter(function (c) { return c.category === 'error'; })
 
         expect(errorBreadcrumbs.length).toEqual(0);
         done();

--- a/test/unit/browser/integrations/onerror.browser.test.ts
+++ b/test/unit/browser/integrations/onerror.browser.test.ts
@@ -1,5 +1,6 @@
 import { onError } from '../../../../src/browser/integrations/onerror'
-import { nullLogger, TestClient } from '../../helpers'
+ // @ts-ignore
+import { nullLogger, TestClient, TestTransport } from '../../helpers'
 
 describe('window.onerror integration', function () {
   let client, mockNotify, mockAddBreadcrumb
@@ -7,7 +8,7 @@ describe('window.onerror integration', function () {
   beforeEach(function () {
     client = new TestClient({
       logger: nullLogger()
-    })
+    }, new TestTransport())
     mockNotify = jest.fn()
     mockAddBreadcrumb = jest.fn()
     client.notify = mockNotify

--- a/test/unit/browser/integrations/onunhandledrejection.browser.test.ts
+++ b/test/unit/browser/integrations/onunhandledrejection.browser.test.ts
@@ -1,5 +1,6 @@
 import onUnhandledRejection from '../../../../src/browser/integrations/onunhandledrejection'
-import { nullLogger, TestClient } from '../../helpers'
+// @ts-ignore
+import { nullLogger, TestClient, TestTransport } from '../../helpers'
 
 describe('window.onunhandledrejection integration', function () {
   let client, mockNotify
@@ -7,7 +8,7 @@ describe('window.onunhandledrejection integration', function () {
   beforeEach(function () {
     client = new TestClient({
       logger: nullLogger()
-    })
+    }, new TestTransport())
     mockNotify = jest.fn()
     client.notify = mockNotify
   })

--- a/test/unit/browser/transport.browser.test.ts
+++ b/test/unit/browser/transport.browser.test.ts
@@ -1,0 +1,87 @@
+import {useFakeXMLHttpRequest} from 'sinon'
+import { BrowserTransport } from "../../../src/browser/transport";
+
+describe('BrowserTransport', function () {
+    let transport: BrowserTransport
+    let requests, request, xhr
+    beforeAll(() => {
+        transport = new BrowserTransport()
+    })
+
+    beforeEach(() => {
+        // Stub HTTP requests.
+        request = undefined
+        requests = []
+        xhr = useFakeXMLHttpRequest()
+        xhr.onCreate = function (xhr) {
+            request = xhr
+            return requests.push(xhr)
+        }
+    })
+
+    it('sends GET request over the network', () => {
+        const promise = transport.send({
+            method: 'GET',
+            endpoint: 'my-endpoint',
+            async: true,
+            logger: console,
+        }).then(resp => {
+            expect(resp.statusCode).toEqual(201)
+            return Promise.resolve()
+        })
+
+        expect(requests).toHaveLength(1)
+        request.respond(201)
+
+        return promise
+    })
+
+    it('sends POST request over the network', () => {
+        const promise = transport.send({
+            method: 'POST',
+            endpoint: 'my-endpoint',
+            async: true,
+            logger: console,
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        }, <any>{ test: 1 }).then(resp => {
+            expect(resp.statusCode).toEqual(201)
+            return Promise.resolve()
+        })
+
+        expect(requests).toHaveLength(1)
+        request.respond(201)
+
+        return promise
+    })
+
+    it('sends POST request over the network with headers', () => {
+        const headers = {
+            'X-API-Key': '123',
+            'Content-Type': 'application/json;charset=utf-8',
+            'Accept': 'text/json, application/json'
+        }
+        const promise = transport.send({
+            method: 'POST',
+            endpoint: 'my-endpoint',
+            headers,
+            async: true,
+            logger: console,
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        }, <any>{ test: 1 }).then(resp => {
+            expect(resp.statusCode).toEqual(201)
+            return Promise.resolve()
+        })
+
+        expect(requests).toHaveLength(1)
+        expect(request.requestHeaders).toEqual(headers)
+        request.respond(201)
+
+
+        return promise
+    })
+
+    afterEach(function () {
+        xhr.restore()
+    })
+
+});

--- a/test/unit/core/client.test.ts
+++ b/test/unit/core/client.test.ts
@@ -927,19 +927,7 @@ describe('client', function () {
 
   describe('checkIn', function () {
     it('sends a checkIn report', async function () {
-      await expect(client.checkIn(123)).resolves.not.toThrow()
-    })
-
-    it('throws an error if checkIn id does not exist', async function () {
-      const failingClient = new TestClient({
-        logger: nullLogger(),
-        environment: null
-      }, {
-        send(_options, _payload?): Promise<{ statusCode: number; body: string }> {
-          return Promise.reject(new Error('id not found'))
-        }
-      })
-      await expect(failingClient.checkIn(123)).rejects.toThrow()
+      await expect(client.checkIn('123')).resolves.not.toThrow()
     })
   })
 })

--- a/test/unit/core/client.test.ts
+++ b/test/unit/core/client.test.ts
@@ -1,7 +1,6 @@
 // @ts-ignore
-import { nullLogger, TestClient } from '../helpers'
+import { nullLogger, TestClient, TestTransport } from '../helpers'
 import { Notice } from '../../../src/core/types'
-import { sanitize } from "../../../src/core/util";
 
 class MyError extends Error {
   context = null
@@ -22,7 +21,7 @@ describe('client', function () {
     client = new TestClient({
       logger: nullLogger(),
       environment: null
-    })
+    }, new TestTransport())
     client.configure()
   })
 
@@ -320,7 +319,7 @@ describe('client', function () {
       const payload = client.getPayload('expected message')
 
       expect(payload.error.message).toEqual('expected message')
-      expect((payload.error.backtrace as Array<Record<string, unknown>>).length).toBeGreaterThan(0)
+      expect((payload.error.backtrace).length).toBeGreaterThan(0)
       expect(payload.error.backtrace[0].file).toMatch("helpers.ts")
     })
 
@@ -782,7 +781,7 @@ describe('client', function () {
       const payload = client.getPayload('message')
 
       expect(payload.breadcrumbs.enabled).toEqual(true)
-      expect((payload.breadcrumbs.trail as Array<Record<string, unknown>>).length).toEqual(2)
+      expect((payload.breadcrumbs.trail).length).toEqual(2)
       expect(payload.breadcrumbs.trail[0].message).toEqual('expected message')
     })
 

--- a/test/unit/core/client.test.ts
+++ b/test/unit/core/client.test.ts
@@ -927,7 +927,7 @@ describe('client', function () {
 
   describe('checkIn', function () {
     it('sends a checkIn report', async function () {
-      await expect(client.checkInAsync('123')).resolves.not.toThrow()
+      await expect(client.checkIn('123')).resolves.not.toThrow()
     })
   })
 })

--- a/test/unit/core/client.test.ts
+++ b/test/unit/core/client.test.ts
@@ -927,7 +927,7 @@ describe('client', function () {
 
   describe('checkIn', function () {
     it('sends a checkIn report', async function () {
-      await expect(client.checkIn('123')).resolves.not.toThrow()
+      await expect(client.checkInAsync('123')).resolves.not.toThrow()
     })
   })
 })

--- a/test/unit/core/client.test.ts
+++ b/test/unit/core/client.test.ts
@@ -924,10 +924,4 @@ describe('client', function () {
     const payload = client.getPayload('testing', { tags: ['tag1'] })
     expect(payload.error.tags).toEqual(['tag1'])
   })
-
-  describe('checkIn', function () {
-    it('sends a checkIn report', async function () {
-      await expect(client.checkIn('123')).resolves.not.toThrow()
-    })
-  })
 })

--- a/test/unit/core/client.test.ts
+++ b/test/unit/core/client.test.ts
@@ -924,4 +924,22 @@ describe('client', function () {
     const payload = client.getPayload('testing', { tags: ['tag1'] })
     expect(payload.error.tags).toEqual(['tag1'])
   })
+
+  describe('checkIn', function () {
+    it('sends a checkIn report', async function () {
+      await expect(client.checkIn(123)).resolves.not.toThrow()
+    })
+
+    it('throws an error if checkIn id does not exist', async function () {
+      const failingClient = new TestClient({
+        logger: nullLogger(),
+        environment: null
+      }, {
+        send(_options, _payload?): Promise<{ statusCode: number; body: string }> {
+          return Promise.reject(new Error('id not found'))
+        }
+      })
+      await expect(failingClient.checkIn(123)).rejects.toThrow()
+    })
+  })
 })

--- a/test/unit/core/util.test.ts
+++ b/test/unit/core/util.test.ts
@@ -1,8 +1,7 @@
 import {fake} from 'sinon'
-import Client from '../../../src/core/client'
 import { merge, mergeNotice, objectIsEmpty, runBeforeNotifyHandlers, runAfterNotifyHandlers, shallowClone, sanitize, logger, filter, filterUrl } from '../../../src/core/util'
 // @ts-ignore
-import { nullLogger } from '../helpers'
+import { nullLogger, TestClient, TestTransport } from '../helpers'
 
 describe('utils', function () {
   describe('filterUrl', function () {
@@ -44,7 +43,7 @@ describe('utils', function () {
       const mockDebug = jest.fn()
       const console = nullLogger()
       console.debug = mockDebug
-      const client = new Client({ logger: console })
+      const client = new TestClient({ logger: console }, new TestTransport())
 
       logger(client).debug('expected')
 
@@ -55,7 +54,7 @@ describe('utils', function () {
       const mockDebug = jest.fn()
       const console = nullLogger()
       console.log = mockDebug
-      const client = new Client({ logger: console, debug: true })
+      const client = new TestClient({ logger: console, debug: true }, new TestTransport())
 
       logger(client).debug('expected')
 

--- a/test/unit/helpers.ts
+++ b/test/unit/helpers.ts
@@ -1,5 +1,5 @@
 import BaseClient from '../../src/core/client'
-import { Config, Logger, Notice, Noticeable, Transport, TransportOptions, TransportPayload } from '../../src/core/types'
+import { Config, Logger, Notice, Noticeable, Transport, TransportOptions, NoticeTransportPayload } from '../../src/core/types'
 import { runAfterNotifyHandlers } from "../../src/core/util";
 
 export function nullLogger(): Logger {
@@ -13,7 +13,7 @@ export function nullLogger(): Logger {
 }
 
 export class TestTransport implements Transport {
-  send(_payload: TransportPayload, _options: TransportOptions): Promise<{ statusCode: number; body: string }> {
+  send(_options: TransportOptions, _payload: NoticeTransportPayload): Promise<{ statusCode: number; body: string }> {
     return Promise.resolve({body: JSON.stringify({ id: 'uuid' }), statusCode: 201});
   }
 }

--- a/test/unit/helpers.ts
+++ b/test/unit/helpers.ts
@@ -1,8 +1,8 @@
 import BaseClient from '../../src/core/client'
-import {Logger, Notice, Noticeable} from '../../src/core/types'
+import { Config, Logger, Notice, Noticeable, Transport, TransportOptions, TransportPayload } from '../../src/core/types'
 import { runAfterNotifyHandlers } from "../../src/core/util";
 
-export function nullLogger (): Logger {
+export function nullLogger(): Logger {
   return {
     log: () => true,
     info: () => true,
@@ -12,7 +12,20 @@ export function nullLogger (): Logger {
   }
 }
 
+export class TestTransport implements Transport {
+  send(_payload: TransportPayload, _options: TransportOptions): Promise<{ statusCode: number; body: string }> {
+    return Promise.resolve({body: JSON.stringify({ id: 'uuid' }), statusCode: 201});
+  }
+}
+
 export class TestClient extends BaseClient {
+  protected factory(_opts: Partial<Config>): void {
+      throw new Error('Method not implemented.');
+  }
+
+  constructor(opts: Partial<Config>, transport: Transport) {
+    super(opts, transport);
+  }
 
   public getContext() {
     return this.__store.getStore().context

--- a/test/unit/helpers.ts
+++ b/test/unit/helpers.ts
@@ -23,6 +23,10 @@ export class TestClient extends BaseClient {
       throw new Error('Method not implemented.');
   }
 
+  public checkIn(_id: string): Promise<void> {
+    throw new Error('Method not implemented.');
+  }
+
   constructor(opts: Partial<Config>, transport: Transport) {
     super(opts, transport);
   }

--- a/test/unit/server.test.ts
+++ b/test/unit/server.test.ts
@@ -239,4 +239,21 @@ describe('server client', function () {
       });
     });
   })
+
+  describe('checkIn', function () {
+    it('sends a checkIn report', async function () {
+      client.configure({
+        apiKey: 'testing',
+        endpoint: 'http://api.honeybadger.io'
+      })
+
+      const checkInId = "123"
+      const request = nock('http://api.honeybadger.io')
+          .get(`/v1/check_in/${checkInId}`)
+          .reply(201)
+
+      await client.checkIn(checkInId)
+      expect(request.isDone()).toBe(true)
+    })
+  })
 })

--- a/test/unit/server/transport.server.test.ts
+++ b/test/unit/server/transport.server.test.ts
@@ -1,0 +1,72 @@
+import { ServerTransport } from "../../../src/server/transport";
+import nock from "nock";
+
+describe('ServerTransport', function () {
+    let transport: ServerTransport
+    beforeAll(() => {
+        transport = new ServerTransport()
+    })
+
+    it('sends GET request over the network', () => {
+        const checkInId = '123'
+        const request = nock('http://api.honeybadger.io')
+            .get(`/v1/check_in/${checkInId}`)
+            .reply(201)
+        return transport
+            .send({
+                endpoint: `http://api.honeybadger.io/v1/check_in/${checkInId}`,
+                method: 'GET',
+                logger: console
+            })
+            .then(resp => {
+                expect(request.isDone()).toBe(true)
+                expect(resp.statusCode).toEqual(201)
+            })
+
+    })
+
+    it('sends POST request over the network', () => {
+        const request = nock('http://api.honeybadger.io')
+            .post('/v1/notices/js')
+            .reply(201, {
+                id: '48b98609-dd3b-48ee-bffc-d51f309a2dfa'
+            })
+        return transport
+            .send({
+                endpoint: 'http://api.honeybadger.io/v1/notices/js',
+                method: 'POST',
+                logger: console
+            })
+            .then(resp => {
+              expect(request.isDone()).toBe(true)
+              expect(resp.statusCode).toEqual(201)
+            })
+    })
+
+    it('sends POST request over the network with headers', () => {
+        const headers = {
+            'X-API-Key': '123',
+            'Content-Type': 'application/json;charset=utf-8',
+            'Accept': 'text/json, application/json'
+        }
+        const request = nock('http://api.honeybadger.io')
+            .post('/v1/notices/js')
+            .matchHeader('X-API-Key', '123')
+            .matchHeader('Content-Type', 'application/json;charset=utf-8')
+            .matchHeader('Accept', 'text/json, application/json')
+            .reply(201, {
+                id: '48b98609-dd3b-48ee-bffc-d51f309a2dfa'
+            })
+        return transport
+            .send({
+                endpoint: 'http://api.honeybadger.io/v1/notices/js',
+                headers,
+                method: 'POST',
+                logger: console
+            })
+            .then(resp => {
+                expect(request.isDone()).toBe(true)
+                expect(resp.statusCode).toEqual(201)
+            })
+    })
+});


### PR DESCRIPTION
## Status
**READY**

## Description
Fixes #725 
In order to create a single `Honeybadger.checkIn()` method to be shared between browser and server, I decided to extract the transport layer logic into a separate interface. This way, we can abstract the browser vs server differences and implement a single `checkIn()` method to be used by both. I refactored `notify()` to use the same approach.

Notes:
- This is the first version of `Honeybadger.checkIn()` that simply pings Honeybadger from inside the code. There is ongoing discussion to add more features into this implementation (maintain/create check-ins through code).
- I noticed that the check-in API call does not require an API key, is that intended? Aren't there security concerns with this approach? @joshuap 
- The check-in API call will return HTTP OK even if the check-in id does not exist.

## Todos
- [x] Trasport Interface
- [x] Server Transport
- [x] Browser Transport
- [x] Honeybadger.checkIn()
- [x] Tests
- [x] Fix CI Tests
- [x] Documentation
- [x] Changelog Entry (unreleased)
