### PR TITLE
ci: ignore eslint imports in example folders

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -90,22 +90,5 @@ jobs:
       - name: Build
         run: npm ci
 
-      - name: Build Typescript example projects
-        run: |
-          cd packages/js/examples/aws-lambda-typescript
-          npm ci
-
-      - name: Install Vue examples deps
-        run: |
-          cd packages/vue/examples/vue2
-          npm ci --force
-          cd ../vue3
-          npm ci
-
-      - name: Install React Native example deps
-        run: |
-          cd packages/react-native/example
-          npm ci --force
-
       - name: Run lint checks
         run: npm run lint

--- a/packages/js/examples/.eslintrc.json
+++ b/packages/js/examples/.eslintrc.json
@@ -1,0 +1,7 @@
+{
+    "rules": {
+      // Since these are just examples, the monorepo's linting should not
+      // fail just because we didn't run `npm install` in the example folders
+        "import/no-unresolved": ["off"]
+      }
+}

--- a/packages/react-native/example/.eslintrc.json
+++ b/packages/react-native/example/.eslintrc.json
@@ -1,0 +1,7 @@
+{
+    "rules": {
+      // Since these are just examples, the monorepo's linting should not
+      // fail just because we didn't run `npm install` in the example folders
+        "import/no-unresolved": ["off"]
+      }
+}

--- a/packages/vue/examples/.eslintrc.json
+++ b/packages/vue/examples/.eslintrc.json
@@ -1,0 +1,8 @@
+{
+    "rules": {
+      // Since these are just examples, the monorepo's linting should not
+      // fail just because we didn't run `npm install` in the example folders
+        "import/no-unresolved": ["off"],
+        "import/default": ["off"]
+      }
+}


### PR DESCRIPTION
## Status
<!--- **READY/WIP/HOLD** --->
**READY**

## Description
Currently, running `npm run lint` fails locally unless you remember to install all the dependencies in each of the example folders, plus we have to install all those dependencies in CI. Since these are just the examples and not the main code, we can save time in CI and have fewer local errors during development if we selectively ignore these. 


## Steps to Test or Reproduce
Outline the steps to test or reproduce the PR here.
```bash
npm run lint
```
1. You should not see errors, even if you neglected to `cd` into each example folder and `npm install`
2. CI should succeed without having to install these extra node modules just for linting
