### PR TITLE
feat(nextjs): simplify default configuration

### DIFF
--- a/packages/nextjs/src/types.ts
+++ b/packages/nextjs/src/types.ts
@@ -1,8 +1,8 @@
 export type NextJsRuntime = 'server' | 'browser' | 'edge'
 export type HoneybadgerNextJsConfig = {
-    disableSourceMapUpload: boolean
-    silent: boolean
-    webpackPluginOptions: Omit<HoneybadgerWebpackPluginOptions, 'silent'>
+    disableSourceMapUpload?: boolean
+    silent?: boolean
+    webpackPluginOptions?: Omit<HoneybadgerWebpackPluginOptions, 'silent'>
 }
 
 // this should be in @honeybadger-io/webpack


### PR DESCRIPTION
## Status
**READY**

## Description
Simplifies nextjs installation:
- no need to setup source map upload to get nextjs working
- simpler installation with `setupHoneybadger(nextJsConfig)`

You can read more about this [here](https://github.com/honeybadger-io/honeybadger/issues/4169).
