### PR TITLE
chore(integration): test minimum browser version as well as latest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ node_modules
 
 lerna-debug.log
 browserstack.err
+
+# for use with direnv
+.envrc

--- a/packages/js/test/integration/browsers.js
+++ b/packages/js/test/integration/browsers.js
@@ -1,29 +1,58 @@
 module.exports = {
-  bs_safari: {
+  bs_safari_min: {
+    base: 'BrowserStack',
+    browser: 'Safari',
+    browser_version: '12.1',
+    os: 'OS X',
+    os_version: 'Mojave'
+  },
+  bs_safari_latest: {
     base: 'BrowserStack',
     browser: 'Safari',
     browser_version: 'latest',
     os: 'OS X',
-    os_version: 'Mojave'
+    os_version: 'Ventura'
   },
-  bs_chrome: {
+  bs_chrome_min: {
+    base: 'BrowserStack',
+    browser: 'Chrome',
+    browser_version: '49',
+    os: 'Windows',
+    os_version: '10'
+  },
+  bs_chrome_latest: {
     base: 'BrowserStack',
     browser: 'Chrome',
     browser_version: 'latest',
     os: 'Windows',
-    os_version: '10'
+    os_version: '11'
   },
-  bs_firefox: {
+  bs_firefox_min: {
     base: 'BrowserStack',
     browser: 'Firefox',
-    browser_version: '108.0',
+    browser_version: '58',
     os: 'Windows',
     os_version: '10'
   },
-  bs_edge: {
+  bs_firefox_latest: {
     base: 'BrowserStack',
-    browser: 'Edge',
+    browser: 'Firefox',
+    browser_version: 'latest',
     os: 'Windows',
     os_version: '10'
+  },
+  bs_edge_min: {
+    base: 'BrowserStack',
+    browser: 'Edge',
+    browser_version: '15',
+    os: 'Windows',
+    os_version: '10'
+  },
+  bs_edge_latest: {
+    base: 'BrowserStack',
+    browser: 'Edge',
+    browser_version: 'latest',
+    os: 'Windows',
+    os_version: '11'
   }
 }


### PR DESCRIPTION
## Status
**READY**

## Description
Needed for https://github.com/honeybadger-io/docs/issues/243. 

My approach to picking the minimum browser versions were as follows: 
1. Must support fetch: https://caniuse.com/fetch
2. Must support let, var, const: https://caniuse.com/let
3. If the minimum version that met criteria 1 and 2 didn't pass integration tests, test a bunch of versions to find one that was released in 2018 or earlier and passed the tests. 

*Notes on criterion 3 above:*
Specifically, I had trouble with Firefox and Safari. 

*Safari*: 
- versions 10.1 on Sierra and 11.1 on High Sierra had a failure when testing a Web Worker
- specifically, [expect(results.notices.length).toEqual(1);](https://github.com/honeybadger-io/honeybadger-js/blob/0a9df3c0a2ffe13a08b8ce1a70aee901a50ac5fd/packages/js/test/integration/test.js#L538-L539) failed because there was no notice. 

*Firefox*: 
- on version 49 and 65, I saw failures in all of the feedback form tests
- it looked like the feedback form was not in the DOM, the tests thought it was null
- however, when viewing the video recordings of the integration tests on BrowserStack, I saw the feedback form appear on screen at least once
- it may be a timeout issue?

I spent some time trying to diagnose these issues, but wasn't making a ton of progress so I decided to find versions that passed and that were reasonably old (2018). 


## Steps to Test or Reproduce
Changes can be seen in the github `integration` action. 
