### PR TITLE
fix(react): import correctly @honeybadger-io/js

### DIFF
--- a/packages/react/src/HoneybadgerErrorBoundary.tsx
+++ b/packages/react/src/HoneybadgerErrorBoundary.tsx
@@ -1,5 +1,5 @@
 import React, { Component, ReactNode } from 'react'
-import Honeybadger from '@honeybadger-io/js/dist/browser/honeybadger'
+import Honeybadger from '@honeybadger-io/js'
 import DefaultErrorComponent, { DefaultErrorComponentProps } from './DefaultErrorComponent'
 import PropTypes from 'prop-types';
 

--- a/packages/react/src/index.test.tsx
+++ b/packages/react/src/index.test.tsx
@@ -1,12 +1,19 @@
 import React, { ReactNode } from 'react'
 import TestRenderer from 'react-test-renderer'
-import { Honeybadger, HoneybadgerErrorBoundary } from './'
+
+// Need to import like this because react-scripts does not support jest's {@link https://jestjs.io/docs/configuration#resolver-string resolver} option.
+// We need "resolver" to ask jest to respect the "browser" field in the package.json.
+// Since we do not have that, we import here manually. The alternative would be to do "react-scripts eject", but that would be an overkill.
+import Honeybadger from '@honeybadger-io/js/dist/browser/honeybadger'
+import { Honeybadger as HoneybadgerUniversalType, HoneybadgerErrorBoundary } from './'
 import { SinonSpy, assert, createSandbox } from 'sinon'
 import fetch from 'jest-fetch-mock'
 
 describe('HoneybadgerReact', () => {
   const config = { apiKey: 'FFAACCCC00' }
-  const honeybadger = Honeybadger.configure(config)
+  // need to type cast to the universal type (both Server and Client) because that's what the component expects
+  // in a real world scenario, the correct implementation is imported: Server in the case of SSR and Client in the browser
+  const honeybadger = Honeybadger.configure(config) as HoneybadgerUniversalType
 
   class Clean extends React.Component {
     render() {

--- a/packages/react/src/index.tsx
+++ b/packages/react/src/index.tsx
@@ -1,4 +1,4 @@
-import Honeybadger from '@honeybadger-io/js/dist/browser/honeybadger'
+import Honeybadger from '@honeybadger-io/js'
 import HoneybadgerErrorBoundary from './HoneybadgerErrorBoundary'
 
 export {


### PR DESCRIPTION
Fixes: #1020

## Status
**READY**

## Description
This was a brain teaser 😓 .
This PR fixes a bug I introduced with the release of the Collect User Feedback feature. The bug was introduced because I couldn't run the tests 🤦 .

### Some context:
- With the "Collect User Feedback", I added a new property in the react component to show the form automatically in case of an error (`showUserFeedbackForm`)
- I created a test for it, but it was failing with HTTP 403, even though I tried mocking the fetch api. I realised that it was importing the _server_ implementation of Honeybadger (as it is the main entry point of the `@honeybadger-io/js` package.
- So, since we always need the client side implementation, I changed the import to be explicit and imported `@honeybadger-io/js/dist/browser`.
- Hooray! My tests passed!

### This is what I missed:
- Some frameworks use SSR, and in this case importing the browser implementation will create errors; and this is what happens with the next.js app.

### The fix:
- Always import `@honeybadger-io/js` and let bundlers decide which entry point to use depending on the environment. I tested this in @BethanyBerkowitz's [repo](https://github.com/BethanyBerkowitz/hb-nextjs-react-test) by adding a line in `_app.js`:
```
// honeybadger.errorHandler should exist only on server implementation
console.log(typeof window === 'undefined' ? 'server' : 'browser', honeybadger.errorHandler) 
```
When running `npm run dev`, I get this on the terminal:
```
server [Function: bound errorHandler]
```
and this on the browser console:
```
browser undefined
```
Which indicates that everything is imported correctly.
- Fixing the tests: jest supports a `resolver` config which can be used for these cases (to make it respect the browser field in package.json). However, it's not supported in react-scripts so I explicitly import the browser implementation.

