### PR TITLE
fix(rollup-plugin): don't add subfolder to file if it's already there

### DIFF
--- a/packages/rollup-plugin/src/rollupUtils.ts
+++ b/packages/rollup-plugin/src/rollupUtils.ts
@@ -46,10 +46,13 @@ function formatSourcemapData(
   // the same name as the js file... however we can pull the file name
   // from the sourcemap source just in case.
   let jsFilename: string
-  if (typeof sourcemap.source === 'string') {
+  if (sourcemap.source && typeof sourcemap.source === 'string') {
     const { file } = JSON.parse(sourcemap.source)
-    // The file in the source won't have the subfolder, need to add it
-    jsFilename = path.join(path.dirname(sourcemapFilename), file)
+    // The file in the source usually won't have the subfolder, we may need to add it
+    const subfolder = path.dirname(sourcemapFilename)
+    jsFilename = file.startsWith(subfolder) 
+      ? file
+      : path.join(subfolder, file)
   } else {
     jsFilename = sourcemapFilename.replace('.map', '')
   }

--- a/packages/rollup-plugin/test/fixtures/bundle.ts
+++ b/packages/rollup-plugin/test/fixtures/bundle.ts
@@ -149,6 +149,14 @@ const assets = {
     type: 'asset' as const,
     needsCodeReference: false
   },
+  // The subfolder is included in the "file" key within "source"
+  'sub/folder/baz.js.map': {
+    fileName: 'sub/folder/baz.js.map',
+    name: undefined,
+    source: '{"version":3,"file":"sub/folder/baz.js","sources":["../../src/subfolder/baz.js"],"sourcesContent":["export default \'This is in a subfolder!\'"],"names":[],"mappings":";;AAAA,UAAe;;;;"}',
+    type: 'asset' as const,
+    needsCodeReference: false
+  },
   'foo.js.map': {
     fileName: 'foo.js.map',
     name: undefined,

--- a/packages/rollup-plugin/test/rollupUtils.test.ts
+++ b/packages/rollup-plugin/test/rollupUtils.test.ts
@@ -11,7 +11,7 @@ describe('extractSourcemapDataFromBundle', () => {
 
   it('should return an array with sourcemap file data', () => {
     const data = extractSourcemapDataFromBundle(outputOptions, bundle, [])
-    expect(data).to.be.an('array').lengthOf(3)
+    expect(data).to.be.an('array').lengthOf(4)
     expect(data).to.have.deep.members([
       {
         sourcemapFilename: 'index.js.map',
@@ -31,6 +31,12 @@ describe('extractSourcemapDataFromBundle', () => {
         jsFilename: 'subfolder/bar.js',
         jsFilePath: path.resolve('dist/subfolder/bar.js')
       },
+      {
+        sourcemapFilename: 'sub/folder/baz.js.map',
+        sourcemapFilePath: path.resolve('dist/sub/folder/baz.js.map'),
+        jsFilename: 'sub/folder/baz.js',
+        jsFilePath: path.resolve('dist/sub/folder/baz.js')
+      },
     ])
   })
 
@@ -38,7 +44,7 @@ describe('extractSourcemapDataFromBundle', () => {
   for (const ignorePath of itEach) {
     it(`should ignore files that match the ignorePath ${ignorePath}`, () => {
       const data = extractSourcemapDataFromBundle(outputOptions, bundle, [ignorePath])
-      expect(data).to.be.an('array').lengthOf(2)
+      expect(data).to.be.an('array').lengthOf(3)
       expect(data).to.have.deep.members([
         {
           sourcemapFilename: 'index.js.map',
@@ -51,6 +57,12 @@ describe('extractSourcemapDataFromBundle', () => {
           sourcemapFilePath: path.resolve('dist/subfolder/bar.js.map'),
           jsFilename: 'subfolder/bar.js',
           jsFilePath: path.resolve('dist/subfolder/bar.js')
+        },
+        {
+          sourcemapFilename: 'sub/folder/baz.js.map',
+          sourcemapFilePath: path.resolve('dist/sub/folder/baz.js.map'),
+          jsFilename: 'sub/folder/baz.js',
+          jsFilePath: path.resolve('dist/sub/folder/baz.js')
         },
       ])
     })
@@ -67,7 +79,7 @@ describe('extractSourcemapDataFromBundle', () => {
     })
 
     const data = extractSourcemapDataFromBundle(outputOptions, bundle, [])
-    expect(data).to.be.an('array').lengthOf(3)
+    expect(data).to.be.an('array').lengthOf(4)
     expect(data).to.not.have.deep.members([
       {
         sourcemapFilename: 'empty.js.map',


### PR DESCRIPTION
## Status
READY

## Description
See https://github.com/honeybadger-io/honeybadger-js/issues/1062. 

Most of the time, it seems that the `file` key within the sourcemap's `source` in the rollup bundle does not include the subfolder. However, based on the issue above, it *could*. Why this field does or does not include the subfolder requires further investigation, however we can add a quick check so we don't add a duplicate. 

This should not change existing projects that are working, with the exception of one possible edge case. If the `file` key has something like "subfolder/foo.js" and the actual real folder name is "subfolder/subfolder/foo.js", we won't add that second folder with the same name. This seems highly unlikely, especially since as far as I know, rollup will put the js file and the sourcemap in the same folder. 



## Related PRs
List related PRs against other branches:

| branch              | PR       |
|---------------------|----------|
| other_pr_production | [link]() |
| other_pr_master     | [link]() |

## Todos
- [x] Tests
- [ ] Documentation

## Steps to Test or Reproduce
Outline the steps to test or reproduce the PR here.
```bash
> git pull --prune
> git checkout <branch>
> grunt jasmine
```
1.
