### PR TITLE
chore: skip shipjs release if there are no changes

### DIFF
--- a/ship.config.js
+++ b/ship.config.js
@@ -1,4 +1,11 @@
 module.exports = {
+  shouldPrepare: ({ releaseType, commitNumbersPerType }) => {
+    const { fix = 0 } = commitNumbersPerType;
+    if (releaseType === 'patch' && fix === 0) {
+      return false;
+    }
+    return true;
+  },
   publishCommand: ({ defaultCommand, tag }) =>
     `${defaultCommand} --access public --tag ${tag}`,
   afterPublish: ({ exec }) => {


### PR DESCRIPTION
Fixes #799

## Status
**READY**

## Description
Does not prepare a release if there are no changes.
