### PR TITLE
fix: README.md misleading dev to use wrong import code on while working with ES6 Import. 

### DIFF
--- a/packages/js/README.md
+++ b/packages/js/README.md
@@ -21,7 +21,7 @@ This project is _isomorphic_, meaning it's a single library which contains both 
 
 In addition, the TypeScript type declaration for each build is generated into its `types/` directory (ie `dist/browser/types/browser.d.ts` and `dist/server/types/server.d.ts`).
 
-However, since the package is isomorphic, TypeScript users will likely be writing `import * as Honeybadger from '@honeybadger-io/js'` or `import Honeybadger = require('@honeybadger-io/js')` in their IDE. Our `package.json` has ` main` and `browser` fields that determine which build they get, but [there can only be a single type declaration file](https://github.com/Microsoft/TypeScript/issues/29128). So we use an extra file in the project root, `honeybadger.d.ts`, that combines the types from both builds.
+However, since the package is isomorphic, TypeScript users will likely be writing `import Honeybadger from '@honeybadger-io/js'` or `import Honeybadger = require('@honeybadger-io/js')` in their IDE. Our `package.json` has ` main` and `browser` fields that determine which build they get, but [there can only be a single type declaration file](https://github.com/Microsoft/TypeScript/issues/29128). So we use an extra file in the project root, `honeybadger.d.ts`, that combines the types from both builds.
 
 ### Tests
 1. To run unit tests for both browser and server builds: `npm test`. Or separately: `npm run test:browser`, `npm run test:server`.


### PR DESCRIPTION
Context: 
`import * as HoneyBadger from '@honeybadger-io/js'` as indicated in the documentation using nodejs + TypeScript results in errors such as 'configure' is not a function.

What really works in a nodejs + TypeScript context is using:
`import HoneyBadger from '@honeybadger-io/js'`

## Status
**READY**

## Description
A Change in the README.MD file to make it clear which is the right import statement to use while using ES6 imports + TypeScript 

## Todos
- [ ] Changelog Entry (unreleased)

