### PR TITLE
fix(nextjs): build copy files script as a commonjs module with rollup

### DIFF
--- a/packages/nextjs/package-lock.json
+++ b/packages/nextjs/package-lock.json
@@ -24,6 +24,7 @@
         "next": "^13.2.3",
         "rollup": "^2.70.2",
         "rollup-plugin-copy": "^3.4.0",
+        "rollup-plugin-executable": "^1.6.3",
         "ts-jest": "^29.1.1",
         "typescript": "^4.6.3"
       },
@@ -619,9 +620,9 @@
       "dev": true
     },
     "node_modules/@honeybadger-io/core": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@honeybadger-io/core/-/core-6.1.0.tgz",
-      "integrity": "sha512-t8GonzOfy0zSUvFvFIsvyCrYEyhNi341CDGiNbCQa6XBIISCr4BZPnXmnfRwqQZsVY6H5xyip4aZ8iT8LvvdXA==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@honeybadger-io/core/-/core-6.3.0.tgz",
+      "integrity": "sha512-iwLmh7GJCWQoqPrN56zdDfpNccwmUZbUyxTqkVhk16OpHJPz8kgENKHB/U6ZWf5/w43UzoHvxiJN8dAhlYoERg==",
       "dependencies": {
         "stacktrace-parser": "^0.1.10"
       },
@@ -630,11 +631,11 @@
       }
     },
     "node_modules/@honeybadger-io/js": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/@honeybadger-io/js/-/js-6.2.0.tgz",
-      "integrity": "sha512-+Zana1kfOEIEAB5U6gNzH3IvYJM8fRKIm7agqF0DhOwWgaVkNPnHLEs1HyKY+Bc1DGM5JZx95y5fGcnol0PmtA==",
+      "version": "6.4.3",
+      "resolved": "https://registry.npmjs.org/@honeybadger-io/js/-/js-6.4.3.tgz",
+      "integrity": "sha512-wL2o0xdyX9uwgNFuBUuD9KluLAxIL9JK7tC976mkxpi+MXFjgkHNC41E9/Z8Zv+UBNYO4jQaI/jiLvPl32uqpw==",
       "dependencies": {
-        "@honeybadger-io/core": "^6.1.0",
+        "@honeybadger-io/core": "^6.3.0",
         "@types/aws-lambda": "^8.10.89",
         "@types/express": "^4.17.13"
       },
@@ -643,15 +644,15 @@
       }
     },
     "node_modules/@honeybadger-io/react": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@honeybadger-io/react/-/react-6.1.0.tgz",
-      "integrity": "sha512-BOhmr1S2SDMynAEQv4fexYoekuRouHl5yAVONA8IwN6DRgCRaRZseqqr0/Rb9jauySTC6GbL1U8krYsuLZgH7Q==",
+      "version": "6.1.5",
+      "resolved": "https://registry.npmjs.org/@honeybadger-io/react/-/react-6.1.5.tgz",
+      "integrity": "sha512-wn49PCF5qK6FRnSlHs1yTNK0qs5Ec6vbt6LspTIbH85WyDDrFX8yrr455hVpJOOjQCLvixQfeO/+0mBYnGHdSw==",
       "dev": true,
       "engines": {
         "node": ">=14"
       },
       "peerDependencies": {
-        "@honeybadger-io/js": "4.x || 5.x || 6.x",
+        "@honeybadger-io/js": "^6.2.0",
         "prop-types": "^15.0.0",
         "react": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0",
         "react-dom": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0"
@@ -4496,6 +4497,20 @@
         "node": ">=8.3"
       }
     },
+    "node_modules/rollup-plugin-executable": {
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-executable/-/rollup-plugin-executable-1.6.3.tgz",
+      "integrity": "sha512-634q95UyowXcX5yu3zIxVQ5aWgE3WVE1zdIiwKangMYt1Lw0T0MfCHEPYvZP/0V7ni2NJr/4iVseIgCjkuSA1A==",
+      "dev": true,
+      "dependencies": {
+        "@babel/runtime": "^7.14.0"
+      },
+      "engines": {
+        "node": ">=10.0.0",
+        "npm": ">=4.0.0",
+        "yarn": ">=1.0.0"
+      }
+    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -5800,27 +5815,27 @@
       "dev": true
     },
     "@honeybadger-io/core": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@honeybadger-io/core/-/core-6.1.0.tgz",
-      "integrity": "sha512-t8GonzOfy0zSUvFvFIsvyCrYEyhNi341CDGiNbCQa6XBIISCr4BZPnXmnfRwqQZsVY6H5xyip4aZ8iT8LvvdXA==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@honeybadger-io/core/-/core-6.3.0.tgz",
+      "integrity": "sha512-iwLmh7GJCWQoqPrN56zdDfpNccwmUZbUyxTqkVhk16OpHJPz8kgENKHB/U6ZWf5/w43UzoHvxiJN8dAhlYoERg==",
       "requires": {
         "stacktrace-parser": "^0.1.10"
       }
     },
     "@honeybadger-io/js": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/@honeybadger-io/js/-/js-6.2.0.tgz",
-      "integrity": "sha512-+Zana1kfOEIEAB5U6gNzH3IvYJM8fRKIm7agqF0DhOwWgaVkNPnHLEs1HyKY+Bc1DGM5JZx95y5fGcnol0PmtA==",
+      "version": "6.4.3",
+      "resolved": "https://registry.npmjs.org/@honeybadger-io/js/-/js-6.4.3.tgz",
+      "integrity": "sha512-wL2o0xdyX9uwgNFuBUuD9KluLAxIL9JK7tC976mkxpi+MXFjgkHNC41E9/Z8Zv+UBNYO4jQaI/jiLvPl32uqpw==",
       "requires": {
-        "@honeybadger-io/core": "^6.1.0",
+        "@honeybadger-io/core": "^6.3.0",
         "@types/aws-lambda": "^8.10.89",
         "@types/express": "^4.17.13"
       }
     },
     "@honeybadger-io/react": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@honeybadger-io/react/-/react-6.1.0.tgz",
-      "integrity": "sha512-BOhmr1S2SDMynAEQv4fexYoekuRouHl5yAVONA8IwN6DRgCRaRZseqqr0/Rb9jauySTC6GbL1U8krYsuLZgH7Q==",
+      "version": "6.1.5",
+      "resolved": "https://registry.npmjs.org/@honeybadger-io/react/-/react-6.1.5.tgz",
+      "integrity": "sha512-wn49PCF5qK6FRnSlHs1yTNK0qs5Ec6vbt6LspTIbH85WyDDrFX8yrr455hVpJOOjQCLvixQfeO/+0mBYnGHdSw==",
       "dev": true,
       "requires": {}
     },
@@ -8739,6 +8754,15 @@
         "fs-extra": "^8.1.0",
         "globby": "10.0.1",
         "is-plain-object": "^3.0.0"
+      }
+    },
+    "rollup-plugin-executable": {
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-executable/-/rollup-plugin-executable-1.6.3.tgz",
+      "integrity": "sha512-634q95UyowXcX5yu3zIxVQ5aWgE3WVE1zdIiwKangMYt1Lw0T0MfCHEPYvZP/0V7ni2NJr/4iVseIgCjkuSA1A==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.14.0"
       }
     },
     "run-parallel": {

--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -30,7 +30,7 @@
     "url": "git+https://github.com/honeybadger-io/honeybadger-js.git"
   },
   "scripts": {
-    "build": "tsc --build tsconfig.json && rollup -c && tsc --build tsconfig.types.json",
+    "build": "tsc --build tsconfig.json && rollup -c && rollup -c rollup.scripts.config.js && tsc --build tsconfig.types.json",
     "test": "./node_modules/jest/bin/jest.js --config jest.config.js"
   },
   "bugs": {
@@ -53,6 +53,7 @@
     "next": "^13.2.3",
     "rollup": "^2.70.2",
     "rollup-plugin-copy": "^3.4.0",
+    "rollup-plugin-executable": "^1.6.3",
     "ts-jest": "^29.1.1",
     "typescript": "^4.6.3"
   },

--- a/packages/nextjs/rollup.config.js
+++ b/packages/nextjs/rollup.config.js
@@ -37,8 +37,6 @@ export default {
     commonjs(),
     copy({
       targets: [
-        { src: 'build/copy-config-files.js*', dest: 'dist' },
-        { src: 'build/copy-config-files-exec.js*', dest: 'dist' },
         { src: 'build/*.d.ts', dest: 'dist' },
       ]
     })

--- a/packages/nextjs/rollup.scripts.config.js
+++ b/packages/nextjs/rollup.scripts.config.js
@@ -1,0 +1,28 @@
+import commonjs from '@rollup/plugin-commonjs'
+import executable from 'rollup-plugin-executable'
+import path from 'path'
+
+export default {
+  input: 'build/copy-config-files-exec.js',
+  output: [
+    {
+      file: 'dist/copy-config-files-exec.js',
+      banner: '#!/usr/bin/env node', // rollup throws an error if this line is already in the js file
+      exports: 'named',
+      format: 'cjs',
+      sourcemap: true,
+      sourcemapPathTransform: relativePath => {
+        // will transform e.g. "src/main.js" -> "main.js"
+        return path.relative('src', relativePath)
+      },
+    },
+  ],
+  external: [
+    'fs',
+    'path',
+  ],
+  plugins: [
+    commonjs(),
+    executable(),
+  ]
+}

--- a/packages/nextjs/src/copy-config-files-exec.ts
+++ b/packages/nextjs/src/copy-config-files-exec.ts
@@ -1,5 +1,3 @@
-#!/usr/bin/env node
-
 const { copyConfigFiles } = require('./copy-config-files')
 
 copyConfigFiles().catch((err) => {


### PR DESCRIPTION
## Status
**READY**

## Description
Fixes #1186.
I can't pinpoint how this broke, but I know that it was working before 😓 .
The issue is that the executable script is built with Typescript with a module target to esnext. Nodejs uses commonjs by default and we usually transform to commonjs when bundling with rollup. This PR adds a rollup config file to bundle the `honeybadger-copy-config-files` script in commonjs.