### PR TITLE
feat: rework store API

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,4 +1,4 @@
 export { Client } from './client'
-export * as Store from './store'
+export * from './store'
 export * as Types from './types'
 export * as Util from './util'

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1,5 +1,4 @@
 import { Client } from './client'
-import type { AsyncLocalStorage } from 'async_hooks';
 
 export interface Logger {
   log(...args: unknown[]): unknown
@@ -163,5 +162,29 @@ export interface Transport {
   send(options: TransportOptions, payload?: NoticeTransportPayload | undefined): Promise<{ statusCode: number; body: string; }>
 }
 
-export type HoneybadgerStore<T> = Pick<AsyncLocalStorage<T>, 'getStore' | 'run'>
-export type DefaultStoreContents = {context: Record<string, unknown>, breadcrumbs: BreadcrumbRecord[]}
+export interface HoneybadgerStore {
+  /**
+   * Is the store available for writing and reading?
+   */
+  available(): boolean
+
+  /**
+   * With no arguments, returns a copy of the store contents for reading.
+   * When a key is supplied, returns the value of that key in the store.
+   */
+  getContents(): StoreContents
+  getContents<K extends keyof StoreContents>(key: K): StoreContents[K]
+
+  setContext(context: Record<string, unknown>): void
+
+  addBreadcrumb(breadcrumb: BreadcrumbRecord): void
+
+  clear(): void
+
+  run<R>(callback: () => R, ...opts: unknown[]): R
+}
+
+export type StoreContents = {
+  context: Record<string, unknown>,
+  breadcrumbs: BreadcrumbRecord[]
+}

--- a/packages/core/test/client.test.ts
+++ b/packages/core/test/client.test.ts
@@ -47,7 +47,7 @@ describe('client', function () {
   })
 
   it('has a context object', function () {
-    expect(client.getContext()).toEqual({})
+    expect(client.__getContext()).toEqual({})
   })
 
   describe('setContext', function () {
@@ -58,8 +58,7 @@ describe('client', function () {
         foo: 'bar'
       })
 
-      expect(client.getContext().user_id).toEqual('1')
-      expect(client.getContext().foo).toEqual('bar')
+      expect(client.__getContext()).toEqual({ user_id: '1', foo: 'bar' })
     })
 
     it('is chainable', function () {
@@ -70,7 +69,7 @@ describe('client', function () {
 
     it('does not accept non-objects', function () {
       client.setContext(<never>'foo')
-      expect(client.getContext()).toEqual({})
+      expect(client.__getContext()).toEqual({})
     })
 
     it('keeps previous context when called with non-object', function () {
@@ -78,7 +77,7 @@ describe('client', function () {
         foo: 'bar'
       }).setContext(<never>false)
 
-      expect(client.getContext()).toEqual({
+      expect(client.__getContext()).toEqual({
         foo: 'bar'
       })
     })
@@ -91,13 +90,13 @@ describe('client', function () {
         user_id: '1'
       })
 
-      expect(client.getContext()).not.toEqual({})
-      expect(client.getBreadcrumbs()).not.toEqual([])
+      expect(client.__getContext()).not.toEqual({})
+      expect(client.__getBreadcrumbs()).not.toEqual([])
 
       client.clear()
 
-      expect(client.getContext()).toEqual({})
-      expect(client.getBreadcrumbs()).toEqual([])
+      expect(client.__getContext()).toEqual({})
+      expect(client.__getBreadcrumbs()).toEqual([])
     })
   })
 
@@ -107,7 +106,7 @@ describe('client', function () {
         user_id: '1'
       }).resetContext()
 
-      expect(client.getContext()).toEqual({})
+      expect(client.__getContext()).toEqual({})
     })
 
     it('replaces the context with arguments', function () {
@@ -117,7 +116,7 @@ describe('client', function () {
         foo: 'bar'
       })
 
-      expect(client.getContext()).toEqual({
+      expect(client.__getContext()).toEqual({
         foo: 'bar'
       })
     })
@@ -127,7 +126,7 @@ describe('client', function () {
         foo: 'bar'
       }).resetContext(<never>'foo')
 
-      expect(client.getContext()).toEqual({})
+      expect(client.__getContext()).toEqual({})
     })
 
     it('is chainable', function () {
@@ -706,15 +705,15 @@ describe('client', function () {
 
   describe('addBreadcrumb', function () {
     it('has default breadcrumbs', function () {
-      expect(client.getBreadcrumbs()).toEqual([])
+      expect(client.__getBreadcrumbs()).toEqual([])
     })
 
     it('adds a breadcrumb with defaults', function () {
       client.addBreadcrumb('expected message')
 
-      expect(client.getBreadcrumbs().length).toEqual(1)
+      expect(client.__getBreadcrumbs().length).toEqual(1)
 
-      const crumb = client.getBreadcrumbs()[0]
+      const crumb = client.__getBreadcrumbs()[0]
 
       expect(crumb.message).toEqual('expected message')
       expect(crumb.category).toEqual('custom')
@@ -727,8 +726,8 @@ describe('client', function () {
         category: 'test'
       })
 
-      expect(client.getBreadcrumbs().length).toEqual(1)
-      expect(client.getBreadcrumbs()[0].category).toEqual('test')
+      expect(client.__getBreadcrumbs().length).toEqual(1)
+      expect(client.__getBreadcrumbs()[0].category).toEqual('test')
     })
 
     it('overrides the default metadata', function () {
@@ -738,8 +737,8 @@ describe('client', function () {
         }
       })
 
-      expect(client.getBreadcrumbs().length).toEqual(1)
-      expect(client.getBreadcrumbs()[0].metadata).toEqual({
+      expect(client.__getBreadcrumbs().length).toEqual(1)
+      expect(client.__getBreadcrumbs()[0].metadata).toEqual({
         key: 'expected value'
       })
     })
@@ -755,9 +754,9 @@ describe('client', function () {
         metadata: metadata
       })
 
-      expect(client.getBreadcrumbs().length).toEqual(2)
-      expect(client.getBreadcrumbs()[0].metadata).toEqual(client.getBreadcrumbs()[1].metadata)
-      expect(client.getBreadcrumbs()[0].metadata).not.toBe(client.getBreadcrumbs()[1].metadata)
+      expect(client.__getBreadcrumbs().length).toEqual(2)
+      expect(client.__getBreadcrumbs()[0].metadata).toEqual(client.__getBreadcrumbs()[1].metadata)
+      expect(client.__getBreadcrumbs()[0].metadata).not.toBe(client.__getBreadcrumbs()[1].metadata)
     })
 
     it('maintains the size of the breadcrumbs queue', function () {
@@ -765,10 +764,10 @@ describe('client', function () {
         client.addBreadcrumb('expected message ' + i)
       }
 
-      expect(client.getBreadcrumbs().length).toEqual(40)
+      expect(client.__getBreadcrumbs().length).toEqual(40)
 
-      expect(client.getBreadcrumbs()[0].message).toEqual('expected message 6')
-      expect(client.getBreadcrumbs()[39].message).toEqual('expected message 45')
+      expect(client.__getBreadcrumbs()[0].message).toEqual('expected message 6')
+      expect(client.__getBreadcrumbs()[39].message).toEqual('expected message 45')
     })
 
     it('sends breadcrumbs by default', function () {

--- a/packages/core/test/helpers.ts
+++ b/packages/core/test/helpers.ts
@@ -31,14 +31,6 @@ export class TestClient extends BaseClient {
     super(opts, transport);
   }
 
-  public getContext() {
-    return this.__store.getStore().context
-  }
-
-  public getBreadcrumbs() {
-    return this.__store.getStore().breadcrumbs
-  }
-
   public getPayload(noticeable: Noticeable, name: string | Partial<Notice> = undefined, extra: Partial<Notice> = undefined) {
     // called in client.notify()
     const notice = this.makeNotice(noticeable, name, extra)
@@ -52,7 +44,7 @@ export class TestClient extends BaseClient {
       }
     })
 
-    notice.__breadcrumbs = this.config.breadcrumbsEnabled ? this.getBreadcrumbs().slice() : []
+    notice.__breadcrumbs = this.config.breadcrumbsEnabled ? this.__getBreadcrumbs() : []
 
     // called in (server|browser).__send()
     return this.__buildPayload(notice)

--- a/packages/js/src/server/async_store.ts
+++ b/packages/js/src/server/async_store.ts
@@ -1,13 +1,86 @@
-import { Types, Store as StoreModule } from '@honeybadger-io/core'
+import { Types } from '@honeybadger-io/core';
+import { AsyncLocalStorage } from 'async_hooks';
 
-let Store: Types.HoneybadgerStore<{ context: Record<string, unknown>; breadcrumbs: Types.BreadcrumbRecord[]; }>
-try {
-  // eslint-disable-next-line @typescript-eslint/no-var-requires
-  const { AsyncLocalStorage } = require('async_hooks')
-  Store = new AsyncLocalStorage()
-}
-catch (e) {
-  Store = new StoreModule.GlobalStore({ context: {}, breadcrumbs: [] })
-}
+const kHoneybadgerStore = Symbol.for('kHoneybadgerStore');
 
-export const AsyncStore = Store
+export class AsyncStore implements Types.HoneybadgerStore {
+  private als: AsyncLocalStorage<Types.StoreContents>;
+  private readonly contents: Types.StoreContents;
+  private readonly breadcrumbsLimit: number;
+
+  constructor(
+    asyncLocalStorage: AsyncLocalStorage<Types.StoreContents>,
+    contents: Types.StoreContents, breadcrumbsLimit: number
+  ) {
+    this.als = asyncLocalStorage;
+    this.contents = contents;
+    this.breadcrumbsLimit = breadcrumbsLimit;
+  }
+
+  /**
+   * Attempt to create a new AsyncStore instance
+   */
+  static create(contents: Types.StoreContents, breadcrumbsLimit: number): AsyncStore|null {
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-var-requires
+      const { AsyncLocalStorage } = require('async_hooks');
+      return new AsyncStore(new AsyncLocalStorage, contents, breadcrumbsLimit);
+    } catch (e) {
+      return null
+    }
+  }
+
+  /**
+   * This returns the live store object, so we can mutate it.
+   * If we're in an async context (a `run()` callback), the stored contents at this point will be returned.
+   * Otherwise, the initial stored contents will be returned.
+   */
+  __currentContents() {
+    return this.als.getStore() || this.contents
+  }
+
+  getContents(key?: keyof Types.StoreContents) {
+    const value = key ? this.__currentContents()[key] : this.__currentContents();
+    return JSON.parse(JSON.stringify(value));
+  }
+
+  available() {
+    return !!this.als.getStore()
+  }
+
+  setContext(context: Record<string, unknown>): void {
+    Object.assign(this.__currentContents().context, context || {});
+  }
+
+  addBreadcrumb(breadcrumb) {
+    if (this.__currentContents().breadcrumbs.length == this.breadcrumbsLimit) {
+      this.__currentContents().breadcrumbs.shift()
+    }
+    this.__currentContents().breadcrumbs.push(breadcrumb);
+  }
+
+  clear() {
+    this.__currentContents().context = {}
+    this.__currentContents().breadcrumbs = []
+  }
+
+  run<R>(callback: () => R, request?: Record<symbol, unknown>): R {
+    // When entering an async context, we pass in *a copy* of the initial contents.
+    // This allows every request to start from the same state
+    // and add data specific to them, without overlapping.
+
+    if (!request) {
+      return this.als.run(this.getContents(), callback);
+    }
+
+    let contents: Types.StoreContents;
+    if (request[kHoneybadgerStore]) {
+      contents = request[kHoneybadgerStore] as Types.StoreContents
+    } else {
+      contents = this.getContents();
+      request[kHoneybadgerStore] = contents;
+    }
+
+    return this.als.run(contents, callback);
+  }
+}

--- a/packages/js/src/server/stacked_store.ts
+++ b/packages/js/src/server/stacked_store.ts
@@ -1,0 +1,51 @@
+import { GlobalStore, Types } from '@honeybadger-io/core';
+import { AsyncStore } from './async_store';
+
+/**
+ * A store that's really a "stack" of stores (async and global)
+ * Will proxy calls to the async store if it's active (ie when we enter an async context via `ALS.run()`),
+ * otherwise it will fall back to the global store.
+ * Both stores in the stack start out with the same contents object.
+ * Note that the asyncStore may be null if ALS is not supported.
+ */
+export class StackedStore implements Types.HoneybadgerStore {
+  private readonly contents: Types.StoreContents
+  private readonly asyncStore: AsyncStore|null
+  private readonly globalStore: GlobalStore
+
+  constructor(breadcrumbsLimit: number) {
+    this.contents = { context: {}, breadcrumbs: [] };
+    this.asyncStore = AsyncStore.create(this.contents, breadcrumbsLimit);
+    this.globalStore = GlobalStore.create(this.contents, breadcrumbsLimit);
+  }
+
+  __activeStore() {
+    return this.asyncStore?.available() ? this.asyncStore : this.globalStore
+  }
+
+  available() {
+    return true;
+  }
+
+  // @ts-ignore
+  getContents(key?: keyof Types.StoreContents) {
+    return this.__activeStore().getContents(key);
+  }
+
+  setContext(context) {
+    this.__activeStore().setContext(context);
+  }
+
+  addBreadcrumb(breadcrumb) {
+    this.__activeStore().addBreadcrumb(breadcrumb)
+  }
+
+  clear() {
+    this.__activeStore().clear();
+  }
+
+  run<R>(callback: () => R, request?: Record<symbol, unknown>): R {
+    // We explicitly favour the async store here, if ALS is supported. It's the whole point of the `run()` method
+    return this.asyncStore ? this.asyncStore.run(callback, request) : this.globalStore.run(callback);
+  }
+}

--- a/packages/js/test/unit/helpers.ts
+++ b/packages/js/test/unit/helpers.ts
@@ -31,14 +31,6 @@ export class TestClient extends BaseClient {
     super(opts, transport);
   }
 
-  public getContext() {
-    return this.__store.getStore().context
-  }
-
-  public getBreadcrumbs() {
-    return this.__store.getStore().breadcrumbs
-  }
-
   public getPayload(noticeable: Types.Noticeable, name: string | Partial<Types.Notice> = undefined, extra: Partial<Types.Notice> = undefined) {
     // called in client.notify()
     const notice = this.makeNotice(noticeable, name, extra)
@@ -52,7 +44,7 @@ export class TestClient extends BaseClient {
       }
     })
 
-    notice.__breadcrumbs = this.config.breadcrumbsEnabled ? this.getBreadcrumbs().slice() : []
+    notice.__breadcrumbs = this.config.breadcrumbsEnabled ? this.__getBreadcrumbs() : []
 
     // called in (server|browser).__send()
     return this.__buildPayload(notice)


### PR DESCRIPTION
Rework of https://github.com/honeybadger-io/honeybadger-js/pull/845, which should probably fix #905.

Going with @subzero10 's suggestion (thanks!), I've reworked the store API.
- No more singletons
- The store API is no longer just an extension of/workaround for AsyncLocalStorage, but an expression of where the Honeybadger client stores context and breadcrumbs. This means there's now a full-fledged Store interface:

```ts
interface HoneybadgerStore {
  available(): boolean
  getContents(): StoreContents
  getContents<K extends keyof StoreContents>(key: K): StoreContents[K]
  setContext(context: Record<string, unknown>): void
  addBreadcrumb(breadcrumb: BreadcrumbRecord): void
  clear(): void
  run<R>(callback: () => R, ...opts: unknown[]): R
}
```
This gives us better encapsulation. Previously, the client would manually mutate the store's contents; now, it can just call`addBreadcrumb()`, `setContext()`, etc, and the store can figure out what to do. It also allows us to get rid of methods like `__setStore()` and `__getStoreContentsOrDefault()`, which, tbh, were hacks. Plus we can avoid mutability traps by having the store return copies to the client.

- The `core` package includes only the GlobalStore, as before.
- The `js` package comes with two extra stores, `AsyncStore` and `StackedStore`. `AsyncStore` retains the old ALS approach, while `StackedStore` is a wrapper that combines the two stores, using ALS if available, otherwise falling back to global store.

(Oh, there is one singleton—the `contents` object is shared by all three stores. I left it this way so that we don't need to manually "combine" stores. You can add stuff to the global store and then when you enter an async context, it is initialised with a copy of the AsyncStore's `contents`, which is the same as the global one's. Might change it later if it leads to problems, but I found it cleaner this way, as the async store doesn't need to know about the existence of a global store.)