### PR TITLE
Improve typings for optional deps

### DIFF
--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -1,5 +1,5 @@
 import Client from './client'
-import { AsyncLocalStorage } from 'async_hooks';
+import type { AsyncLocalStorage } from 'async_hooks';
 
 export interface Logger {
   log(...args: unknown[]): unknown

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -1,4 +1,5 @@
 import Client from './client'
+/** @ts-ignore */
 import type { AsyncLocalStorage } from 'async_hooks';
 
 export interface Logger {

--- a/src/server/aws_lambda.ts
+++ b/src/server/aws_lambda.ts
@@ -1,8 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import Honeybadger from '../core/client'
-// @ts-ignore
-// eslint-disable-next-line import/no-unresolved
-import { Handler, Callback, Context } from 'aws-lambda'
+import type { Handler, Callback, Context } from 'aws-lambda'
 import { AsyncStore } from './async_store';
 import { ServerlessConfig } from '../core/types';
 

--- a/src/server/aws_lambda.ts
+++ b/src/server/aws_lambda.ts
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import Honeybadger from '../core/client'
+/** @ts-ignore */
 import type { Handler, Callback, Context } from 'aws-lambda'
 import { AsyncStore } from './async_store';
 import { ServerlessConfig } from '../core/types';


### PR DESCRIPTION
## Status
**READY**

## Description
Our d.ts files import types for `node v14` and `aws-lambda`. These deps are optional and this PR makes sure they don't cause type errors when Honeybadger is used with Typescript.

More on `ts-ignore` [here](https://github.com/microsoft/TypeScript/issues/29866#issuecomment-715140696).
More on `import type` [here](https://stackoverflow.com/a/63905376).
