### PR TITLE
fix: remove unneeded dependencies

### DIFF
--- a/packages/js/package.json
+++ b/packages/js/package.json
@@ -50,8 +50,7 @@
     "postpublish": "./scripts/release-cdn.sh"
   },
   "dependencies": {
-    "@honeybadger-io/core": "^4.3.0",
-    "@types/aws-lambda": "^8.10.89"
+    "@honeybadger-io/core": "^4.3.0"
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "^22.0.1",

--- a/packages/js/package.json
+++ b/packages/js/package.json
@@ -57,7 +57,6 @@
     "@rollup/plugin-commonjs": "^22.0.1",
     "@rollup/plugin-node-resolve": "^13.3.0",
     "@rollup/plugin-replace": "^4.0.0",
-    "@types/express": "^4.17.13",
     "@types/jest": "^27.0.3",
     "@types/node": "^17.0.45",
     "express": "^4.17.1",

--- a/packages/js/src/server/async_store.ts
+++ b/packages/js/src/server/async_store.ts
@@ -1,5 +1,5 @@
 import { Types } from '@honeybadger-io/core';
-import { AsyncLocalStorage } from 'async_hooks';
+import type { AsyncLocalStorage } from 'async_hooks';
 
 const kHoneybadgerStore = Symbol.for('kHoneybadgerStore');
 

--- a/packages/js/src/server/middleware.ts
+++ b/packages/js/src/server/middleware.ts
@@ -1,8 +1,21 @@
-import url from 'url'
-import { NextFunction, Request, Response } from 'express'
+import url from 'node:url'
+import http from 'node:http'
 import { Types } from '@honeybadger-io/core'
 
-function fullUrl(req: Request): string {
+type ExpressNextFunction = (err?: unknown) => unknown
+interface ExpressRequest extends http.IncomingMessage {
+  body: unknown;
+  query: unknown;
+  protocol: string;
+  path: string;
+  hostname: string;
+  [x: string]: unknown;
+}
+interface ExpressResponse extends http.ServerResponse {
+  [x: string]: unknown;
+}
+
+function fullUrl(req: ExpressRequest): string {
   const connection = req.connection
   const address = connection && connection.address()
   // @ts-ignore The old @types/node incorrectly defines `address` as string|Address
@@ -18,11 +31,11 @@ function fullUrl(req: Request): string {
   })
 }
 
-export function requestHandler(req: Request, res: Response, next: NextFunction): void {
+export function requestHandler(req: ExpressRequest, res: ExpressResponse, next: ExpressNextFunction): void {
   this.withRequest(req, next, next)
 }
 
-export function errorHandler(err: Types.Noticeable, req: Request, _res: Response, next: NextFunction): unknown {
+export function errorHandler(err: Types.Noticeable, req: ExpressRequest, _res: ExpressResponse, next: ExpressNextFunction): unknown {
   this.notify(err, {
     url:     fullUrl(req),
     params:  req.body,    // http://expressjs.com/en/api.html#req.body


### PR DESCRIPTION
Removes our dependency on `@types/express`, fixing #907. (Also removed `@types/aws_lambda`.( Inlined the types directly; we don't really need the in-depth type info, since we aren't the end user.