### PR TITLE
chore(js): allow unhandledRejection plugin to be loaded more than once

### DIFF
--- a/packages/js/src/server/integrations/unhandled_rejection_monitor.ts
+++ b/packages/js/src/server/integrations/unhandled_rejection_monitor.ts
@@ -5,10 +5,51 @@ import { Types } from '@honeybadger-io/core'
 export default class UnhandledRejectionMonitor {
   protected __isReporting: boolean
   protected __client: typeof Client
+  protected __listener: (reason: unknown, _promise: Promise<unknown>) => void
 
-  constructor(client: typeof Client) {
+  constructor() {
     this.__isReporting = false
+    this.__listener = this.makeListener()
+  }
+
+  setClient(client: typeof Client) {
     this.__client = client
+  }
+
+  makeListener() {
+    const honeybadgerUnhandledRejectionListener = (reason: unknown, _promise: Promise<unknown>) => {
+      if (!this.__client || !this.__client.config.enableUnhandledRejection) {
+        if (!this.hasOtherUnhandledRejectionListeners() && !this.__isReporting) {
+          fatallyLogAndExit(reason as Error)
+        }
+        return
+      }
+  
+      this.__isReporting = true;
+      this.__client.notify(reason as Types.Noticeable, { component: 'unhandledRejection' }, {
+        afterNotify: () => {
+          this.__isReporting = false;
+          if (!this.hasOtherUnhandledRejectionListeners()) {
+            fatallyLogAndExit(reason as Error)
+          }
+        }
+      })
+    }
+    return honeybadgerUnhandledRejectionListener
+  }
+
+  maybeAddListener() {
+    const listeners = process.listeners('unhandledRejection')
+    if (!listeners.includes(this.__listener)) {
+      process.on('unhandledRejection', this.__listener)
+    }
+  }
+
+  maybeRemoveListener() {
+    const listeners = process.listeners('unhandledRejection')
+    if (listeners.includes(this.__listener)) {
+      process.removeListener('unhandledRejection', this.__listener)
+    }
   }
 
   /**
@@ -18,25 +59,8 @@ export default class UnhandledRejectionMonitor {
    * which is to exit the process with code 1
    */
   hasOtherUnhandledRejectionListeners() {
-    return process.listeners('unhandledRejection').length > 1
-  }
-
-  handleUnhandledRejection(reason: unknown, _promise: Promise<unknown>) {
-    if (!this.__client.config.enableUnhandledRejection) {
-      if (!this.hasOtherUnhandledRejectionListeners() && !this.__isReporting) {
-        fatallyLogAndExit(reason as Error)
-      }
-      return
-    }
-
-    this.__isReporting = true;
-    this.__client.notify(reason as Types.Noticeable, { component: 'unhandledRejection' }, {
-      afterNotify: () => {
-        this.__isReporting = false;
-        if (!this.hasOtherUnhandledRejectionListeners()) {
-          fatallyLogAndExit(reason as Error)
-        }
-      }
-    })
+    const otherListeners = process.listeners('unhandledRejection')
+      .filter(listener => listener !== this.__listener)
+    return otherListeners.length > 0
   }
 }

--- a/packages/js/src/server/integrations/unhandled_rejection_plugin.ts
+++ b/packages/js/src/server/integrations/unhandled_rejection_plugin.ts
@@ -2,16 +2,17 @@ import { Types } from '@honeybadger-io/core'
 import Client from '../../server'
 import UnhandledRejectionMonitor from './unhandled_rejection_monitor'
 
+const unhandledRejectionMonitor = new UnhandledRejectionMonitor()
+
 export default function (): Types.Plugin {
   return {
     load: (client: typeof Client) => {
-      if (!client.config.enableUnhandledRejection) {
-        return
-      }
-      const unhandledRejectionMonitor = new UnhandledRejectionMonitor(client)
-      process.on('unhandledRejection', function honeybadgerUnhandledRejectionListener(reason, _promise) {
-        unhandledRejectionMonitor.handleUnhandledRejection(reason, _promise)
-      })
+      unhandledRejectionMonitor.setClient(client)
+      if (client.config.enableUnhandledRejection) {
+        unhandledRejectionMonitor.maybeAddListener()
+      } else {
+        unhandledRejectionMonitor.maybeRemoveListener()
+      } 
     }
   }
 }


### PR DESCRIPTION
## Status
**READY**

## Description
Part of https://github.com/honeybadger-io/honeybadger-js/issues/1163

This PR makes it safe to load the unhandledRejection plugin more than once.

If loaded with enableUnhandledRejection true, it will add a listener if one has not already been added
If loaded with enableUnhandledRejection false, it will remove the listener if it exists
However, the client itself still only loads the plugin once, so this PR should not cause any user-facing change in behavior.

## Related PRs
https://github.com/honeybadger-io/honeybadger-js/pull/1170 does the same with unhandledException

## Todos
- [x] Tests
- [x] Documentation

## Steps to Test or Reproduce
Unit tests mostly cover it, however I also tested manually using the `sails` example app. Any node-based example app would be fine, you just need to trigger a promise rejection where the middleware will not pick it up. eg

```
Honeybadger.configure({
  apiKey: process.env.HONEYBADGER_API_KEY, 
  enableUncaught: false,
  enableUnhandledRejection: true,
})


function reject() {
  Promise.reject(new Error('error within a promise'))
}

setTimeout(reject, 500)
```
I tested with `enableUnhandledRejection: true` and `false`. 