### PR TITLE
feat(rollup): add deployment notification to Rollup plugin

### DIFF
--- a/packages/rollup-plugin/README.md
+++ b/packages/rollup-plugin/README.md
@@ -1,7 +1,7 @@
 # Honeybadger's Rollup Source Map Plugin
 
 [Rollup](https://rollupjs.org/) plugin to upload JavaScript
-sourcemaps to [Honeybadger](https://docs.honeybadger.io/lib/javascript/guides/using-source-maps/).
+sourcemaps and optionally send deployment notifications to [Honeybadger](https://docs.honeybadger.io/lib/javascript/guides/using-source-maps/). 
 
 ## Installation
 
@@ -18,7 +18,7 @@ yarn add @honeybadger-io/rollup-plugin --dev
 
 ### Plugin parameters
 
-These plugin parameters correspond to the Honeybadger [Source Map Upload API](https://docs.honeybadger.io/api/reporting-source-maps/) and [Deployments API](https://docs.honeybadger.io/api/deployments.html).
+These plugin parameters correspond to the Honeybadger [Source Map Upload API](https://docs.honeybadger.io/api/reporting-source-maps/) and [Deployments API](https://docs.honeybadger.io/api/reporting-deployments/).
 
 <dl>
   <dt><code>apiKey</code> (required)</dt>
@@ -40,6 +40,20 @@ These plugin parameters correspond to the Honeybadger [Source Map Upload API](ht
 
   <dt><code>retries</code> (optional &mdash; default: 3, max: 10)</dt>
   <dd>This package implements fetch retry functionality via the <a href="https://github.com/vercel/fetch-retry">fetch-retry</a> package. Retrying helps fix issues like `ECONNRESET` and `SOCKETTIMEOUT` errors.
+  </dd>
+
+  <dt><code>deploy</code> (optional &mdash; default: false)</dt>
+  <dd>
+  Configuration for <a href="https://docs.honeybadger.io/api/reporting-deployments/">deployment notifications</a>. To disable deployment notifications, ignore this option. To enable deployment notifications, set this to <code>true</code>, or to an object containing any of the fields below. Your deploy's <code>revision</code> will be set to the same value as for your sourcemaps (see above). 
+
+  <dl>
+    <dt><code>environment</code></dt>
+    <dd>The environment name, for example, "production"</dd>
+    <dt><code>repository</code></dt>
+    <dd>The base URL of the VCS repository (HTTPS-style), for example, "https://github.com/yourusername/yourrepo"</dd>
+    <dt><code>localUsername</code></dt>
+    <dd>The name of the user that triggered this deploy, for example, "Jane"</dd>
+  </dl>
   </dd>
 </dl>
 

--- a/packages/rollup-plugin/examples/rollup/rollup.config.mjs
+++ b/packages/rollup-plugin/examples/rollup/rollup.config.mjs
@@ -6,7 +6,12 @@ dotenv.config({ path: `.env.local` })
 
 const hbPluginOptions = {
   apiKey: process.env.HONEYBADGER_API_KEY, 
-  assetsUrl: process.env.HONEYBADGER_ASSETS_URL
+  assetsUrl: process.env.HONEYBADGER_ASSETS_URL, 
+  deploy: {
+    repository: 'https://github.com/honeybadger-io/honeybadger-js', 
+    localUsername: 'BethanyBerkowitz', 
+    environment: 'production'
+  }
 }
 
 export default {

--- a/packages/rollup-plugin/examples/vite-vue/vite.config.js
+++ b/packages/rollup-plugin/examples/vite-vue/vite.config.js
@@ -10,6 +10,7 @@ const hbPluginOptions = {
   apiKey: process.env.VITE_HONEYBADGER_API_KEY, 
   assetsUrl: process.env.VITE_HONEYBADGER_ASSETS_URL,
   revision: process.env.VITE_HONEYBADGER_REVISION,
+  deploy: true,
 }
 
 // https://vitejs.dev/config/

--- a/packages/rollup-plugin/src/hbUtils.js
+++ b/packages/rollup-plugin/src/hbUtils.js
@@ -34,7 +34,7 @@ export async function uploadSourcemaps({ sourcemapData = [], hbOptions }) {
   const rejected = results.filter(p => p.status === 'rejected')
 
   if (!hbOptions.silent && fulfilled.length > 0) {
-    console.info(`${fulfilled.length} sourcemap file(s) successfully uploaded to Honeybadger.`)
+    console.info(`${fulfilled.length} sourcemap file(s) successfully uploaded to Honeybadger`)
   }
   if (rejected.length > 0) {
     const errorsStr = rejected.map(p => p.reason).join('\n')

--- a/packages/rollup-plugin/src/hbUtils.js
+++ b/packages/rollup-plugin/src/hbUtils.js
@@ -50,12 +50,13 @@ export async function uploadSourcemaps({ sourcemapData = [], hbOptions }) {
  * @param {String} endpoint
  * @param {String} assetsUrl
  * @param {String} apiKey 
+ * @param {Number} retries
  * @param {String} revision
  * @param {Boolean} silent
  * @param {String} jsFilename
  * @param {String} jsFilePath
  * @param {String} sourcemapFilePath
- * @returns {Promise} Resolves to an instance of FormData
+ * @returns {Promise} Resolves to the response object
  *   Rejects with an error if we don't get an ok response
  */
 export async function uploadSourcemap ({ 
@@ -98,7 +99,7 @@ export async function uploadSourcemap ({
 }
 
 /**
- * Builds the form data for the API call
+ * Builds the form data for the sourcemap API call
  *
  * @param {String} assetsUrl
  * @param {String} apiKey 
@@ -131,6 +132,18 @@ export async function buildBodyForSourcemapUpload({
   return form
 }
 
+/**
+ * Executes an API call to send a deploy notification
+ *
+ * @param {String} deployEndpoint
+ * @param {Boolean | Object} deploy
+ * @param {String} apiKey 
+ * @param {String} revision
+ * @param {Number} retries
+ * @param {Boolean} silent
+ * @returns {Promise} Resolves to the response object
+ *   Rejects with an error if we don't get an ok response
+ */
 export async function sendDeployNotification({
   deployEndpoint,
   deploy, 
@@ -162,7 +175,7 @@ export async function sendDeployNotification({
 
   if (res.ok) {
     if (!silent) {
-      console.info(`Successfully sent deploy notification to Honeybadger`) 
+      console.info('Successfully sent deploy notification to Honeybadger') 
     }
     return res
   } else {
@@ -171,6 +184,13 @@ export async function sendDeployNotification({
   }
 }
 
+/**
+ * Builds the JSON body for the deploy notification
+ *
+ * @param {Boolean | Object} deploy
+ * @param {String} revision
+ * @returns {String} JSON string
+ */
 export function buildBodyForDeployNotification({
   deploy, 
   revision
@@ -188,6 +208,12 @@ export function buildBodyForDeployNotification({
   return JSON.stringify(body)
 }
 
+/**
+ * Attempts to parse error details from a non-ok Response
+ *
+ * @param {Response} res
+ * @returns {String} Error details
+ */
 export async function parseResErrorDetails(res) {
   let details
   try {

--- a/packages/rollup-plugin/src/index.js
+++ b/packages/rollup-plugin/src/index.js
@@ -1,6 +1,6 @@
 import { cleanOptions } from './options.js'
 import { extractSourcemapDataFromBundle, isNonProdEnv } from './rollupUtils.js'
-import { uploadSourcemaps } from './hbUtils.js'
+import { sendDeployNotification, uploadSourcemaps } from './hbUtils.js'
 
 export default function honeybadgerRollupPlugin(options) {
   const hbOptions = cleanOptions(options)
@@ -14,8 +14,13 @@ export default function honeybadgerRollupPlugin(options) {
         }
         return
       }
+
       const sourcemapData = extractSourcemapDataFromBundle({ outputOptions, bundle })
       await uploadSourcemaps({ sourcemapData, hbOptions })
+
+      if (hbOptions.deploy) {
+        await sendDeployNotification({ ...hbOptions })
+      }
     }
   }
 }

--- a/packages/rollup-plugin/src/options.js
+++ b/packages/rollup-plugin/src/options.js
@@ -3,6 +3,7 @@ export const DEFAULT_RETRIES = 3
 export const DEFAULT_ENDPOINT = 'https://api.honeybadger.io/v1/source_maps'
 export const DEFAULT_REVISION = 'main'
 export const DEFAULT_SILENT = false
+export const DEPLOY_ENDPOINT = 'https://api.honeybadger.io/v1/deploys'
 
 /******************************
  * Everything in this file is designed to be shared with the webpack plugin
@@ -18,7 +19,8 @@ const defaultOptions = {
   endpoint: DEFAULT_ENDPOINT, 
   retries: DEFAULT_RETRIES, 
   revision: DEFAULT_REVISION, 
-  silent: DEFAULT_SILENT
+  silent: DEFAULT_SILENT, 
+  deployEndpoint: DEPLOY_ENDPOINT,
 }
 
 export function cleanOptions(options) {

--- a/packages/rollup-plugin/src/options.js
+++ b/packages/rollup-plugin/src/options.js
@@ -3,6 +3,7 @@ export const DEFAULT_RETRIES = 3
 export const DEFAULT_ENDPOINT = 'https://api.honeybadger.io/v1/source_maps'
 export const DEFAULT_REVISION = 'main'
 export const DEFAULT_SILENT = false
+export const DEFAULT_DEPLOY = false
 export const DEPLOY_ENDPOINT = 'https://api.honeybadger.io/v1/deploys'
 
 /******************************
@@ -20,6 +21,7 @@ const defaultOptions = {
   retries: DEFAULT_RETRIES, 
   revision: DEFAULT_REVISION, 
   silent: DEFAULT_SILENT, 
+  deploy: DEFAULT_DEPLOY,
   deployEndpoint: DEPLOY_ENDPOINT,
 }
 

--- a/packages/rollup-plugin/test/hbUtils.test.js
+++ b/packages/rollup-plugin/test/hbUtils.test.js
@@ -12,13 +12,7 @@ describe('hbUtils', () => {
     revision: '12345', 
     silent: false, 
   }
-  const testData = {
-    ...hbOptions,
-    sourcemapFilename: 'index.map.js',
-    sourcemapFilePath: 'path/to/index.map.js', 
-    jsFilename: 'index.js', 
-    jsFilePath: 'path/to/index.js',   
-  }
+  
   // Mock accessing the files via node-fetch's async fileFrom
   async function fileFromMock(filePath, type) {
     return new File([filePath, type], filePath, { type })
@@ -87,7 +81,7 @@ describe('hbUtils', () => {
       // Two rejections, one fulfilled promise
       td.when(fetchMock(hbOptions.endpoint, td.matchers.anything()))
         .thenResolve(new Response('', { status: 200 }))
-      td.when(fetchMock(testData.endpoint, td.matchers.anything()), { times: 2 })
+      td.when(fetchMock(hbOptions.endpoint, td.matchers.anything()), { times: 2 })
         .thenReject(new FetchError())
 
       try {
@@ -99,6 +93,14 @@ describe('hbUtils', () => {
   })
 
   describe('uploadSourcemap', () => {
+    const testData = {
+      ...hbOptions,
+      sourcemapFilename: 'index.map.js',
+      sourcemapFilePath: 'path/to/index.map.js', 
+      jsFilename: 'index.js', 
+      jsFilePath: 'path/to/index.js',   
+    }
+
     it('should resolve with the response if the response is ok', async () => {
       // Check we called fetch with the expected arguments
       td.when(fetchMock(testData.endpoint, {
@@ -188,6 +190,14 @@ describe('hbUtils', () => {
   })
 
   describe('buildBodyForSourcemapUpload', () => {
+    const testData = {
+      ...hbOptions,
+      sourcemapFilename: 'index.map.js',
+      sourcemapFilePath: 'path/to/index.map.js', 
+      jsFilename: 'index.js', 
+      jsFilePath: 'path/to/index.js',   
+    }
+
     it('should return an instance of FormData with expected entries', async () => {
       const result = await utils.buildBodyForSourcemapUpload(testData)
 
@@ -211,6 +221,145 @@ describe('hbUtils', () => {
         expect(file.name).to.equal(filePath)
         expect(file.type).to.equal(type)
       }) 
+    })
+  });
+
+  describe('sendDeployNotification', () => {
+    const testData = {
+      deployEndpoint: 'https://api.honeybadger.io/testing/deploys', 
+      apiKey: 'test_api_key', 
+      revision: 'revision_1', 
+      retries: 0, 
+      silent: false
+    }
+
+    it('should resolve with the response if the response is ok', async () => {
+      // Check we called fetch with the expected arguments
+      td.when(fetchMock(testData.deployEndpoint, {
+        method: 'POST',
+        headers: {
+          'X-API-KEY': testData.apiKey,
+          'Content-Type': 'application/json',
+          Accept: 'application/json'
+        },
+        body: td.matchers.isA(String),
+        redirect: 'follow',
+        retries: testData.retries,
+        retryDelay: 1000
+      }))
+        .thenResolve(new Response({}, { status: 200 }))
+
+      const res = await utils.sendDeployNotification(testData)
+      expect(res.status).to.equal(200)
+    })
+
+    it('should reject with an error if fetch rejects', async () => {
+      td.when(fetchMock(testData.deployEndpoint, td.matchers.anything()))
+        .thenReject(new FetchError('Go fetch it yourself'))
+
+      try {
+        await utils.sendDeployNotification(testData)
+      } catch (err) {
+        expect(err.message).to.equal('Failed to send deploy notification to Honeybadger: FetchError - Go fetch it yourself')
+      }
+    })
+
+    it('should reject with a useful error if response is not ok', async () => {
+      // Nothing useful in the body
+      let res = new Response(JSON.stringify({ foo: 'bar' }), { status: 500, statusText: 'Internal server error' })
+      td.when(fetchMock(testData.deployEndpoint, td.matchers.anything()))
+        .thenResolve(res)
+      try {
+        await utils.sendDeployNotification(testData)
+      } catch (err) {
+        expect(err.message).to.equal('Failed to send deploy notification to Honeybadger: 500 - Internal server error')
+      }
+      
+      // No body at all
+      res = new Response('', { status: 404, statusText: 'Not found' })
+      td.when(fetchMock(testData.deployEndpoint, td.matchers.anything()))
+        .thenResolve(res)
+      try {
+        await utils.sendDeployNotification(testData)
+      } catch (err) {
+        expect(err.message).to.equal('Failed to send deploy notification to Honeybadger: 404 - Not found')
+      }
+
+      // Body contains error data
+      res = new Response(JSON.stringify({ error: 'Server has the hiccups' }), { status: 500 })
+      td.when(fetchMock(testData.deployEndpoint, td.matchers.anything()))
+        .thenResolve(res)
+      try {
+        await utils.sendDeployNotification(testData)
+      } catch (err) {
+        expect(err.message).to.equal('Failed to send deploy notification to Honeybadger: 500 - Server has the hiccups')
+      }
+    })
+
+    it('should not retry if retries = 0', async () => {
+      const okRes = new Response('', { status: 201 })
+
+      // Reject once, then resolve
+      td.when(fetchMock(testData.deployEndpoint, td.matchers.anything()))
+        .thenResolve(okRes)
+      td.when(fetchMock(testData.deployEndpoint, td.matchers.anything()), { times: 1 })
+        .thenReject(new FetchError())
+
+      try {
+        await utils.sendDeployNotification(testData)
+      } catch (err) {
+        expect(err.message).to.equal('Failed to send deploy notification to Honeybadger: FetchError')
+      }
+    })
+
+    it('should retry if retries > 0', async () => {
+      const okRes = new Response('', { status: 201 })
+
+      // Reject once, then resolve
+      td.when(fetchMock(testData.deployEndpoint, td.matchers.anything()))
+        .thenResolve(okRes)
+      td.when(fetchMock(testData.deployEndpoint, td.matchers.anything()), { times: 1 })
+        .thenReject(new FetchError())
+      
+      const res = await utils.sendDeployNotification({ ...testData, retries: 3 })
+      expect(res.status).to.equal(201)
+    })
+  })
+
+  describe('buildBodyForDeployNotification', () => {
+    it('should return expected JSON string if deploy is true', () => {
+      const result = utils.buildBodyForDeployNotification({
+        deploy: true, 
+        revision: 'revision123'
+      })
+
+      expect(result).equals('{"deploy":{"revision":"revision123"}}') 
+    })
+
+    it('should return expected JSON string if deploy is an object', () => {
+      const result = utils.buildBodyForDeployNotification({
+        deploy: { 
+          repository: 'https://github.com/honeybadger-io/honeybadger-js', 
+          localUsername: 'BethanyBerkowitz', 
+          environment: 'production'
+        }, 
+        revision: 'revision123'
+      })
+
+      expect(result).equals('{"deploy":{"revision":"revision123","repository":"https://github.com/honeybadger-io/honeybadger-js","local_username":"BethanyBerkowitz","environment":"production"}}') 
+    })
+
+    it('should ignore missing keys', () => {
+      // Not passing environment in
+      const result = utils.buildBodyForDeployNotification({
+        deploy: { 
+          repository: 'https://github.com/honeybadger-io/honeybadger-js', 
+          localUsername: 'BethanyBerkowitz', 
+        }, 
+        revision: 'revision123'
+      })
+
+      expect(result).equals('{"deploy":{"revision":"revision123","repository":"https://github.com/honeybadger-io/honeybadger-js","local_username":"BethanyBerkowitz"}}') 
     })
   });
 });

--- a/packages/rollup-plugin/test/hbUtils.test.js
+++ b/packages/rollup-plugin/test/hbUtils.test.js
@@ -67,7 +67,7 @@ describe('hbUtils', () => {
       sourcemapData.forEach(({ jsFilename }) => {
         expect(responseBodies).to.deep.include({ jsFilename })
       })
-      td.verify(infoMock('3 sourcemap file(s) successfully uploaded to Honeybadger.'))
+      td.verify(infoMock('3 sourcemap file(s) successfully uploaded to Honeybadger'))
     })
 
     it('should reject with an error if there are failures', async () => {

--- a/packages/rollup-plugin/test/index.test.js
+++ b/packages/rollup-plugin/test/index.test.js
@@ -41,7 +41,7 @@ describe('Index', () => {
     const bundle = { 'index.map.js': {} }
     const sourcemapData = [{ sourcemapFilename: 'index.map.js' }]
 
-    it('Uploads sourcemaps', async () => {
+    it('should upload sourcemaps', async () => {
       td.when(isNonProdEnvMock()).thenReturn(false)
       td.when(extractSourcemapDataFromBundleMock({ outputOptions, bundle })).thenReturn(sourcemapData)
       td.when(cleanOptionsMock(options)).thenReturn(options)
@@ -52,7 +52,7 @@ describe('Index', () => {
       td.verify(uploadSourcemapsMock({ sourcemapData, hbOptions: options }))
     })
 
-    it('Sends deploy notification if deploy is true', async () => {
+    it('should send deploy notification if deploy is true', async () => {
       const deployTrueOpt = { ...options, deploy: true }
       td.when(isNonProdEnvMock()).thenReturn(false)
       td.when(extractSourcemapDataFromBundleMock({ outputOptions, bundle })).thenReturn(sourcemapData)
@@ -64,7 +64,7 @@ describe('Index', () => {
       td.verify(sendDeployNotificationMock(deployTrueOpt))
     })
 
-    it('Sends deploy notification if deploy is an object', async () => {
+    it('should send deploy notification if deploy is an object', async () => {
       const deployObjOpt = { ...options, deploy: { localUsername: 'me' } }
       td.when(isNonProdEnvMock()).thenReturn(false)
       td.when(extractSourcemapDataFromBundleMock({ outputOptions, bundle })).thenReturn(sourcemapData)
@@ -76,7 +76,7 @@ describe('Index', () => {
       td.verify(sendDeployNotificationMock(deployObjOpt))
     })
 
-    it('Does not send deploy notification if deploy is false', async () => {
+    it('should not send deploy notification if deploy is false', async () => {
       const deployFalseOpt = { ...options, deploy: false }
       td.when(isNonProdEnvMock()).thenReturn(false)
       td.when(extractSourcemapDataFromBundleMock({ outputOptions, bundle })).thenReturn(sourcemapData)
@@ -89,7 +89,7 @@ describe('Index', () => {
       td.verify(sendDeployNotificationMock(), { times: 0, ignoreExtraArgs: true })
     })
   
-    it('Does nothing in non-prod environments', async () => {
+    it('should do nothing in non-prod environments', async () => {
       td.when(isNonProdEnvMock()).thenReturn(true)
       td.when(cleanOptionsMock(options)).thenReturn(options)
   

--- a/packages/rollup-plugin/test/options.test.js
+++ b/packages/rollup-plugin/test/options.test.js
@@ -27,7 +27,8 @@ describe('Options', () => {
       const result = cleanOptions({ 
         apiKey: 'test_key', 
         assetsUrl: 'https://foo.bar',
-        retries: 0 
+        retries: 0, 
+        deploy: { localUsername: 'BethanyBerkowitz' },
       })
       expect(result).to.deep.equal({
         apiKey: 'test_key', 
@@ -36,7 +37,8 @@ describe('Options', () => {
         endpoint: DEFAULT_ENDPOINT, 
         revision: DEFAULT_REVISION, 
         silent: DEFAULT_SILENT, 
-        deployEndpoint: DEPLOY_ENDPOINT
+        deploy: { localUsername: 'BethanyBerkowitz' },
+        deployEndpoint: DEPLOY_ENDPOINT,
       })
     })
   });

--- a/packages/rollup-plugin/test/options.test.js
+++ b/packages/rollup-plugin/test/options.test.js
@@ -4,7 +4,8 @@ import {
   DEFAULT_ENDPOINT, 
   DEFAULT_REVISION, 
   DEFAULT_SILENT,
-  cleanOptions 
+  DEPLOY_ENDPOINT,
+  cleanOptions, 
 } from '../src/options.js';
 
 describe('Options', () => {
@@ -34,7 +35,8 @@ describe('Options', () => {
         retries: 0, 
         endpoint: DEFAULT_ENDPOINT, 
         revision: DEFAULT_REVISION, 
-        silent: DEFAULT_SILENT
+        silent: DEFAULT_SILENT, 
+        deployEndpoint: DEPLOY_ENDPOINT
       })
     })
   });

--- a/packages/webpack/README.md
+++ b/packages/webpack/README.md
@@ -25,7 +25,7 @@ yarn add @honeybadger-io/webpack --dev
 
 ### Plugin parameters
 
-These plugin parameters correspond to the Honeybadger [Source Map Upload API](https://docs.honeybadger.io/api/reporting-source-maps/) and [Deployments API](https://docs.honeybadger.io/api/deployments.html).
+These plugin parameters correspond to the Honeybadger [Source Map Upload API](https://docs.honeybadger.io/api/reporting-source-maps/) and [Deployments API](https://docs.honeybadger.io/api/reporting-deployments/).
 
 <dl>
   <dt><code>apiKey</code> (required)</dt>
@@ -63,7 +63,7 @@ These plugin parameters correspond to the Honeybadger [Source Map Upload API](ht
 
   <dt><code>deploy</code> (optional &mdash; default: false)</dt>
   <dd>
-  Configuration for deployment notifications. To disable deployment notifications, ignore this option. To enable deployment notifications, set this to <code>true</code>, or to an object containing any of these fields (see the <a href="https://docs.honeybadger.io/api/deployments.html">API reference</a>):</br>
+  Configuration for deployment notifications. To disable deployment notifications, ignore this option. To enable deployment notifications, set this to <code>true</code>, or to an object containing any of these fields (see the <a href="https://docs.honeybadger.io/api/reporting-deployments/">API reference</a>):</br>
 
   <dl>
     <dt><code>environment</code></dt>


### PR DESCRIPTION
## Status
READY

## Description
Adds the API call to send deployment notifications to Honeybadger via the Rollup plugin. Closes https://github.com/honeybadger-io/honeybadger-js/issues/1012. 

## Todos
- [x] Tests
- [x] Documentation

## Steps to Test or Reproduce
1. In `rollup-plugin` folder, run `npm install && npm run build`. 
2. In either of the example projects within `rollup-plugin`, run `npm install && npm run build`. You should see logging that the upload was successful and see the deploy appear in the UI: https://app.honeybadger.io/projects/[YOUR_PROJECT]/deploys
