### PR TITLE
chore: `notice.causes` refactor

### DIFF
--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -322,7 +322,6 @@ export abstract class Client {
       action: notice.action || this.config.action,
       revision: notice.revision || this.config.revision,
       tags: uniqueTags,
-      causes: getCauses(notice),
     })
 
     let backtraceShift = 0
@@ -389,7 +388,7 @@ export abstract class Client {
         backtrace: notice.backtrace,
         fingerprint: notice.fingerprint,
         tags: notice.tags,
-        causes: notice.causes,
+        causes: getCauses(notice),
       },
       request: {
         url: filterUrl(notice.url, this.config.filters),

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -75,7 +75,6 @@ export interface Notice {
   __breadcrumbs: BreadcrumbRecord[],
   afterNotify?: AfterNotifyHandler,
   cause?: Error|Record<string, unknown>,
-  causes: Array<{class: string, message: string, backtrace: BacktraceFrame[]}>,
   [key: string]: unknown
 }
 
@@ -142,7 +141,8 @@ export type NoticeTransportPayload = {
     enabled: boolean,
     trail: BreadcrumbRecord[]
   },
-  error: Pick<Notice, 'message' | 'backtrace' | 'fingerprint' | 'tags' | 'causes'> & {
+  error: Pick<Notice, 'message' | 'backtrace' | 'fingerprint' | 'tags'> & {
+    causes: Array<{class: string, message: string, backtrace: BacktraceFrame[]}>,
     class: string,
   },
   request: Pick<Notice, 'url' | 'component' | 'action' | 'context' | 'params' | 'session'> & {


### PR DESCRIPTION
## Status
**READY**

## Description
Refactor `notice.causes` outside the `Notice` type, since it's only used when sending the payload to Honeybadger.

## Todos
- [x] Tests
