### PR TITLE
docs(react-native): sourcemaps in own section

### DIFF
--- a/packages/react-native/README.md
+++ b/packages/react-native/README.md
@@ -49,7 +49,7 @@ Error reports can be [customized](https://docs.honeybadger.io/lib/javascript/gui
 ### Limitations
 Some native errors on Android may not be recorded if they cause an immediate crash of the app before the notice makes it to Honeybadger. 
 
-### Source Maps
+## Source Maps
 To generate and upload source maps to Honeybadger, use the following command:
 ```shell
 npx honeybadger-upload-sourcemaps --apiKey <your project API key> --revision <build revision>


### PR DESCRIPTION
## Status
**READY**

## Description
The docs repo does not want to use a `###` heading to pull an excerpt. I'd argue that the sourcemap section is large/important enough to warrant its own section anyway!
