### PR TITLE
fix: exit process on unhandledRejection

### DIFF
--- a/packages/js/rollup.config.js
+++ b/packages/js/rollup.config.js
@@ -45,7 +45,8 @@ export default [
     external: ['http', 'https', 'url', 'os', 'fs', 'util', 'domain', 'async_hooks'],
     output: {
       file: pkg.main,
-      format: 'cjs'
+      format: 'cjs',
+      sourcemap: true
     },
     plugins: sharedPlugins
   }

--- a/packages/js/src/server/integrations/unhandled_rejection.ts
+++ b/packages/js/src/server/integrations/unhandled_rejection.ts
@@ -2,6 +2,8 @@ import { Types } from '@honeybadger-io/core'
 import Client from '../../server'
 import { fatallyLogAndExit } from '../util'
 
+let isReporting = false
+
 /**
  * If there are no other unhandledRejection listeners,
  * we want to report the exception to Honeybadger and
@@ -21,14 +23,16 @@ export default function (): Types.Plugin {
 
       process.on('unhandledRejection', function honeybadgerUnhandledRejectionListener(reason, _promise) {
         if (!client.config.enableUnhandledRejection) {
-          if (!hasOtherUnhandledRejectionListeners()) {
+          if (!hasOtherUnhandledRejectionListeners() && !isReporting) {
             fatallyLogAndExit(reason as Error)
           }
           return
         }
 
+        isReporting = true;
         client.notify(reason as Types.Noticeable, { component: 'unhandledRejection' }, {
           afterNotify: () => {
+            isReporting = false;
             if (!hasOtherUnhandledRejectionListeners()) {
               fatallyLogAndExit(reason as Error)
             }

--- a/packages/js/src/server/integrations/unhandled_rejection.ts
+++ b/packages/js/src/server/integrations/unhandled_rejection.ts
@@ -8,8 +8,8 @@ import { fatallyLogAndExit } from '../util'
  * mimic the default behavior of NodeJs,
  * which is to exit the process with code 1
  */
-function hasUnhandledRejectionListeners() {
-  return process.listeners('unhandledRejection').length !== 0
+function hasOtherUnhandledRejectionListeners() {
+  return process.listeners('unhandledRejection').length > 1
 }
 
 export default function (): Types.Plugin {
@@ -19,10 +19,9 @@ export default function (): Types.Plugin {
         return
       }
 
-      const hasOtherListeners = hasUnhandledRejectionListeners();
       process.on('unhandledRejection', function honeybadgerUnhandledRejectionListener(reason, _promise) {
         if (!client.config.enableUnhandledRejection) {
-          if (!hasOtherListeners) {
+          if (!hasOtherUnhandledRejectionListeners()) {
             fatallyLogAndExit(reason as Error)
           }
           return
@@ -30,7 +29,7 @@ export default function (): Types.Plugin {
 
         client.notify(reason as Types.Noticeable, { component: 'unhandledRejection' }, {
           afterNotify: () => {
-            if (!hasOtherListeners) {
+            if (!hasOtherUnhandledRejectionListeners()) {
               fatallyLogAndExit(reason as Error)
             }
           }

--- a/packages/js/src/server/integrations/unhandled_rejection.ts
+++ b/packages/js/src/server/integrations/unhandled_rejection.ts
@@ -1,14 +1,25 @@
 import { Types } from '@honeybadger-io/core'
 import Client from '../../server'
+import { fatallyLogAndExit } from '../util'
 
 export default function (): Types.Plugin {
   return {
     load: (client: typeof Client) => {
-      if (!client.config.enableUnhandledRejection) { return }
+      if (!client.config.enableUnhandledRejection) {
+        return
+      }
 
       process.on('unhandledRejection', function (reason, _promise) {
-        if (!client.config.enableUnhandledRejection) { return }
-        client.notify(reason as Types.Noticeable, { component: 'unhandledRejection' })
+        if (!client.config.enableUnhandledRejection) {
+          fatallyLogAndExit(reason as Error)
+          return
+        }
+
+        client.notify(reason as Types.Noticeable, { component: 'unhandledRejection' }, {
+          afterNotify: () => {
+            fatallyLogAndExit(reason as Error)
+          }
+        })
       })
     }
   }

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -7,6 +7,7 @@
     "noImplicitAny": false,
     "declaration": true,
     "declarationMap": true,
+    "sourceMap": true,
     "stripInternal": true,
     "skipLibCheck": true
   }


### PR DESCRIPTION
## Status
**READY**

## Description
Fixes: #946.
I wanted to write tests but it seems that jest will exit the process without calling `process.on('unhandledRejection')`.
So, I tested manually with an example project.

## Bonus
I applied similar logic to `unhandledException`s for nodejs.
