### PR TITLE
fix(react/vue): update peer dep for vue and react

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -23,7 +23,7 @@
     "deploy": "gh-pages -d example/build"
   },
   "peerDependencies": {
-    "@honeybadger-io/js": "4.x || 5.x || 6.x",
+    "@honeybadger-io/js": "^6.2.0",
     "prop-types": "^15.0.0",
     "react": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0",
     "react-dom": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0"

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -64,7 +64,7 @@
     "vue-jest": "^5.0.0-alpha.10"
   },
   "peerDependencies": {
-    "@honeybadger-io/js": "3.x || 4.x || 5.x || 6.x",
+    "@honeybadger-io/js": "^6.2.0",
     "vue": "2.x || 3.x"
   },
   "browserslist": [


### PR DESCRIPTION
## Status
**READY**

## Description

Fixes #1175.

I think an older `@honeybadger-io/js` version is the cause of https://github.com/honeybadger-io/honeybadger-js/issues/1175 (waiting for user confirmation but it seems likely). 

https://github.com/honeybadger-io/honeybadger-js/pull/1107 started using `setNotifier()` but didn’t upgrade the peer dependency requirement. The change was released in 6.2.0: https://github.com/honeybadger-io/honeybadger-js/releases/tag/%40honeybadger-io/js%406.2.0

## Steps to Test or Reproduce
In the react example project, install a version of `@honeybadger-io/js` older than 6.2.0. You should see an error in the browser console related to `setNotifier()`. Installing version 6.2.0 should fix it. 
