### PR TITLE
fix: improve type definition for GlobalStore

### DIFF
--- a/packages/core/package-lock.json
+++ b/packages/core/package-lock.json
@@ -15,7 +15,7 @@
         "@types/aws-lambda": "^8.10.89",
         "@types/express": "^4.17.13",
         "@types/jest": "^27.0.3",
-        "@types/node": "^12.20.46",
+        "@types/node": "^17.0.45",
         "jest": "^27.4.4",
         "sinon": "^14.0.0",
         "ts-jest": "^27.1.5",
@@ -1080,9 +1080,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "12.20.55",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.55.tgz",
-      "integrity": "sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==",
+      "version": "17.0.45",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.45.tgz",
+      "integrity": "sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw==",
       "dev": true
     },
     "node_modules/@types/prettier": {
@@ -5200,9 +5200,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "12.20.55",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.55.tgz",
-      "integrity": "sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==",
+      "version": "17.0.45",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.45.tgz",
+      "integrity": "sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw==",
       "dev": true
     },
     "@types/prettier": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -38,7 +38,7 @@
     "@types/aws-lambda": "^8.10.89",
     "@types/express": "^4.17.13",
     "@types/jest": "^27.0.3",
-    "@types/node": "^12.20.46",
+    "@types/node": "^17.0.45",
     "jest": "^27.4.4",
     "sinon": "^14.0.0",
     "ts-jest": "^27.1.5",

--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -11,7 +11,7 @@ export class GlobalStore<T> implements HoneybadgerStore<T> {
     return this.store
   }
 
-  run<R, TArgs extends never[]>(store: T, callback: (...args: TArgs) => R, ...args: TArgs): R {
+  run<R, TArgs extends unknown[]>(store: T, callback: (...args: TArgs) => R, ...args: TArgs): R {
     this.store = store;
     return callback(...args);
   }

--- a/packages/js/package-lock.json
+++ b/packages/js/package-lock.json
@@ -15,7 +15,7 @@
         "@types/aws-lambda": "^8.10.89",
         "@types/express": "^4.17.13",
         "@types/jest": "^27.0.3",
-        "@types/node": "^12.20.46",
+        "@types/node": "^17.0.45",
         "express": "^4.17.1",
         "jest": "^27.4.4",
         "nock": "^13.2.1",
@@ -1306,9 +1306,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "12.20.55",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.55.tgz",
-      "integrity": "sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==",
+      "version": "17.0.45",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.45.tgz",
+      "integrity": "sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw==",
       "dev": true
     },
     "node_modules/@types/normalize-package-data": {
@@ -7291,9 +7291,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "12.20.55",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.55.tgz",
-      "integrity": "sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==",
+      "version": "17.0.45",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.45.tgz",
+      "integrity": "sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw==",
       "dev": true
     },
     "@types/normalize-package-data": {

--- a/packages/js/package.json
+++ b/packages/js/package.json
@@ -59,7 +59,7 @@
     "@types/aws-lambda": "^8.10.89",
     "@types/express": "^4.17.13",
     "@types/jest": "^27.0.3",
-    "@types/node": "^12.20.46",
+    "@types/node": "^17.0.45",
     "express": "^4.17.1",
     "jest": "^27.4.4",
     "nock": "^13.2.1",


### PR DESCRIPTION
## Status
**READY**

## Description
Updates the type definition of `GlobalStore` to work with the latest version of node typings.
Discussed on [slack](https://honeybadger.slack.com/archives/C7ET3UGD6/p1660838115322689).
