### PR TITLE
chore(js): allow uncaughtException plugin to be loaded more than once

### DIFF
--- a/packages/js/src/server/integrations/uncaught_exception_monitor.ts
+++ b/packages/js/src/server/integrations/uncaught_exception_monitor.ts
@@ -79,14 +79,16 @@ export default class UncaughtExceptionMonitor {
    * we want to report the exception to Honeybadger and
    * mimic the default behavior of NodeJs,
    * which is to exit the process with code 1
+   * 
+   * Node sets up domainUncaughtExceptionClear when we use domains.
+   * Since they're not set up by a user, they shouldn't affect whether we exit or not
    */
-  hasOtherUncaughtExceptionListeners() {
+  hasOtherUncaughtExceptionListeners(): boolean {
     const allListeners = process.listeners('uncaughtException')
-    // Node sets up these listeners when we use domains
-    // Since they're not set up by a user, they shouldn't affect whether we exit or not
-    const domainListeners = allListeners.filter(listener => {
-      return listener.name === 'domainUncaughtExceptionClear' 
-    })
-    return allListeners.length - domainListeners.length > 1
+    const otherListeners = allListeners.filter(listener => (
+      listener.name !== 'domainUncaughtExceptionClear' 
+      && listener !== this.__listener
+    ))
+    return otherListeners.length > 0
   }
 }

--- a/packages/js/src/server/integrations/uncaught_exception_monitor.ts
+++ b/packages/js/src/server/integrations/uncaught_exception_monitor.ts
@@ -6,12 +6,32 @@ export default class UncaughtExceptionMonitor {
   protected __isReporting: boolean
   protected __handlerAlreadyCalled: boolean
   protected __client: typeof Client
+  // TODO: binding this makes the name 'bound honeybadgerUncaughtExceptionlistener'
+  // could instead do something like 'makeListener()'
+  // the name is not critical afaik, but I'd like it to be clean
+  protected __listener = function honeybadgerUncaughtExceptionListener(uncaughtError) {
+    this.handleUncaughtException(uncaughtError)
+  }.bind(this)
 
-  constructor(client: typeof Client) {
+  constructor() {
     this.__isReporting = false
-    this.__handlerAlreadyCalled = false
-    this.__client = client
+    this.__handlerAlreadyCalled = false 
     this.removeAwsLambdaListener()
+  }
+
+  setClient(client: typeof Client) {
+    this.__client = client
+  }
+
+  maybeAddListener() {
+    const listeners = process.listeners('uncaughtException')
+    if (!listeners.includes(this.__listener)) {
+      process.on('uncaughtException', this.__listener)
+    }
+  }
+
+  maybeRemoveListener() {
+
   }
 
   removeAwsLambdaListener() {

--- a/packages/js/src/server/integrations/uncaught_exception_monitor.ts
+++ b/packages/js/src/server/integrations/uncaught_exception_monitor.ts
@@ -62,7 +62,10 @@ export default class UncaughtExceptionMonitor {
   }
 
   maybeRemoveListener() {
-
+    const listeners = process.listeners('uncaughtException')
+    if (listeners.includes(this.__listener)) {
+      process.removeListener('uncaughtException', this.__listener)
+    }
   }
 
   removeAwsLambdaListener() {

--- a/packages/js/src/server/integrations/uncaught_exception_plugin.ts
+++ b/packages/js/src/server/integrations/uncaught_exception_plugin.ts
@@ -8,10 +8,11 @@ export default function (): Types.Plugin {
   return {
     load: (client: typeof Client) => {
       uncaughtExceptionMonitor.setClient(client)
-      if (!client.config.enableUncaught) { 
-        return
+      if (client.config.enableUncaught) { 
+        uncaughtExceptionMonitor.maybeAddListener()
+      } else {
+        uncaughtExceptionMonitor.maybeRemoveListener()
       }
-      uncaughtExceptionMonitor.maybeAddListener()
     }
   }
 }

--- a/packages/js/src/server/integrations/uncaught_exception_plugin.ts
+++ b/packages/js/src/server/integrations/uncaught_exception_plugin.ts
@@ -2,16 +2,16 @@ import { Types } from '@honeybadger-io/core'
 import Client from '../../server'
 import UncaughtExceptionMonitor from './uncaught_exception_monitor'
 
+const uncaughtExceptionMonitor = new UncaughtExceptionMonitor()
+
 export default function (): Types.Plugin {
   return {
     load: (client: typeof Client) => {
+      uncaughtExceptionMonitor.setClient(client)
       if (!client.config.enableUncaught) { 
         return
       }
-      const uncaughtExceptionMonitor = new UncaughtExceptionMonitor(client)
-      process.on('uncaughtException', function honeybadgerUncaughtExceptionListener(uncaughtError) {
-        uncaughtExceptionMonitor.handleUncaughtException(uncaughtError)
-      })
+      uncaughtExceptionMonitor.maybeAddListener()
     }
   }
 }

--- a/packages/js/test/unit/server/integrations/uncaught_exception_monitor.server.test.ts
+++ b/packages/js/test/unit/server/integrations/uncaught_exception_monitor.server.test.ts
@@ -137,9 +137,7 @@ describe('UncaughtExceptionMonitor', () => {
 
   describe('hasOtherUncaughtExceptionListeners', () => {
     it('returns true if there are user-added listeners', () => {
-      process.on('uncaughtException', function honeybadgerUncaughtExceptionListener() {
-        return
-      })
+      uncaughtExceptionMonitor.maybeAddListener()
       process.on('uncaughtException', function domainUncaughtExceptionClear() {
         return 
       })
@@ -150,9 +148,7 @@ describe('UncaughtExceptionMonitor', () => {
     })
 
     it('returns false if there are only our expected listeners', () => {
-      process.on('uncaughtException', function honeybadgerUncaughtExceptionListener() {
-        return
-      })
+      uncaughtExceptionMonitor.maybeAddListener()
       process.on('uncaughtException', function domainUncaughtExceptionClear() {
         return 
       })

--- a/packages/js/test/unit/server/integrations/uncaught_exception_monitor.server.test.ts
+++ b/packages/js/test/unit/server/integrations/uncaught_exception_monitor.server.test.ts
@@ -69,6 +69,25 @@ describe('UncaughtExceptionMonitor', () => {
     })
   })
 
+  describe('maybeRemoveListener', () => {
+    it('removes our listener if it is present', () => {
+      uncaughtExceptionMonitor.maybeAddListener()
+      process.on('uncaughtException', (err) => { console.log(err) })
+      expect(process.listeners('uncaughtException').length).toBe(2)
+
+      uncaughtExceptionMonitor.maybeRemoveListener()
+      expect(process.listeners('uncaughtException').length).toBe(1)
+    })
+
+    it('does nothing if our listener is not present', () => {
+      process.on('uncaughtException', (err) => { console.log(err) })
+      expect(process.listeners('uncaughtException').length).toBe(1)
+      
+      uncaughtExceptionMonitor.maybeRemoveListener()
+      expect(process.listeners('uncaughtException').length).toBe(1)
+    })
+  })
+
   describe('__listener', () => {   
     const error = new Error('dang, broken again')  
 

--- a/packages/js/test/unit/server/integrations/uncaught_exception_plugin.server.test.ts
+++ b/packages/js/test/unit/server/integrations/uncaught_exception_plugin.server.test.ts
@@ -38,7 +38,7 @@ describe('Uncaught Exception Plugin', () => {
       load(client)
       const listeners = process.listeners('uncaughtException')
       expect(listeners.length).toBe(1)
-      expect(listeners[0].name).toBe('honeybadgerUncaughtExceptionListener') 
+      expect(listeners[0].name).toBe('bound honeybadgerUncaughtExceptionListener') 
 
       const error = new Error('uncaught')
       process.emit('uncaughtException', error)

--- a/packages/js/test/unit/server/integrations/uncaught_exception_plugin.server.test.ts
+++ b/packages/js/test/unit/server/integrations/uncaught_exception_plugin.server.test.ts
@@ -38,7 +38,7 @@ describe('Uncaught Exception Plugin', () => {
       load(client)
       const listeners = process.listeners('uncaughtException')
       expect(listeners.length).toBe(1)
-      expect(listeners[0].name).toBe('bound honeybadgerUncaughtExceptionListener') 
+      expect(listeners[0].name).toBe('honeybadgerUncaughtExceptionListener') 
 
       const error = new Error('uncaught')
       process.emit('uncaughtException', error)

--- a/packages/js/test/unit/server/integrations/uncaught_exception_plugin.server.test.ts
+++ b/packages/js/test/unit/server/integrations/uncaught_exception_plugin.server.test.ts
@@ -3,6 +3,14 @@ import { TestTransport, TestClient, nullLogger } from '../../helpers'
 import * as util from '../../../../src/server/util'
 import Singleton from '../../../../src/server'
 
+function getListeners() {
+  return process.listeners('uncaughtException')
+}
+
+function getListenerCount() {
+  return getListeners().length
+}
+
 describe('Uncaught Exception Plugin', () => {
   let client: typeof Singleton
   let notifySpy: jest.SpyInstance
@@ -34,9 +42,9 @@ describe('Uncaught Exception Plugin', () => {
   describe('load', () => {
     const load = plugin().load
 
-    it('attaches a listener for uncaughtException', () => {
+    it('adds a listener for uncaughtException if enableUncaught is true', () => {
       load(client)
-      const listeners = process.listeners('uncaughtException')
+      const listeners = getListeners()
       expect(listeners.length).toBe(1)
       expect(listeners[0].name).toBe('honeybadgerUncaughtExceptionListener') 
 
@@ -45,11 +53,23 @@ describe('Uncaught Exception Plugin', () => {
       expect(notifySpy).toHaveBeenCalledTimes(1)
     })
 
-    it('returns if enableUncaught is not true', () => {
+    it('does not add a listener if enableUncaught is false', () => {
       client.configure({ enableUncaught: false })
       load(client)
-      const listeners = process.listeners('uncaughtException')
-      expect(listeners.length).toBe(0)
+      expect(getListenerCount()).toBe(0)
+    })
+
+    it('adds or removes listener if needed when reloaded', () => {
+      load(client)
+      expect(getListenerCount()).toBe(1)
+      
+      client.configure({ enableUncaught: false })
+      load(client)
+      expect(getListenerCount()).toBe(0)
+      
+      client.configure({ enableUncaught: true })
+      load(client)
+      expect(getListenerCount()).toBe(1)
     })
   })  
 })


### PR DESCRIPTION
## Status
**READY**

## Description
Part of https://github.com/honeybadger-io/honeybadger-js/issues/1163

This PR makes it safe to load the uncaughtException plugin more than once. 

- If loaded with enableUncaught true, it will add a listener if one has not already been added
- If loaded with enableUncaught false, it will remove the listener if it exists

However, the client itself still only loads the plugin once, so this PR should not cause any user-facing change in behavior. 

## Todos
- [x] Tests
- [x] Documentation

## Steps to Test or Reproduce
Unit tests should mostly cover it. I also tested it by throwing an uncaught error in one of the example applications. I chose `sails`, but it could have been `express` or another node project. The trick is that you have to throw an error in a node application that is not covered by the honeybadger middleware, but also doesn't cause an import to fail entirely. So for example: 

```
Honeybadger.configure({
  apiKey: process.env.HONEYBADGER_API_KEY, 
  enableUncaught: true,
})

setTimeout(() => {
  throw new Error('unhandled err at top-level')
}, 50)
```

Also tested with `enableUncaught: false`, which did not send a report (as expected). 

I also found that you can't test this in AWS Lambda because the wrapper just wraps the whole thing and calls notify(). So if you throw an uncaught error within your lambda, it’s just going to get reported up to the wrapper.