### PR TITLE
fix: make sure shipjs workflows do not modify package-lock.json

### DIFF
--- a/.github/workflows/shipjs-manual-prepare.yml
+++ b/.github/workflows/shipjs-manual-prepare.yml
@@ -21,7 +21,7 @@ jobs:
           if [ -f "yarn.lock" ]; then
             yarn install
           else
-            npm install
+            npm ci
           fi
       - run: |
           git config --global user.email "github-actions[bot]@users.noreply.github.com"

--- a/.github/workflows/shipjs-schedule-prepare.yml
+++ b/.github/workflows/shipjs-schedule-prepare.yml
@@ -18,7 +18,7 @@ jobs:
           if [ -f "yarn.lock" ]; then
             yarn install
           else
-            npm install
+            npm ci
           fi
       - run: |
           git config --global user.email "github-actions[bot]@users.noreply.github.com"

--- a/.github/workflows/shipjs-trigger.yml
+++ b/.github/workflows/shipjs-trigger.yml
@@ -23,7 +23,7 @@ jobs:
           if [ -f "yarn.lock" ]; then
             yarn install
           else
-            npm install
+            npm ci
           fi
       - run: npx shipjs trigger
         env:

--- a/package-lock.json
+++ b/package-lock.json
@@ -17007,7 +17007,8 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-1.0.4.tgz",
       "integrity": "sha512-mLUsMkgP7K/cnFEw07kWqXGF5LKrOkD+lhCrKvPHXWDywAwuDUeDwWBpc69XK3pNX0uKiVt8g5z96PJ6z9xCFA==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "@octokit/plugin-rest-endpoint-methods": {
       "version": "3.17.0",
@@ -17768,7 +17769,8 @@
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "acorn-walk": {
       "version": "7.2.0",
@@ -19697,7 +19699,8 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-6.0.0.tgz",
       "integrity": "sha512-7GPezalm5Bfi/E22PnQxDWH2iW9GTvAlUNTztemeHb6c1BniSyoeTrM87JkC0wYdi6aQrZX9p2qEiAno8aTcbw==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "eslint-rule-docs": {
       "version": "1.1.231",
@@ -22732,7 +22735,8 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.2.tgz",
       "integrity": "sha512-olV41bKSMm8BdnuMsewT4jqlZ8+3TCARAXjZGT9jcoSnrfUnRCqnMoF9XEeoWjbzObpqF9dRhHQj0Xb9QdF6/w==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "jest-regex-util": {
       "version": "27.4.0",
@@ -26482,7 +26486,8 @@
       "version": "7.5.6",
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.6.tgz",
       "integrity": "sha512-6GLgCqo2cy2A2rjCNFlxQS6ZljG/coZfZXclldI8FB/1G3CCI36Zd8xy2HrFVACi8tfk5XrgLQEk+P0Tnz9UcA==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "xml-name-validator": {
       "version": "3.0.0",


### PR DESCRIPTION
[Last shipjs prepare](https://github.com/honeybadger-io/honeybadger-js/runs/6394578790?check_suite_focus=true) failed because working tree was not empty. I suspect it's because `npm install` modified the `package-lock.json` file. We won't have this problem with `npm ci`.