### PR TITLE
chore: add Next.js package to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ You can refer to the README of each package for more information and instruction
   [![npm version](https://badge.fury.io/js/%40honeybadger-io%2Freact.svg)](https://badge.fury.io/js/%40honeybadger-io%2Freact)  
   SDK for React integration
 - [@honeybadger-io/nextjs](./packages/nextjs)  
-  [![npm version](https://badge.fury.io/js/%40honeybadger-io%2nextjs.svg)](https://badge.fury.io/js/%40honeybadger-io%2nextjs)  
+  [![npm version](https://badge.fury.io/js/%40honeybadger-io%2nextjs.svg)](https://badge.fury.io/js/%40honeybadger-io%2Fnextjs)  
   SDK for Next.js integration
 - [@honeybadger-io/gatsby-plugin-honeybadger](./packages/gatsby-plugin)  
   [![npm version](https://badge.fury.io/js/%40honeybadger-io%2Fgatsby-plugin-honeybadger.svg)](https://badge.fury.io/js/%40honeybadger-io%2Fgatsby-plugin-honeybadger)  

--- a/README.md
+++ b/README.md
@@ -19,6 +19,9 @@ You can refer to the README of each package for more information and instruction
 - [@honeybadger-io/react](./packages/react)  
   [![npm version](https://badge.fury.io/js/%40honeybadger-io%2Freact.svg)](https://badge.fury.io/js/%40honeybadger-io%2Freact)  
   SDK for React integration
+- [@honeybadger-io/nextjs](./packages/nextjs)  
+  [![npm version](https://badge.fury.io/js/%40honeybadger-io%2nextjs.svg)](https://badge.fury.io/js/%40honeybadger-io%2nextjs)  
+  SDK for Next.js integration
 - [@honeybadger-io/gatsby-plugin-honeybadger](./packages/gatsby-plugin)  
   [![npm version](https://badge.fury.io/js/%40honeybadger-io%2Fgatsby-plugin-honeybadger.svg)](https://badge.fury.io/js/%40honeybadger-io%2Fgatsby-plugin-honeybadger)  
   [Gatsby](https://www.gatsbyjs.com) plugin


### PR DESCRIPTION
## Status
<!--- **READY/WIP/HOLD** --->
**READY**

## Description
Adds the Next.js package to the README, which is the only package not documented. 

## Related PRs
n/a
## Todos
- [ ] Fix badge logo; the link is working but I'm not sure why the badge is not displaying. 
## Steps to Test or Reproduce
n/a