### PR TITLE
fix: improve generateStackTrace function to hide vue warn message

### DIFF
--- a/packages/vue/package-lock.json
+++ b/packages/vue/package-lock.json
@@ -11,7 +11,6 @@
       "devDependencies": {
         "@babel/plugin-transform-runtime": "^7.18.9",
         "@babel/preset-env": "^7.18.9",
-        "@honeybadger-io/js": "^4.8.2",
         "@vue/compiler-sfc": "^3.2.37",
         "@vue/test-utils": "^2.0.2",
         "babel-plugin-syntax-jsx": "^6.18.0",
@@ -20,6 +19,7 @@
         "eslint": "^8.20.0",
         "eslint-plugin-vue": "^9.2.0",
         "jest": "^26.6.3",
+        "jest-fetch-mock": "^3.0.3",
         "rollup": "^2.77.0",
         "rollup-plugin-buble": "^0.19.8",
         "rollup-plugin-conditional": "^3.1.2",
@@ -1812,7 +1812,7 @@
       "version": "4.8.1",
       "resolved": "https://registry.npmjs.org/@honeybadger-io/core/-/core-4.8.1.tgz",
       "integrity": "sha512-P/4pXSQfc7bzz55vifOPcCoiPUrepcPN3KFBQpGWwTzk4gDSzvmQmwa02FY+e7VEXpqpxIBbQdl3w7h+BedKqw==",
-      "dev": true,
+      "peer": true,
       "dependencies": {
         "stacktrace-parser": "^0.1.10"
       }
@@ -1821,7 +1821,7 @@
       "version": "4.8.1",
       "resolved": "https://registry.npmjs.org/@honeybadger-io/js/-/js-4.8.1.tgz",
       "integrity": "sha512-mqixvew+Zhq/ctjp24qHMxc3f5fqqkXZTQ5d9IzI5XlKwBYExrGZIfmZllMQkSNMO9M5FEFLrumkgotnmKkNnw==",
-      "dev": true,
+      "peer": true,
       "dependencies": {
         "@honeybadger-io/core": "^4.8.1",
         "@types/aws-lambda": "^8.10.89",
@@ -2709,7 +2709,7 @@
       "version": "8.10.104",
       "resolved": "https://registry.npmjs.org/@types/aws-lambda/-/aws-lambda-8.10.104.tgz",
       "integrity": "sha512-HXZJH8aBa06re9NCtFudOr21izYZycgXIVjd8vFBSNSf6Ca4GYD77TfKqwYgcDqv4olqj5KK+Ks7Xi5IXFbNGA==",
-      "dev": true
+      "peer": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.1.19",
@@ -2756,7 +2756,7 @@
       "version": "1.19.2",
       "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.2.tgz",
       "integrity": "sha512-ALYone6pm6QmwZoAgeyNksccT9Q4AWZQ6PvfwR37GT6r6FWUPguq6sUmNGSMV2Wr761oQoBxwGGa6DR5o1DC9g==",
-      "dev": true,
+      "peer": true,
       "dependencies": {
         "@types/connect": "*",
         "@types/node": "*"
@@ -2766,7 +2766,7 @@
       "version": "3.4.35",
       "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.35.tgz",
       "integrity": "sha512-cdeYyv4KWoEgpBISTxWvqYsVy444DOqehiF3fM3ne10AmJ62RSyNkUnxMJXHQWRQQX2eR94m5y1IZyDwBjV9FQ==",
-      "dev": true,
+      "peer": true,
       "dependencies": {
         "@types/node": "*"
       }
@@ -2791,7 +2791,7 @@
       "version": "4.17.14",
       "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.14.tgz",
       "integrity": "sha512-TEbt+vaPFQ+xpxFLFssxUDXj5cWCxZJjIcB7Yg0k0GMHGtgtQgpvx/MUQUeAkNbA9AAGrwkAsoeItdTgS7FMyg==",
-      "dev": true,
+      "peer": true,
       "dependencies": {
         "@types/body-parser": "*",
         "@types/express-serve-static-core": "^4.17.18",
@@ -2803,7 +2803,7 @@
       "version": "4.17.31",
       "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.31.tgz",
       "integrity": "sha512-DxMhY+NAsTwMMFHBTtJFNp5qiHKJ7TeqOo23zVEM9alT1Ml27Q3xcTH0xwxn7Q0BbMcVEJOs/7aQtUWupUQN3Q==",
-      "dev": true,
+      "peer": true,
       "dependencies": {
         "@types/node": "*",
         "@types/qs": "*",
@@ -2853,7 +2853,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-3.0.1.tgz",
       "integrity": "sha512-Y4XFY5VJAuw0FgAqPNd6NNoV44jbq9Bz2L7Rh/J6jLTiHBSBJa9fxqQIvkIld4GsoDOcCbvzOUAbLPsSKKg+uA==",
-      "dev": true
+      "peer": true
     },
     "node_modules/@types/minimist": {
       "version": "1.2.2",
@@ -2864,8 +2864,7 @@
     "node_modules/@types/node": {
       "version": "18.0.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.0.0.tgz",
-      "integrity": "sha512-cHlGmko4gWLVI27cGJntjs/Sj8th9aYwplmZFwmmgYQQvL5NUsgVJG7OddLvNfLqYS31KFN0s3qlaD9qCaxACA==",
-      "dev": true
+      "integrity": "sha512-cHlGmko4gWLVI27cGJntjs/Sj8th9aYwplmZFwmmgYQQvL5NUsgVJG7OddLvNfLqYS31KFN0s3qlaD9qCaxACA=="
     },
     "node_modules/@types/normalize-package-data": {
       "version": "2.4.1",
@@ -2883,19 +2882,19 @@
       "version": "6.9.7",
       "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.7.tgz",
       "integrity": "sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw==",
-      "dev": true
+      "peer": true
     },
     "node_modules/@types/range-parser": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.4.tgz",
       "integrity": "sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw==",
-      "dev": true
+      "peer": true
     },
     "node_modules/@types/serve-static": {
       "version": "1.15.0",
       "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.0.tgz",
       "integrity": "sha512-z5xyF6uh8CbjAu9760KDKsH2FcDxZ2tFCsA4HIMWE6IkiYMXfVoa+4f9KX+FN0ZLsaMw1WNG2ETLA6N+/YA+cg==",
-      "dev": true,
+      "peer": true,
       "dependencies": {
         "@types/mime": "*",
         "@types/node": "*"
@@ -4076,6 +4075,15 @@
       "dev": true,
       "optional": true,
       "peer": true
+    },
+    "node_modules/cross-fetch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.5.tgz",
+      "integrity": "sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==",
+      "dev": true,
+      "dependencies": {
+        "node-fetch": "2.6.7"
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
@@ -6740,6 +6748,16 @@
         "node": ">= 10.14.2"
       }
     },
+    "node_modules/jest-fetch-mock": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/jest-fetch-mock/-/jest-fetch-mock-3.0.3.tgz",
+      "integrity": "sha512-Ux1nWprtLrdrH4XwE7O7InRY6psIi3GOsqNESJgMJ+M5cv4A8Lh7SN9d2V2kKRZ8ebAfcd1LNyZguAOb6JiDqw==",
+      "dev": true,
+      "dependencies": {
+        "cross-fetch": "^3.0.4",
+        "promise-polyfill": "^8.1.3"
+      }
+    },
     "node_modules/jest-get-type": {
       "version": "26.3.0",
       "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-26.3.0.tgz",
@@ -8501,6 +8519,48 @@
         "path-to-regexp": "^1.7.0"
       }
     },
+    "node_modules/node-fetch": {
+      "version": "2.6.7",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+      "dev": true,
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/node-fetch/node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "dev": true
+    },
+    "node_modules/node-fetch/node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "dev": true
+    },
+    "node_modules/node-fetch/node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dev": true,
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
     "node_modules/node-int64": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
@@ -9133,6 +9193,12 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/promise-polyfill": {
+      "version": "8.2.3",
+      "resolved": "https://registry.npmjs.org/promise-polyfill/-/promise-polyfill-8.2.3.tgz",
+      "integrity": "sha512-Og0+jCRQetV84U8wVjMNccfGCnMQ9mGs9Hv78QFe+pSDD3gWTpz0y+1QCuxy5d/vBFuZ3iwP2eycAkvqIMPmWg==",
       "dev": true
     },
     "node_modules/prompts": {
@@ -10516,7 +10582,7 @@
       "version": "0.1.10",
       "resolved": "https://registry.npmjs.org/stacktrace-parser/-/stacktrace-parser-0.1.10.tgz",
       "integrity": "sha512-KJP1OCML99+8fhOHxwwzyWrlUuVX5GQ0ZpJTd1DFXhdkrvg1szxfHhawXUZ3g9TkXORQd4/WG68jMlQZ2p8wlg==",
-      "dev": true,
+      "peer": true,
       "dependencies": {
         "type-fest": "^0.7.1"
       },
@@ -10528,7 +10594,7 @@
       "version": "0.7.1",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.7.1.tgz",
       "integrity": "sha512-Ne2YiiGN8bmrmJJEuTWTLJR32nh/JdL1+PSicowtNb0WFpn59GK8/lfD61bVtzguz7b3PBt74nxpv/Pw5po5Rg==",
-      "dev": true,
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -12943,7 +13009,7 @@
       "version": "4.8.1",
       "resolved": "https://registry.npmjs.org/@honeybadger-io/core/-/core-4.8.1.tgz",
       "integrity": "sha512-P/4pXSQfc7bzz55vifOPcCoiPUrepcPN3KFBQpGWwTzk4gDSzvmQmwa02FY+e7VEXpqpxIBbQdl3w7h+BedKqw==",
-      "dev": true,
+      "peer": true,
       "requires": {
         "stacktrace-parser": "^0.1.10"
       }
@@ -12952,7 +13018,7 @@
       "version": "4.8.1",
       "resolved": "https://registry.npmjs.org/@honeybadger-io/js/-/js-4.8.1.tgz",
       "integrity": "sha512-mqixvew+Zhq/ctjp24qHMxc3f5fqqkXZTQ5d9IzI5XlKwBYExrGZIfmZllMQkSNMO9M5FEFLrumkgotnmKkNnw==",
-      "dev": true,
+      "peer": true,
       "requires": {
         "@honeybadger-io/core": "^4.8.1",
         "@types/aws-lambda": "^8.10.89",
@@ -13663,7 +13729,7 @@
       "version": "8.10.104",
       "resolved": "https://registry.npmjs.org/@types/aws-lambda/-/aws-lambda-8.10.104.tgz",
       "integrity": "sha512-HXZJH8aBa06re9NCtFudOr21izYZycgXIVjd8vFBSNSf6Ca4GYD77TfKqwYgcDqv4olqj5KK+Ks7Xi5IXFbNGA==",
-      "dev": true
+      "peer": true
     },
     "@types/babel__core": {
       "version": "7.1.19",
@@ -13710,7 +13776,7 @@
       "version": "1.19.2",
       "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.2.tgz",
       "integrity": "sha512-ALYone6pm6QmwZoAgeyNksccT9Q4AWZQ6PvfwR37GT6r6FWUPguq6sUmNGSMV2Wr761oQoBxwGGa6DR5o1DC9g==",
-      "dev": true,
+      "peer": true,
       "requires": {
         "@types/connect": "*",
         "@types/node": "*"
@@ -13720,7 +13786,7 @@
       "version": "3.4.35",
       "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.35.tgz",
       "integrity": "sha512-cdeYyv4KWoEgpBISTxWvqYsVy444DOqehiF3fM3ne10AmJ62RSyNkUnxMJXHQWRQQX2eR94m5y1IZyDwBjV9FQ==",
-      "dev": true,
+      "peer": true,
       "requires": {
         "@types/node": "*"
       }
@@ -13745,7 +13811,7 @@
       "version": "4.17.14",
       "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.14.tgz",
       "integrity": "sha512-TEbt+vaPFQ+xpxFLFssxUDXj5cWCxZJjIcB7Yg0k0GMHGtgtQgpvx/MUQUeAkNbA9AAGrwkAsoeItdTgS7FMyg==",
-      "dev": true,
+      "peer": true,
       "requires": {
         "@types/body-parser": "*",
         "@types/express-serve-static-core": "^4.17.18",
@@ -13757,7 +13823,7 @@
       "version": "4.17.31",
       "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.31.tgz",
       "integrity": "sha512-DxMhY+NAsTwMMFHBTtJFNp5qiHKJ7TeqOo23zVEM9alT1Ml27Q3xcTH0xwxn7Q0BbMcVEJOs/7aQtUWupUQN3Q==",
-      "dev": true,
+      "peer": true,
       "requires": {
         "@types/node": "*",
         "@types/qs": "*",
@@ -13807,7 +13873,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-3.0.1.tgz",
       "integrity": "sha512-Y4XFY5VJAuw0FgAqPNd6NNoV44jbq9Bz2L7Rh/J6jLTiHBSBJa9fxqQIvkIld4GsoDOcCbvzOUAbLPsSKKg+uA==",
-      "dev": true
+      "peer": true
     },
     "@types/minimist": {
       "version": "1.2.2",
@@ -13818,8 +13884,7 @@
     "@types/node": {
       "version": "18.0.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.0.0.tgz",
-      "integrity": "sha512-cHlGmko4gWLVI27cGJntjs/Sj8th9aYwplmZFwmmgYQQvL5NUsgVJG7OddLvNfLqYS31KFN0s3qlaD9qCaxACA==",
-      "dev": true
+      "integrity": "sha512-cHlGmko4gWLVI27cGJntjs/Sj8th9aYwplmZFwmmgYQQvL5NUsgVJG7OddLvNfLqYS31KFN0s3qlaD9qCaxACA=="
     },
     "@types/normalize-package-data": {
       "version": "2.4.1",
@@ -13837,19 +13902,19 @@
       "version": "6.9.7",
       "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.7.tgz",
       "integrity": "sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw==",
-      "dev": true
+      "peer": true
     },
     "@types/range-parser": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.4.tgz",
       "integrity": "sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw==",
-      "dev": true
+      "peer": true
     },
     "@types/serve-static": {
       "version": "1.15.0",
       "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.0.tgz",
       "integrity": "sha512-z5xyF6uh8CbjAu9760KDKsH2FcDxZ2tFCsA4HIMWE6IkiYMXfVoa+4f9KX+FN0ZLsaMw1WNG2ETLA6N+/YA+cg==",
-      "dev": true,
+      "peer": true,
       "requires": {
         "@types/mime": "*",
         "@types/node": "*"
@@ -14796,6 +14861,15 @@
       "dev": true,
       "optional": true,
       "peer": true
+    },
+    "cross-fetch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.5.tgz",
+      "integrity": "sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==",
+      "dev": true,
+      "requires": {
+        "node-fetch": "2.6.7"
+      }
     },
     "cross-spawn": {
       "version": "7.0.3",
@@ -16816,6 +16890,16 @@
         "jest-util": "^26.6.2"
       }
     },
+    "jest-fetch-mock": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/jest-fetch-mock/-/jest-fetch-mock-3.0.3.tgz",
+      "integrity": "sha512-Ux1nWprtLrdrH4XwE7O7InRY6psIi3GOsqNESJgMJ+M5cv4A8Lh7SN9d2V2kKRZ8ebAfcd1LNyZguAOb6JiDqw==",
+      "dev": true,
+      "requires": {
+        "cross-fetch": "^3.0.4",
+        "promise-polyfill": "^8.1.3"
+      }
+    },
     "jest-get-type": {
       "version": "26.3.0",
       "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-26.3.0.tgz",
@@ -18160,6 +18244,39 @@
         "path-to-regexp": "^1.7.0"
       }
     },
+    "node-fetch": {
+      "version": "2.6.7",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+      "dev": true,
+      "requires": {
+        "whatwg-url": "^5.0.0"
+      },
+      "dependencies": {
+        "tr46": {
+          "version": "0.0.3",
+          "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+          "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+          "dev": true
+        },
+        "webidl-conversions": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+          "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+          "dev": true
+        },
+        "whatwg-url": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+          "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+          "dev": true,
+          "requires": {
+            "tr46": "~0.0.3",
+            "webidl-conversions": "^3.0.0"
+          }
+        }
+      }
+    },
     "node-int64": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
@@ -18629,6 +18746,12 @@
           "dev": true
         }
       }
+    },
+    "promise-polyfill": {
+      "version": "8.2.3",
+      "resolved": "https://registry.npmjs.org/promise-polyfill/-/promise-polyfill-8.2.3.tgz",
+      "integrity": "sha512-Og0+jCRQetV84U8wVjMNccfGCnMQ9mGs9Hv78QFe+pSDD3gWTpz0y+1QCuxy5d/vBFuZ3iwP2eycAkvqIMPmWg==",
+      "dev": true
     },
     "prompts": {
       "version": "2.4.2",
@@ -19727,7 +19850,7 @@
       "version": "0.1.10",
       "resolved": "https://registry.npmjs.org/stacktrace-parser/-/stacktrace-parser-0.1.10.tgz",
       "integrity": "sha512-KJP1OCML99+8fhOHxwwzyWrlUuVX5GQ0ZpJTd1DFXhdkrvg1szxfHhawXUZ3g9TkXORQd4/WG68jMlQZ2p8wlg==",
-      "dev": true,
+      "peer": true,
       "requires": {
         "type-fest": "^0.7.1"
       },
@@ -19736,7 +19859,7 @@
           "version": "0.7.1",
           "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.7.1.tgz",
           "integrity": "sha512-Ne2YiiGN8bmrmJJEuTWTLJR32nh/JdL1+PSicowtNb0WFpn59GK8/lfD61bVtzguz7b3PBt74nxpv/Pw5po5Rg==",
-          "dev": true
+          "peer": true
         }
       }
     },

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -26,7 +26,7 @@
   ],
   "homepage": "https://github.com/honeybadger-io/honeybadger-js/tree/master/packages/vue",
   "scripts": {
-    "unit": "jest --coverage",
+    "unit": "jest --coverage --env=jsdom",
     "e2e": "node test/e2e/runner.js",
     "tsd": "npx tsd",
     "test": "npm run tsd && npm run unit",
@@ -51,6 +51,7 @@
     "eslint": "^8.20.0",
     "eslint-plugin-vue": "^9.2.0",
     "jest": "^26.6.3",
+    "jest-fetch-mock": "^3.0.3",
     "rollup": "^2.77.0",
     "rollup-plugin-buble": "^0.19.8",
     "rollup-plugin-conditional": "^3.1.2",

--- a/packages/vue/src/vue-debug.js
+++ b/packages/vue/src/vue-debug.js
@@ -1,5 +1,5 @@
 /**
- * This was taken from https://github.com/vuejs/vue/blob/master/src/core/util/debug.js.
+ * This was originally taken from https://github.com/vuejs/vue/blob/master/src/core/util/debug.js.
  * The method generateStackTrace is used to log errors the same way as Vue logs them when errorHandler is not set.
  */
 
@@ -8,15 +8,27 @@ const classify = str => str
   .replace(classifyRE, c => c.toUpperCase())
   .replace(/[-_]/g, '')
 
+const ANONYMOUS_COMPONENT = '<Anonymous>'
+const ROOT_COMPONENT = '<Root>'
+
 const formatComponentName = (vm, includeFile) => {
-  if (vm.$root === vm) {
-    return '<Root>'
+  if (!vm) {
+    return ANONYMOUS_COMPONENT
   }
-  const options = typeof vm === 'function' && vm.cid != null
-    ? vm.options
-    : vm._isVue
-      ? vm.$options || vm.constructor.options
-      : vm || {}
+
+  if (vm.$root === vm) {
+    return ROOT_COMPONENT
+  }
+
+  if (!vm.$options) {
+    return ANONYMOUS_COMPONENT
+  }
+
+  const options = vm.$options
+  if (!options) {
+    return ANONYMOUS_COMPONENT
+  }
+
   let name = options.name || options._componentTag
   const file = options.__file
   if (!name && file) {
@@ -25,7 +37,7 @@ const formatComponentName = (vm, includeFile) => {
   }
 
   return (
-    (name ? `<${classify(name)}>` : '<Anonymous>') +
+    (name ? `<${classify(name)}>` : ANONYMOUS_COMPONENT) +
     (file && includeFile !== false ? ` at ${file}` : '')
   )
 }
@@ -41,7 +53,7 @@ const repeat = (str, n) => {
 }
 
 export const generateComponentTrace = vm => {
-  if (vm._isVue && vm.$parent) {
+  if (vm && (vm.__isVue || vm._isVue) && vm.$parent) {
     const tree = []
     let currentRecursiveSequence = 0
     while (vm) {

--- a/packages/vue/src/vue-debug.js
+++ b/packages/vue/src/vue-debug.js
@@ -20,10 +20,6 @@ const formatComponentName = (vm, includeFile) => {
     return ROOT_COMPONENT
   }
 
-  if (!vm.$options) {
-    return ANONYMOUS_COMPONENT
-  }
-
   const options = vm.$options
   if (!options) {
     return ANONYMOUS_COMPONENT

--- a/packages/vue/test/unit/specs/HoneyBadgerVue.spec.js
+++ b/packages/vue/test/unit/specs/HoneyBadgerVue.spec.js
@@ -3,6 +3,7 @@ import Honeybadger from '@honeybadger-io/js'
 import Miniwolf from '../Miniwolf.vue'
 import TestCanvasForProps from '../TestCanvasForProps.vue'
 import { createSandbox } from 'sinon'
+import fetch from 'jest-fetch-mock'
 import { mount } from '@vue/test-utils'
 
 describe('HoneybadgerVue', () => {
@@ -53,13 +54,7 @@ describe('HoneybadgerVue', () => {
     // Refresh singleton state.
     // Honeybadger.reset()
 
-    // Stub HTTP requests.
-    requests = []
-    xhr = sandbox.useFakeXMLHttpRequest()
-
-    xhr.onCreate = function (xhr) {
-      return requests.push(xhr)
-    }
+    fetch.resetMocks()
   })
 
   afterEach(function () {
@@ -132,7 +127,7 @@ describe('HoneybadgerVue', () => {
   })
 
   it("should invoke Honeybadger's notify and log error in console", (done) => {
-    const wrapper = factory({}, { debug: true })
+    const wrapper = factory(Miniwolf, { debug: true })
     const app = getAppInstance(wrapper)
     sandbox.spy(app.$honeybadger, 'notify')
     const err = new Error('oops')

--- a/packages/vue/test/unit/specs/HoneyBadgerVue.spec.js
+++ b/packages/vue/test/unit/specs/HoneyBadgerVue.spec.js
@@ -7,7 +7,6 @@ import fetch from 'jest-fetch-mock'
 import { mount } from '@vue/test-utils'
 
 describe('HoneybadgerVue', () => {
-  let requests, xhr
   let sandbox
 
   const DUMMY_API_KEY = 'FFAACCCC00'


### PR DESCRIPTION
## Status
**READY**
Fixes: #996

## Description
Improves `generateStackTrace` function to hide `Vue[warn]` message about undefined property `_isVue`.

*Bonus*: adds `jest-fetch-mock` to remove some errors logged in tests
