### PR TITLE
feat(core): accept a backtrace passed in the notice

### DIFF
--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -314,12 +314,15 @@ export abstract class Client {
       tags: uniqueTags,
     })
 
-    if (typeof notice.stack !== 'string' || !notice.stack.trim()) {
-      notice.stack = generateStackTrace()
-      notice.backtrace = makeBacktrace(notice.stack, true, this.logger)
-    }
-    else {
-      notice.backtrace = makeBacktrace(notice.stack, false, this.logger)
+    // If we're passed a custom backtrace array, use it
+    // Otherwise we make one. 
+    if (!Array.isArray(notice.backtrace) || !notice.backtrace.length) {
+      if (typeof notice.stack !== 'string' || !notice.stack.trim()) {
+        notice.stack = generateStackTrace()
+        notice.backtrace = makeBacktrace(notice.stack, true, this.logger)
+      } else {
+        notice.backtrace = makeBacktrace(notice.stack, false, this.logger)
+      }
     }
 
     return notice as Notice

--- a/packages/core/test/client.test.ts
+++ b/packages/core/test/client.test.ts
@@ -330,6 +330,48 @@ describe('client', function () {
   })
 
   describe('backtrace', function () {
+    it('uses the passed-in backtrace if there is one', function () {
+      client.configure({
+        apiKey: 'testing'
+      })
+
+      const payload = client.getPayload({
+        name: 'TestError', 
+        message: 'I have a custom backtrace', 
+        backtrace: [{
+          file: 'foo.js', 
+          method: 'doStuff', 
+          number: 3, 
+          column: 23,
+        }]
+      })
+
+      expect(payload.error.backtrace.length).toBe(1)
+      expect(payload.error.backtrace[0].file).toBe('foo.js')
+    })
+
+    it('generates a backtrace when existing one is not an array or empty', function () {
+      client.configure({
+        apiKey: 'testing'
+      })
+
+      const stringBacktracePayload = client.getPayload({
+        name: 'TestError', 
+        message: 'I have a custom backtrace', 
+        // @ts-expect-error
+        backtrace: 'oops this should not be a string',
+      })
+
+      const emptyBacktracePayload = client.getPayload({
+        name: 'TestError', 
+        message: 'I have a custom backtrace', 
+        backtrace: [],
+      })
+
+      expect(stringBacktracePayload.error.backtrace[0].file).toMatch('client.test.ts')
+      expect(emptyBacktracePayload.error.backtrace[0].file).toMatch('client.test.ts')
+    })
+
     it('generates a backtrace when there isn\'t one', function () {
       client.configure({
         apiKey: 'testing'


### PR DESCRIPTION
## Status
READY

## Description
In working on https://github.com/honeybadger-io/honeybadger-js/issues/926, I found it would be helpful if the core package would accept a backtrace passed in, rather than exclusively either parse the `notice.stack` string into a backtrace array or create its own backtrace. The existing react-native package has custom code to make nice backtraces for native iOS and android errors, which are not formatted the same as javascript errors, so they wouldn't be parsed correctly from `notice.stack`. 

## Todos
- [x] Tests
- [ ] Documentation
