### PR TITLE
fix: make sure file is bundled with rollup

### DIFF
--- a/src/server/async_store.ts
+++ b/src/server/async_store.ts
@@ -1,4 +1,5 @@
 import { BreadcrumbRecord, HoneybadgerStore } from '../core/types'
+import { GlobalStore } from '../core/store';
 
 let Store: HoneybadgerStore<{ context: Record<string, unknown>; breadcrumbs: BreadcrumbRecord[]; }>
 try {
@@ -7,9 +8,7 @@ try {
   Store = new AsyncLocalStorage()
 }
 catch (e) {
-  // eslint-disable-next-line @typescript-eslint/no-var-requires
-  const { GlobalStore } = require('../core/store')
-  Store = new GlobalStore()
+  Store = new GlobalStore({ context: {}, breadcrumbs: [] })
 }
 
 export const AsyncStore = Store


### PR DESCRIPTION
## Status
**READY**

## Description
I was trying to fix honeybadger-react issues with v4.0.1 and v4.0.2. The latest issue is seen [here](https://github.com/honeybadger-io/honeybadger-react/runs/6458315730?check_suite_focus=true):
- The rollup bundle does not include the `core/store.js` because it didn't see the require statement hidden inside the catch block.
