### PR TITLE
Update peer dependency @honeybadger-io/js to 5.1.1

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -23,7 +23,7 @@
     "deploy": "gh-pages -d example/build"
   },
   "peerDependencies": {
-    "@honeybadger-io/js": "^4.3.0",
+    "@honeybadger-io/js": "^5.1.1",
     "prop-types": "^15.5.4",
     "react": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0",
     "react-dom": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0"


### PR DESCRIPTION
I guess that was missed with the latest 5.x.x release. npm install failed without the force option.