### PR TITLE
feat(core): optionally reload plugins

### DIFF
--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -39,7 +39,7 @@ const TAG_SEPARATOR = /,|\s+/
 const NOT_BLANK = /\S/
 
 export abstract class Client {
-  protected __pluginsExecuted = false
+  protected __pluginsLoaded = false
 
   protected __store: HoneybadgerStore = null;
   protected __beforeNotifyHandlers: BeforeNotifyHandler[] = []
@@ -118,12 +118,17 @@ export abstract class Client {
     for (const k in opts) {
       this.config[k] = opts[k]
     }
-    if (!this.__pluginsExecuted) {
-      this.__pluginsExecuted = true
-      this.config.__plugins.forEach((plugin) => plugin.load(this))
-    }
+    this.loadPlugins()
 
     return this
+  }
+
+  loadPlugins() {
+    const pluginsToLoad = this.__pluginsLoaded
+      ? this.config.__plugins.filter(plugin => plugin.shouldReloadOnConfigure)
+      : this.config.__plugins
+    pluginsToLoad.forEach(plugin => plugin.load(this))
+    this.__pluginsLoaded = true
   }
 
   protected __initStore() {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -48,6 +48,7 @@ export interface AfterNotifyHandler {
 
 export interface Plugin {
   load(client: Client): void
+  shouldReloadOnConfigure?: boolean
 }
 
 export interface Notice {

--- a/packages/core/test/client.test.ts
+++ b/packages/core/test/client.test.ts
@@ -37,40 +37,51 @@ describe('client', function () {
     it('configures client and doesn\'t overwrite existing options', function () {
       expect(client.configure).toEqual(expect.any(Function))
 
-      client.configure({
-        apiKey: 'expected'
-      })
-      client.configure({
-        reportData: true
-      })
+      client.configure({ apiKey: 'expected' })
+      client.configure({ reportData: true })
 
       expect(client.config.apiKey).toEqual('expected')
       expect(client.config.reportData).toEqual(true)
     })
 
-    it('loads plugins once', function () {  
-      const plugin1 = { load: jest.fn()}
-      const plugin2 = { load: jest.fn()}
-
-      const clientWithPlugin = new TestClient({
-        logger: nullLogger(),
-        environment: null,
-        projectRoot: process.cwd(), 
-        __plugins: [ plugin1, plugin2 ],
-      }, new TestTransport())
-
-      clientWithPlugin.configure()
-      expect(plugin1.load).toHaveBeenCalledTimes(1)
-      expect(plugin2.load).toHaveBeenCalledTimes(1)
-
-      // Configuring again does not re-load
-      clientWithPlugin.configure()
-      expect(plugin1.load).toHaveBeenCalledTimes(1)
-      expect(plugin2.load).toHaveBeenCalledTimes(1)
+    it('loads plugins', function () {
+      jest.spyOn(client, 'loadPlugins')
+      client.configure()
+      expect(client.loadPlugins).toHaveBeenCalledTimes(1)
     })
 
     it('is chainable', function () {
       expect(client.configure({})).toEqual(client)
+    })
+  })
+
+  describe('loadPlugins', function () {
+    it('does nothing if there are no plugins', function () {
+      client.loadPlugins()
+      expect(client.getPluginsLoaded()).toEqual(true)
+    })
+
+    it('loads all plugins once and reloads as needed', function () {  
+      const plugin1 = { load: jest.fn() }
+      const plugin2 = { load: jest.fn(), shouldReloadOnConfigure: false }
+      const plugin3 = { load: jest.fn(), shouldReloadOnConfigure: true }
+
+      const clientWithPlugins = new TestClient({
+        logger: nullLogger(),
+        __plugins: [ plugin1, plugin2, plugin3 ],
+      }, new TestTransport())
+
+      clientWithPlugins.configure()
+      expect(plugin1.load).toHaveBeenCalledTimes(1)
+      expect(plugin2.load).toHaveBeenCalledTimes(1)
+      expect(plugin3.load).toHaveBeenCalledTimes(1)
+      expect(client.getPluginsLoaded()).toEqual(true)
+
+      // Only re-loads if shouldReloadOnConfigure is true
+      clientWithPlugins.configure()
+      expect(plugin1.load).toHaveBeenCalledTimes(1)
+      expect(plugin2.load).toHaveBeenCalledTimes(1)
+      expect(plugin3.load).toHaveBeenCalledTimes(2)
     })
   })
 

--- a/packages/core/test/client.test.ts
+++ b/packages/core/test/client.test.ts
@@ -34,14 +34,39 @@ describe('client', function () {
   })
 
   describe('configure', function () {
-    it('configures client', function () {
+    it('configures client and doesn\'t overwrite existing options', function () {
       expect(client.configure).toEqual(expect.any(Function))
 
       client.configure({
         apiKey: 'expected'
       })
+      client.configure({
+        reportData: true
+      })
 
       expect(client.config.apiKey).toEqual('expected')
+      expect(client.config.reportData).toEqual(true)
+    })
+
+    it('loads plugins once', function () {  
+      const plugin1 = { load: jest.fn()}
+      const plugin2 = { load: jest.fn()}
+
+      const clientWithPlugin = new TestClient({
+        logger: nullLogger(),
+        environment: null,
+        projectRoot: process.cwd(), 
+        __plugins: [ plugin1, plugin2 ],
+      }, new TestTransport())
+
+      clientWithPlugin.configure()
+      expect(plugin1.load).toHaveBeenCalledTimes(1)
+      expect(plugin2.load).toHaveBeenCalledTimes(1)
+
+      // Configuring again does not re-load
+      clientWithPlugin.configure()
+      expect(plugin1.load).toHaveBeenCalledTimes(1)
+      expect(plugin2.load).toHaveBeenCalledTimes(1)
     })
 
     it('is chainable', function () {

--- a/packages/core/test/helpers.ts
+++ b/packages/core/test/helpers.ts
@@ -52,4 +52,8 @@ export class TestClient extends BaseClient {
     // called in (server|browser).__send()
     return this.__buildPayload(notice)
   }
+
+  public getPluginsLoaded() {
+    return this.__pluginsLoaded
+  }
 }


### PR DESCRIPTION
## Status
**READY**

## Description
Part of https://github.com/honeybadger-io/honeybadger-js/issues/1163

This PR allows a plugin to use an option `reloadOnConfigure` to be reloaded whenever `configure()` is called, rather than just once. 

Currently no plugins use this feature, but we plan to use this functionality in the server-side `js` package's `unhandledRejection` and `uncaughtException` plugins. 



## Todos
- [x] Tests
~~- Documentation~~ The `__plugins` option appears to be undocumented (ie it does not appear [here](https://docs.honeybadger.io/lib/javascript/reference/configuration/#configuration-options), so I don't think this change requires documentation. 

## Steps to Test or Reproduce
```
npm run test
```
