### PR TITLE
fix(rollup-plugin): document rollup peer dependency

### DIFF
--- a/packages/rollup-plugin/README.md
+++ b/packages/rollup-plugin/README.md
@@ -3,6 +3,8 @@
 [Rollup](https://rollupjs.org/) plugin to upload JavaScript
 sourcemaps and optionally send deployment notifications to [Honeybadger](https://docs.honeybadger.io/lib/javascript/guides/using-source-maps/). 
 
+Supports rollup version 3. If you use rollup version 2, you can either upgrade or [send your sourcemaps to Honeybadger's API](https://docs.honeybadger.io/api/reporting-source-maps/) directly.
+
 ## Installation
 
 ```

--- a/packages/rollup-plugin/package-lock.json
+++ b/packages/rollup-plugin/package-lock.json
@@ -11,7 +11,8 @@
       "dependencies": {
         "fetch-retry": "^5.0.3",
         "form-data": "^4.0.0",
-        "node-fetch": "^2.6.9"
+        "node-fetch": "^2.6.9",
+        "picomatch": "^2.3.1"
       },
       "devDependencies": {
         "@rollup/plugin-commonjs": "^24.0.0",
@@ -27,6 +28,9 @@
         "testdouble": "^3.16.8",
         "ts-node": "^10.9.1",
         "typescript": "^4.9.5"
+      },
+      "peerDependencies": {
+        "rollup": "^3.0.0"
       }
     },
     "node_modules/@cspotcode/source-map-support": {
@@ -1289,7 +1293,6 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
       "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-      "dev": true,
       "engines": {
         "node": ">=8.6"
       },
@@ -2642,8 +2645,7 @@
     "picomatch": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-      "dev": true
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="
     },
     "quibble": {
       "version": "0.6.15",

--- a/packages/rollup-plugin/package.json
+++ b/packages/rollup-plugin/package.json
@@ -49,6 +49,9 @@
     "node-fetch": "^2.6.9",
     "picomatch": "^2.3.1"
   },
+  "peerDependencies": {
+    "rollup": "^3.0.0"
+  },
   "main": "dist/cjs/index.js",
   "module": "dist/es/index.js",
   "publishConfig": {


### PR DESCRIPTION
## Status
READY

## Description
Document peer dependency of rollup v3: https://github.com/honeybadger-io/honeybadger-js/issues/1060 

## Todos
- [ ] Tests
- [ ] Documentation

## Steps to Test or Reproduce
Try changing the rollup version in a test project to rollup v2 and then run `npm i`. You'll get a peer dependency error. 
