### PR TITLE
feat(js): reload unhandledRejection and uncaughtException plugins on configure

### DIFF
--- a/packages/js/package-lock.json
+++ b/packages/js/package-lock.json
@@ -633,9 +633,9 @@
       "dev": true
     },
     "node_modules/@honeybadger-io/core": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@honeybadger-io/core/-/core-6.1.0.tgz",
-      "integrity": "sha512-t8GonzOfy0zSUvFvFIsvyCrYEyhNi341CDGiNbCQa6XBIISCr4BZPnXmnfRwqQZsVY6H5xyip4aZ8iT8LvvdXA==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@honeybadger-io/core/-/core-6.3.0.tgz",
+      "integrity": "sha512-iwLmh7GJCWQoqPrN56zdDfpNccwmUZbUyxTqkVhk16OpHJPz8kgENKHB/U6ZWf5/w43UzoHvxiJN8dAhlYoERg==",
       "dependencies": {
         "stacktrace-parser": "^0.1.10"
       },
@@ -6971,9 +6971,9 @@
       "dev": true
     },
     "@honeybadger-io/core": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@honeybadger-io/core/-/core-6.1.0.tgz",
-      "integrity": "sha512-t8GonzOfy0zSUvFvFIsvyCrYEyhNi341CDGiNbCQa6XBIISCr4BZPnXmnfRwqQZsVY6H5xyip4aZ8iT8LvvdXA==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@honeybadger-io/core/-/core-6.3.0.tgz",
+      "integrity": "sha512-iwLmh7GJCWQoqPrN56zdDfpNccwmUZbUyxTqkVhk16OpHJPz8kgENKHB/U6ZWf5/w43UzoHvxiJN8dAhlYoERg==",
       "requires": {
         "stacktrace-parser": "^0.1.10"
       }

--- a/packages/js/src/server/integrations/uncaught_exception_monitor.ts
+++ b/packages/js/src/server/integrations/uncaught_exception_monitor.ts
@@ -22,14 +22,6 @@ export default class UncaughtExceptionMonitor {
   makeListener() {
     const honeybadgerUncaughtExceptionListener = (uncaughtError: Error) => {
       if (this.__isReporting || !this.__client) { return }
-  
-      if (!this.__client.config.enableUncaught) {
-        this.__client.config.afterUncaught(uncaughtError)
-        if (!this.hasOtherUncaughtExceptionListeners()) {
-          fatallyLogAndExit(uncaughtError)
-        }
-        return
-      }
     
       // report only the first error - prevent reporting recursive errors
       if (this.__handlerAlreadyCalled) {

--- a/packages/js/src/server/integrations/uncaught_exception_plugin.ts
+++ b/packages/js/src/server/integrations/uncaught_exception_plugin.ts
@@ -13,6 +13,7 @@ export default function (): Types.Plugin {
       } else {
         uncaughtExceptionMonitor.maybeRemoveListener()
       }
-    }
+    }, 
+    shouldReloadOnConfigure: true,
   }
 }

--- a/packages/js/src/server/integrations/unhandled_rejection_monitor.ts
+++ b/packages/js/src/server/integrations/unhandled_rejection_monitor.ts
@@ -18,13 +18,6 @@ export default class UnhandledRejectionMonitor {
 
   makeListener() {
     const honeybadgerUnhandledRejectionListener = (reason: unknown, _promise: Promise<unknown>) => {
-      if (!this.__client || !this.__client.config.enableUnhandledRejection) {
-        if (!this.hasOtherUnhandledRejectionListeners() && !this.__isReporting) {
-          fatallyLogAndExit(reason as Error)
-        }
-        return
-      }
-  
       this.__isReporting = true;
       this.__client.notify(reason as Types.Noticeable, { component: 'unhandledRejection' }, {
         afterNotify: () => {

--- a/packages/js/src/server/integrations/unhandled_rejection_plugin.ts
+++ b/packages/js/src/server/integrations/unhandled_rejection_plugin.ts
@@ -13,6 +13,7 @@ export default function (): Types.Plugin {
       } else {
         unhandledRejectionMonitor.maybeRemoveListener()
       } 
-    }
+    }, 
+    shouldReloadOnConfigure: true,
   }
 }

--- a/packages/js/test/unit/server.test.ts
+++ b/packages/js/test/unit/server.test.ts
@@ -299,4 +299,29 @@ describe('server client', function () {
       expect(request.isDone()).toBe(true)
     })
   })
+
+  describe('__plugins', function () {
+    it('exported singleton includes plugins', function () {
+      Singleton.configure({ apiKey: 'foo' })
+      expect(Singleton.config.__plugins.length).toBe(2)
+    })
+    
+    it('clients produced via factory don\'t include plugins', function () {
+      client.configure({ apiKey: 'foo' })
+      expect(client.config.__plugins.length).toBe(0)
+    })
+
+    // Integration test with the plugins themselves
+    it('uncaughtException and unhandledRejection plugins reload on configure', function () {
+      function getListenerCount(type) {
+        return process.listeners(type).length
+      }
+      Singleton.configure({ apiKey: 'foo' })
+      expect(getListenerCount('uncaughtException')).toBe(1)
+      expect(getListenerCount('unhandledRejection')).toBe(1)
+      Singleton.configure({ enableUncaught: false, enableUnhandledRejection: false })
+      expect(getListenerCount('uncaughtException')).toBe(0)
+      expect(getListenerCount('unhandledRejection')).toBe(0)
+    })
+  })
 })

--- a/packages/js/test/unit/server/integrations/uncaught_exception_plugin.server.test.ts
+++ b/packages/js/test/unit/server/integrations/uncaught_exception_plugin.server.test.ts
@@ -35,7 +35,8 @@ describe('Uncaught Exception Plugin', () => {
 
   it('is a function which returns an object with a load function', () => {
     expect(plugin()).toStrictEqual({
-      load: expect.any(Function)
+      load: expect.any(Function), 
+      shouldReloadOnConfigure: true,
     })
   })
 

--- a/packages/js/test/unit/server/integrations/unhandled_rejection_monitor.server.test.ts
+++ b/packages/js/test/unit/server/integrations/unhandled_rejection_monitor.server.test.ts
@@ -92,22 +92,6 @@ describe('UnhandledRejectionMonitor', () => {
         done()
       }) 
     })
-
-    it('exits if enableUnhandledRejection is false and there are no other listeners', () => {
-      client.configure({ enableUnhandledRejection: false })
-      unhandledRejectionMonitor.__listener(reason, promise)
-      expect(notifySpy).not.toHaveBeenCalled()
-      expect(fatallyLogAndExitSpy).toHaveBeenCalledWith(reason)
-    })
-
-    it('returns if enableUnhandledRejection is false and there are other listeners', () => {
-      process.on('unhandledRejection', () => true)
-      process.on('unhandledRejection', () => true)
-      client.configure({ enableUnhandledRejection: false })
-      unhandledRejectionMonitor.__listener(reason, promise)
-      expect(notifySpy).not.toHaveBeenCalled()
-      expect(fatallyLogAndExitSpy).not.toHaveBeenCalled()
-    })
   })
 
   describe('hasOtherUnhandledRejectionListeners', () => {

--- a/packages/js/test/unit/server/integrations/unhandled_rejection_plugin.server.test.ts
+++ b/packages/js/test/unit/server/integrations/unhandled_rejection_plugin.server.test.ts
@@ -35,7 +35,8 @@ describe('Uncaught Exception Plugin', () => {
 
   it('is a function which returns an object with a load function', () => {
     expect(plugin()).toStrictEqual({
-      load: expect.any(Function)
+      load: expect.any(Function), 
+      shouldReloadOnConfigure: true,
     })
   })
 


### PR DESCRIPTION
## Status
**READY**

## Description
Part of https://github.com/honeybadger-io/honeybadger-js/issues/1163

Core version 6.3.0 includes the ability for plugins to set `shouldReloadOnConfigure`. This PR turns that on for the `unhandledRejection` and `uncaughtException` plugins. 


## Related PRs
Listed in https://github.com/honeybadger-io/honeybadger-js/issues/1163 

## Todos
- [x] Tests
- [x] Documentation - https://github.com/honeybadger-io/docs/pull/334

## Steps to Test or Reproduce
```bash
cd packages/js
npm run test:server
```

