### PR TITLE
fix: require correct honeybadger js package

### DIFF
--- a/packages/gatsby-plugin/gatsby-browser.js
+++ b/packages/gatsby-plugin/gatsby-browser.js
@@ -1,4 +1,4 @@
-const Honeybadger = require('honeybadger-js')
+const Honeybadger = require('@honeybadger-io/js')
 
 exports.onClientEntry = function(_, { apiKey, revision, environment = process.env.NODE_ENV }) {
   if (!apiKey) {


### PR DESCRIPTION
## Status
<!--- **READY/WIP/HOLD** --->
**READY/WIP/HOLD**

## Description
Received error - Can't resolve 'honeybadger-js' in 'node_modules/@honeybadger-io/gatsby-plugin-honeybadger'
Changed the require statement to import from `@honeybadger-io/js`

## Related PRs
List related PRs against other branches:

| branch              | PR       |
|---------------------|----------|
| other_pr_production | [link]() |
| other_pr_master     | [link]() |

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Changelog Entry (unreleased)

## Steps to Test or Reproduce
Outline the steps to test or reproduce the PR here.
```bash
> git pull --prune
> git checkout <branch>
> grunt jasmine
```
1.
