### PR TITLE
chore: switch to independent versioning

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -3,5 +3,5 @@
     "packages/*"
   ],
   "useNx": false,
-  "version": "5.5.0"
+  "version": "independent"
 }


### PR DESCRIPTION
## Status
**READY**

## Description
Closes #957.
I first looked at the documentation which pointed to a very old package (supports up to lerna v2). Obviously, that didn't work.

Then, I simply tried setting `"version": "independent"` in `lerna.json`. To my surprise, it just works 🤷 
![image](https://github.com/honeybadger-io/honeybadger-js/assets/5813382/b7afee5b-ccff-494d-867b-ce5d46c703df)

Here's the [dummy monorepo](https://github.com/subzero10/lerna-getting-started-example) I played with, and the published packages under an `hb-test` npm organization:
- [@hb-test/footer](https://www.npmjs.com/package/@hb-test/footer)
- [@hb-test/header](https://www.npmjs.com/package/@hb-test/header)
- [@hb-test/remixapp](https://www.npmjs.com/package/@hb-test/remixapp)

Notes:
- _footer_ and _header_ are dependencies of _remixapp_
- [git tags for releases](https://github.com/subzero10/lerna-getting-started-example/tags) are now created separately for each package
- [github releases](https://github.com/subzero10/lerna-getting-started-example/releases) are now created separately for each package

## Tests:

- [x] Publish breaking change to _remixapp_ -> bumps major version only to _remixapp_ ✅ 
- [x] Publish fix to _header_ -> bumps patch version to _header_ **and** _remixapp_ ✅ 
- [x] Publish breaking change to _footer_ > bumps major version to _footer_ (actually only minor version was bumped for this package since v0 is special and minor versions are also considered breaking) **and** _remixapp_ ✅  