### PR TITLE
chore(rollup): add rollup-plugin to the main README

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,9 @@ You can refer to the README of each package for more information and instruction
 - [@honeybadger-io/react-native](./packages/react-native)  
   [![npm version](https://badge.fury.io/js/%40honeybadger-io%2Freact-native.svg)](https://badge.fury.io/js/%40honeybadger-io%2Freact-native)  
   SDK for React Native integration
+- [@honeybadger-io/rollup-plugin](./packages/rollup-plugin)  
+  [![npm version](https://badge.fury.io/js/%40honeybadger-io%2Frollup-plugin.svg)](https://badge.fury.io/js/%40honeybadger-io%2Frollup-plugin)  
+  Rollup/Vite plugin to upload source maps to Honeybadger
 
 ## Documentation and Support
 


### PR DESCRIPTION
## Status
READY

## Description
Just noticed I forgot to link to the Rollup plugin from the monorepo README

