### PR TITLE
#679 AWS Timeout Warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased][beta]
 ### Added
+- AWS Lambda Timeout Warning (#679)
 - Enforce Conventional Commits using a git hook (#731)
 - Nodejs: Include source snippet in backtraces when available (#624)
 - `notifyAsync`: Async version of `notify` that returns a promise (#327)

--- a/examples/aws-lambda/handler.js
+++ b/examples/aws-lambda/handler.js
@@ -70,5 +70,21 @@ module.exports = {
       });
       callback(null, resp);
     }, 300);
-  })
+  }),
+  timeoutWarning: honeybadgerWrapper(async (event) => {
+    const asyncThatThrows = async (shouldTimeout) => {
+      return new Promise((resolve, reject) => {
+        setTimeout(() => {
+          resolve()
+        }, shouldTimeout ? (1000 * 60 * 20) : 200) // 20 minutes
+      });
+    }
+
+    const shouldTimeout = event.body && event.body.timeout === 'yes';
+    await asyncThatThrows(shouldTimeout);
+    return formatJSONResponse({
+      message: `You summoned the timeoutWarning handler! Nothing was sent to Honeybadger. POST with { 'body': { 'timeout': 'yes' } } to run the function until it times out.`,
+      event,
+    });
+  }),
 }

--- a/examples/aws-lambda/serverless.yml
+++ b/examples/aws-lambda/serverless.yml
@@ -45,3 +45,9 @@ functions:
       - httpApi:
           path: /set-timeout-error
           method: post
+  timeoutWarning:
+    handler: handler.timeoutWarning
+    events:
+      - httpApi:
+          path: /timeout-warning
+          method: post

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -33,6 +33,11 @@ export interface Config {
   tags: unknown,
 }
 
+export interface ServerlessConfig extends Config {
+  reportTimeoutWarning: boolean;
+  timeoutWarningThresholdMs: number;
+}
+
 export interface BeforeNotifyHandler {
   (notice?: Notice): boolean | void
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -49,7 +49,7 @@ class Honeybadger extends Client {
 
     // serverless defaults
     const config = this.config as ServerlessConfig
-    config.reportTimeoutWarning = config.reportTimeoutWarning || true
+    config.reportTimeoutWarning = config.reportTimeoutWarning ?? true
     config.timeoutWarningThresholdMs = config.timeoutWarningThresholdMs || 50
 
     this.__getSourceFileHandler = getSourceFile.bind(this)

--- a/src/server/aws_lambda.ts
+++ b/src/server/aws_lambda.ts
@@ -82,7 +82,7 @@ function setupTimeoutWarning(hb: Honeybadger, context: Context) {
 
     const delay = context.getRemainingTimeInMillis() - ((hb.config as ServerlessConfig).timeoutWarningThresholdMs)
     return setTimeout(() => {
-        hb.notify(`${context.functionName}[${context.functionVersion}] may timeout`)
+        hb.notify(`${context.functionName}[${context.functionVersion}] may have timed out`)
     }, delay > 0 ? delay : 0)
 
 }

--- a/src/server/aws_lambda.ts
+++ b/src/server/aws_lambda.ts
@@ -3,6 +3,7 @@ import Honeybadger from '../core/client'
 // eslint-disable-next-line import/no-unresolved
 import { Handler, Callback, Context } from 'aws-lambda'
 import { AsyncStore } from "./async_store";
+import { ServerlessConfig } from "../core/types";
 
 export type SyncHandler<TEvent = any, TResult = any> = (
     event: TEvent,
@@ -33,11 +34,14 @@ function asyncHandler<TEvent = any, TResult = any>(handler: AsyncHandler<TEvent,
         hb.__setStore(AsyncStore)
         return new Promise<TResult>((resolve, reject) => {
             AsyncStore.run({context: {}, breadcrumbs: []}, () => {
+                const timeoutHandler = setupTimeoutWarning(hb, context)
                 try {
                     handler(event, context)
                         .then(resolve)
                         .catch(err => reportToHoneybadger(hb, err, reject))
+                        .finally(() => clearTimeout(timeoutHandler))
                 } catch (err) {
+                    clearTimeout(timeoutHandler)
                     reportToHoneybadger(hb, err, reject)
                 }
             })
@@ -49,8 +53,10 @@ function syncHandler<TEvent = any, TResult = any>(handler: SyncHandler<TEvent, T
     return function wrappedLambdaHandler(event, context, cb) {
         hb.__setStore(AsyncStore)
         AsyncStore.run({context: {}, breadcrumbs: []}, () => {
+            const timeoutHandler = setupTimeoutWarning(hb, context)
             try {
                 handler(event, context, (error, result) => {
+                    clearTimeout(timeoutHandler)
                     if (error) {
                         return reportToHoneybadger(hb, error, cb)
                     }
@@ -58,10 +64,27 @@ function syncHandler<TEvent = any, TResult = any>(handler: SyncHandler<TEvent, T
                     cb(null, result)
                 });
             } catch (err) {
+                clearTimeout(timeoutHandler)
                 reportToHoneybadger(hb, err, cb)
             }
         })
     }
+}
+
+function shouldReportTimeoutWarning(hb: Honeybadger, context: Context): boolean {
+    return typeof context.getRemainingTimeInMillis === 'function' && !!((hb.config as ServerlessConfig).reportTimeoutWarning)
+}
+
+function setupTimeoutWarning(hb: Honeybadger, context: Context) {
+    if (!shouldReportTimeoutWarning(hb, context)) {
+        return
+    }
+
+    const delay = context.getRemainingTimeInMillis() - ((hb.config as ServerlessConfig).timeoutWarningThresholdMs)
+    return setTimeout(() => {
+        hb.notify(`${context.functionName}[${context.functionVersion}] may timeout`)
+    }, delay > 0 ? delay : 0)
+
 }
 
 export function lambdaHandler<TEvent = any, TResult = any>(handler: Handler<TEvent, TResult>): Handler<TEvent, TResult> {

--- a/test/unit/server/aws_lambda.server.test.ts
+++ b/test/unit/server/aws_lambda.server.test.ts
@@ -20,11 +20,11 @@ const mockAwsResult = (obj: Partial<APIGatewayProxyResult> = {}) => {
     return Object.assign({}, obj) as APIGatewayProxyResult;
 }
 
-const initNock = (expectedTimes = 1): nock.Scope => {
+const initNock = (expectedTimes = 1, requestBodyMatcher?: (body: any) => boolean): nock.Scope => {
     nock.cleanAll()
 
     return nock("https://api.honeybadger.io")
-        .post("/v1/notices/js")
+        .post("/v1/notices/js", requestBodyMatcher)
         .times(expectedTimes)
         .reply(201, '{"id":"1a327bf6-e17a-40c1-ad79-404ea1489c7a"}')
 }
@@ -159,6 +159,176 @@ describe('Lambda Handler', function () {
                 }, 50)
             })
         })
+
+        it('reports timeout warning to Honeybadger by default', async function () {
+            const REMAINING_TIME_MS = 200
+            const TIMEOUT_THRESHOLD_MS = 50 // default
+            const SHOULD_BE_CALLED_AFTER_MS = REMAINING_TIME_MS - TIMEOUT_THRESHOLD_MS
+
+            client.configure({
+                apiKey: 'testing',
+            })
+
+            let noticeSentAt: number
+            const api = initNock(1, (body) => {
+                noticeSentAt = Date.now()
+                return body.error.message === 'serverlessFunction[v1.0.0] may timeout'
+            })
+            const handler = client.lambdaHandler(async function (_event) {
+                return new Promise<APIGatewayProxyResult>((resolve, _reject) => {
+                    setTimeout(function () {
+                        resolve({body: 'should not resolve', statusCode: 200})
+                    }, REMAINING_TIME_MS * 2)
+                })
+            }) as AsyncHandler
+
+            const handlerCalledAt = Date.now()
+            let handlerResolvedAt: number
+            handler(mockAwsEvent(), mockAwsContext({
+                functionName: 'serverlessFunction',
+                functionVersion: 'v1.0.0',
+                getRemainingTimeInMillis: () => REMAINING_TIME_MS
+            }))
+                .then(() => {
+                    handlerResolvedAt = Date.now()
+                })
+
+            return new Promise<void>(resolve => {
+                setTimeout(() => {
+                    if (handlerResolvedAt) {
+                        // eslint-disable-next-line jest/no-conditional-expect
+                        expect(noticeSentAt).toBeLessThan(handlerResolvedAt)
+                    }
+                    // let a 100ms window because setTimeout cannot guarantee exact execution at specified interval
+                    expect(noticeSentAt - handlerCalledAt).toBeLessThan(SHOULD_BE_CALLED_AFTER_MS + 100)
+                    api.done()
+                    resolve()
+                }, SHOULD_BE_CALLED_AFTER_MS + 150)
+            })
+        })
+
+        it('reports timeout warning to Honeybadger with custom timeout threshold', async function () {
+            const REMAINING_TIME_MS = 2000
+            const TIMEOUT_THRESHOLD_MS = 1000
+            const SHOULD_BE_CALLED_AFTER_MS = REMAINING_TIME_MS - TIMEOUT_THRESHOLD_MS
+
+            client.configure({
+                apiKey: 'testing',
+                timeoutWarningThresholdMs: TIMEOUT_THRESHOLD_MS
+            })
+
+            let noticeSentAt: number
+            const api = initNock(1, (body) => {
+                noticeSentAt = Date.now()
+                return body.error.message === 'serverlessFunction[v1.0.0] may timeout'
+            })
+            const handler = client.lambdaHandler(async function (_event) {
+                return new Promise<APIGatewayProxyResult>((resolve, _reject) => {
+                    setTimeout(function () {
+                        resolve({body: 'should not resolve', statusCode: 200})
+                    }, REMAINING_TIME_MS * 2)
+                })
+            }) as AsyncHandler
+
+            const handlerCalledAt = Date.now()
+            let handlerResolvedAt: number
+            handler(mockAwsEvent(), mockAwsContext({
+                functionName: 'serverlessFunction',
+                functionVersion: 'v1.0.0',
+                getRemainingTimeInMillis: () => REMAINING_TIME_MS
+            }))
+                .then(() => {
+                    handlerResolvedAt = Date.now()
+                })
+
+            return new Promise<void>(resolve => {
+                setTimeout(() => {
+                    if (handlerResolvedAt) {
+                        // eslint-disable-next-line jest/no-conditional-expect
+                        expect(noticeSentAt).toBeLessThan(handlerResolvedAt)
+                    }
+                    // let a 100ms window because setTimeout cannot guarantee exact execution at specified interval
+                    expect(noticeSentAt - handlerCalledAt).toBeLessThan(SHOULD_BE_CALLED_AFTER_MS + 100)
+                    api.done()
+                    resolve()
+                }, SHOULD_BE_CALLED_AFTER_MS + 150)
+            })
+        })
+
+        it('does not report timeout warning to Honeybadger', async function () {
+            const REMAINING_TIME_MS = 100
+            const HANDLER_RESOLVE_AFTER_MS = 200
+
+            client.configure({
+                apiKey: 'testing',
+                reportTimeoutWarning: false
+            })
+
+            const api = initNock()
+
+            const handler = client.lambdaHandler(async function (_event) {
+                return new Promise<APIGatewayProxyResult>((resolve, _reject) => {
+                    setTimeout(function () {
+                        resolve({body: 'should resolve', statusCode: 200})
+                    }, HANDLER_RESOLVE_AFTER_MS)
+                })
+            }) as AsyncHandler
+
+            const handlerCalledAt = Date.now()
+            const result = await handler(mockAwsEvent(), mockAwsContext({
+                functionName: 'serverlessFunction',
+                functionVersion: 'v1.0.0',
+                getRemainingTimeInMillis: () => REMAINING_TIME_MS
+            }))
+            const handlerResolvedAt = Date.now()
+
+            expect(result.statusCode).toEqual(200)
+            expect(handlerResolvedAt - handlerCalledAt).toBeLessThan(HANDLER_RESOLVE_AFTER_MS + 50)
+            expect(api.isDone()).toBe(false)
+        })
+
+        it('does not report timeout warning if function resolves', async function () {
+            const REMAINING_TIME_MS = 200
+            const TIMEOUT_THRESHOLD_MS = 50 // default
+            const SHOULD_BE_CALLED_AFTER_MS = REMAINING_TIME_MS - TIMEOUT_THRESHOLD_MS
+
+            client.configure({
+                apiKey: 'testing',
+            })
+
+            let noticeSentAt: number
+            const api = initNock(1, (body) => {
+                noticeSentAt = Date.now()
+                return body.error.message === 'serverlessFunction[v1.0.0] may timeout'
+            })
+            const handler = client.lambdaHandler(async function (_event) {
+                return new Promise<APIGatewayProxyResult>((resolve, _reject) => {
+                    setTimeout(function () {
+                        resolve({body: 'should resolve', statusCode: 200})
+                    }, REMAINING_TIME_MS / 2)
+                })
+            }) as AsyncHandler
+
+            const handlerCalledAt = Date.now()
+            let handlerResolvedAt: number
+            handler(mockAwsEvent(), mockAwsContext({
+                functionName: 'serverlessFunction',
+                functionVersion: 'v1.0.0',
+                getRemainingTimeInMillis: () => REMAINING_TIME_MS
+            }))
+                .then(() => {
+                    handlerResolvedAt = Date.now()
+                })
+
+            return new Promise<void>(resolve => {
+                setTimeout(() => {
+                    expect(handlerResolvedAt).toBeGreaterThan(handlerCalledAt)
+                    expect(noticeSentAt).toBeUndefined()
+                    expect(api.isDone()).toEqual(false)
+                    resolve()
+                }, SHOULD_BE_CALLED_AFTER_MS + 150)
+            })
+        })
     })
 
     describe('non-async handlers', function () {
@@ -266,6 +436,159 @@ describe('Lambda Handler', function () {
                         done(null)
                     }, 50)
                 })
+            })
+        })
+
+        it('reports timeout warning to Honeybadger', async function () {
+            const REMAINING_TIME_MS = 200
+            const TIMEOUT_THRESHOLD_MS = 50 // default
+            const SHOULD_BE_CALLED_AFTER_MS = REMAINING_TIME_MS - TIMEOUT_THRESHOLD_MS
+
+            let noticeSentAt: number
+            const api = initNock(1, (body) => {
+                noticeSentAt = Date.now()
+                return body.error.message === 'serverlessFunction[v1.0.0] may timeout'
+            })
+
+            const handler = client.lambdaHandler(function (_event, _context, callback) {
+                setTimeout(function () {
+                    callback(null, { body: 'should not resolve', statusCode: 200 })
+                }, REMAINING_TIME_MS * 2)
+            }) as SyncHandler<APIGatewayProxyEvent, APIGatewayProxyResult>
+
+            return new Promise<void>((resolve) => {
+                const handlerCalledAt = Date.now()
+                let handlerResolvedAt: number
+                handler(mockAwsEvent(), mockAwsContext(mockAwsContext({
+                    functionName: 'serverlessFunction',
+                    functionVersion: 'v1.0.0',
+                    getRemainingTimeInMillis: () => REMAINING_TIME_MS
+                })), (_err, _res) => {
+                    handlerResolvedAt = Date.now()
+                })
+                setTimeout(() => {
+                    if (handlerResolvedAt) {
+                        // eslint-disable-next-line jest/no-conditional-expect
+                        expect(noticeSentAt).toBeLessThan(handlerResolvedAt)
+                    }
+                    // let a 100ms window because setTimeout cannot guarantee exact execution at specified interval
+                    expect(noticeSentAt - handlerCalledAt).toBeLessThan(SHOULD_BE_CALLED_AFTER_MS + 100)
+                    api.done()
+                    resolve()
+                }, SHOULD_BE_CALLED_AFTER_MS + 150)
+            })
+        })
+
+        it('reports timeout warning to Honeybadger with custom timeout threshold', async function () {
+            const REMAINING_TIME_MS = 2000
+            const TIMEOUT_THRESHOLD_MS = 1000 // default
+            const SHOULD_BE_CALLED_AFTER_MS = REMAINING_TIME_MS - TIMEOUT_THRESHOLD_MS
+
+            client.configure({
+                timeoutWarningThresholdMs: TIMEOUT_THRESHOLD_MS
+            })
+
+            let noticeSentAt: number
+            const api = initNock(1, (body) => {
+                noticeSentAt = Date.now()
+                return body.error.message === 'serverlessFunction[v1.0.0] may timeout'
+            })
+
+            const handler = client.lambdaHandler(function (_event, _context, callback) {
+                setTimeout(function () {
+                    callback(null, { body: 'should not resolve', statusCode: 200 })
+                }, REMAINING_TIME_MS * 2)
+            }) as SyncHandler<APIGatewayProxyEvent, APIGatewayProxyResult>
+
+            return new Promise<void>((resolve) => {
+                const handlerCalledAt = Date.now()
+                let handlerResolvedAt: number
+                handler(mockAwsEvent(), mockAwsContext(mockAwsContext({
+                    functionName: 'serverlessFunction',
+                    functionVersion: 'v1.0.0',
+                    getRemainingTimeInMillis: () => REMAINING_TIME_MS
+                })), (_err, _res) => {
+                    handlerResolvedAt = Date.now()
+                })
+                setTimeout(() => {
+                    if (handlerResolvedAt) {
+                        // eslint-disable-next-line jest/no-conditional-expect
+                        expect(noticeSentAt).toBeLessThan(handlerResolvedAt)
+                    }
+                    // let a 100ms window because setTimeout cannot guarantee exact execution at specified interval
+                    expect(noticeSentAt - handlerCalledAt).toBeLessThan(SHOULD_BE_CALLED_AFTER_MS + 100)
+                    api.done()
+                    resolve()
+                }, SHOULD_BE_CALLED_AFTER_MS + 150)
+            })
+        })
+
+        it('does not report timeout warning to Honeybadger', async function () {
+            const REMAINING_TIME_MS = 100
+            const HANDLER_RESOLVE_AFTER_MS = 200
+
+            client.configure({
+                reportTimeoutWarning: false
+            })
+
+            const api = initNock()
+
+            const handler = client.lambdaHandler(function (_event, _context, callback) {
+                setTimeout(function () {
+                    callback(null, { body: 'should resolve', statusCode: 200 })
+                }, HANDLER_RESOLVE_AFTER_MS)
+            }) as SyncHandler<APIGatewayProxyEvent, APIGatewayProxyResult>
+
+            return new Promise<void>(resolve => {
+                const handlerCalledAt = Date.now()
+                handler(mockAwsEvent(), mockAwsContext({
+                    functionName: 'serverlessFunction',
+                    functionVersion: 'v1.0.0',
+                    getRemainingTimeInMillis: () => REMAINING_TIME_MS
+                }), (err, result) => {
+                    const handlerResolvedAt = Date.now()
+                    expect(err).toBeNull()
+                    expect(result.statusCode).toEqual(200)
+                    expect(handlerResolvedAt - handlerCalledAt).toBeLessThan(HANDLER_RESOLVE_AFTER_MS + 50)
+                    expect(api.isDone()).toBe(false)
+                    resolve()
+                })
+            })
+        })
+
+        it('does not report timeout warning if function resolves', async function () {
+            const REMAINING_TIME_MS = 200
+            const TIMEOUT_THRESHOLD_MS = 50 // default
+            const SHOULD_BE_CALLED_AFTER_MS = REMAINING_TIME_MS - TIMEOUT_THRESHOLD_MS
+
+            let noticeSentAt: number
+            const api = initNock(1, (body) => {
+                noticeSentAt = Date.now()
+                return body.error.message === 'serverlessFunction[v1.0.0] may timeout'
+            })
+
+            const handler = client.lambdaHandler(function (_event, _context, callback) {
+                setTimeout(function () {
+                    callback(null, { body: 'should resolve', statusCode: 200 })
+                }, REMAINING_TIME_MS / 2)
+            }) as SyncHandler<APIGatewayProxyEvent, APIGatewayProxyResult>
+
+            return new Promise<void>((resolve) => {
+                const handlerCalledAt = Date.now()
+                let handlerResolvedAt: number
+                handler(mockAwsEvent(), mockAwsContext(mockAwsContext({
+                    functionName: 'serverlessFunction',
+                    functionVersion: 'v1.0.0',
+                    getRemainingTimeInMillis: () => REMAINING_TIME_MS
+                })), (_err, _res) => {
+                    handlerResolvedAt = Date.now()
+                })
+                setTimeout(() => {
+                    expect(handlerResolvedAt).toBeGreaterThan(handlerCalledAt)
+                    expect(noticeSentAt).toBeUndefined()
+                    expect(api.isDone()).toEqual(false)
+                    resolve()
+                }, SHOULD_BE_CALLED_AFTER_MS + 150)
             })
         })
     })

--- a/test/unit/server/aws_lambda.server.test.ts
+++ b/test/unit/server/aws_lambda.server.test.ts
@@ -172,7 +172,7 @@ describe('Lambda Handler', function () {
             let noticeSentAt: number
             const api = initNock(1, (body) => {
                 noticeSentAt = Date.now()
-                return body.error.message === 'serverlessFunction[v1.0.0] may timeout'
+                return body.error.message === 'serverlessFunction[v1.0.0] may have timed out'
             })
             const handler = client.lambdaHandler(async function (_event) {
                 return new Promise<APIGatewayProxyResult>((resolve, _reject) => {
@@ -220,7 +220,7 @@ describe('Lambda Handler', function () {
             let noticeSentAt: number
             const api = initNock(1, (body) => {
                 noticeSentAt = Date.now()
-                return body.error.message === 'serverlessFunction[v1.0.0] may timeout'
+                return body.error.message === 'serverlessFunction[v1.0.0] may have timed out'
             })
             const handler = client.lambdaHandler(async function (_event) {
                 return new Promise<APIGatewayProxyResult>((resolve, _reject) => {
@@ -299,7 +299,7 @@ describe('Lambda Handler', function () {
             let noticeSentAt: number
             const api = initNock(1, (body) => {
                 noticeSentAt = Date.now()
-                return body.error.message === 'serverlessFunction[v1.0.0] may timeout'
+                return body.error.message === 'serverlessFunction[v1.0.0] may have timed out'
             })
             const handler = client.lambdaHandler(async function (_event) {
                 return new Promise<APIGatewayProxyResult>((resolve, _reject) => {
@@ -447,7 +447,7 @@ describe('Lambda Handler', function () {
             let noticeSentAt: number
             const api = initNock(1, (body) => {
                 noticeSentAt = Date.now()
-                return body.error.message === 'serverlessFunction[v1.0.0] may timeout'
+                return body.error.message === 'serverlessFunction[v1.0.0] may have timed out'
             })
 
             const handler = client.lambdaHandler(function (_event, _context, callback) {
@@ -491,7 +491,7 @@ describe('Lambda Handler', function () {
             let noticeSentAt: number
             const api = initNock(1, (body) => {
                 noticeSentAt = Date.now()
-                return body.error.message === 'serverlessFunction[v1.0.0] may timeout'
+                return body.error.message === 'serverlessFunction[v1.0.0] may have timed out'
             })
 
             const handler = client.lambdaHandler(function (_event, _context, callback) {
@@ -564,7 +564,7 @@ describe('Lambda Handler', function () {
             let noticeSentAt: number
             const api = initNock(1, (body) => {
                 noticeSentAt = Date.now()
-                return body.error.message === 'serverlessFunction[v1.0.0] may timeout'
+                return body.error.message === 'serverlessFunction[v1.0.0] may have timed out'
             })
 
             const handler = client.lambdaHandler(function (_event, _context, callback) {


### PR DESCRIPTION
## Status
**READY**

## Description
Fixes #679
Report to Honeybadger if AWS lambda function may possibly timeout.

## Todos
- [x] Create `ServerlessConfig` for `reportTimeoutWarning` and `timeoutWarningThresholdMs`
- [x] Send timeout warning for callback-based functions
- [x] Send timeout warning for async functions
- [x] Tests
- [x] Manual Tests
- [x] [Documentation](https://github.com/honeybadger-io/docs/pull/171)
- [x] Changelog Entry (unreleased)
