### PR TITLE
fix(plugin-core): support minified url creation with pathname in assetUrl

### DIFF
--- a/packages/plugin-core/src/sourcemaps.ts
+++ b/packages/plugin-core/src/sourcemaps.ts
@@ -3,6 +3,7 @@ import originalFetch from 'node-fetch'
 import FormData from 'form-data'
 import { promises as fs } from 'fs'
 import fetchRetry from 'fetch-retry'
+import path from 'path'
 // @ts-expect-error
 const fetch = fetchRetry(originalFetch)
 
@@ -81,7 +82,9 @@ export async function buildBodyForSourcemapUpload(
 ): Promise<FormData> {
   const form = new FormData()
 
-  const minifiedUrl = new URL(sourcemapData.jsFilename, hbOptions.assetsUrl).href
+  const url = new URL(hbOptions.assetsUrl)
+  url.pathname = path.join(url.pathname, sourcemapData.jsFilename)
+  const minifiedUrl = url.href
 
   form.append('api_key', hbOptions.apiKey)
   form.append('minified_url', minifiedUrl)

--- a/packages/plugin-core/test/sourcemaps.test.ts
+++ b/packages/plugin-core/test/sourcemaps.test.ts
@@ -224,5 +224,33 @@ describe('sourcemaps', () => {
         expect(str.match(pattern)).to.have.length(1)
       }) 
     })
+
+    it('should support assetsUrl with path', async () => {
+      const result = await sourcemaps.buildBodyForSourcemapUpload(testData, { ...hbOptions, assetsUrl: 'https://foo.bar/_next' })
+
+      expect(result).to.be.an.instanceOf(FormData)
+
+      const buf = result.getBuffer()
+      const str = buf.toString()
+
+      const expectedFields = [
+        ['api_key', 'test_key'], 
+        ['minified_url', 'https://foo.bar/_next/index.js'], 
+        ['revision', '12345'],    
+      ]
+      const expectedFiles = [
+        ['minified_file', 'index.js', 'application/javascript'], 
+        ['source_map', 'index.map.js', 'application/octet-stream']
+      ]
+
+      expectedFields.forEach(([key, value]) => {
+        const pattern = new RegExp(`Content-Disposition: form-data; name="${key}"\\s*${value}`)
+        expect(str.match(pattern)).to.have.length(1)
+      })  
+      expectedFiles.forEach(([key, fileName, type]) => {
+        const pattern = new RegExp(`Content-Disposition: form-data; name="${key}"; filename="${fileName}"\\s*Content-Type: ${type}`)
+        expect(str.match(pattern)).to.have.length(1)
+      }) 
+    })
   })
 })


### PR DESCRIPTION
## Status
<!--- **READY/WIP/HOLD** --->
**READY**

## Description
`honeybadger-io/next` suggest to set the assetUrl to `https://my-app.vercel.app/_next` ([link](https://docs.honeybadger.io/lib/javascript/integration/nextjs/#configuration))

However, the plugin-core uses the `URL` class in a way that does not support this. Instead of overwriting the assetsUrl pathname, this PR joins them.

## Steps to Test or Reproduce
1. Follow the instructions at https://docs.honeybadger.io/lib/javascript/integration/nextjs
2. Observe that sourcemaps are not correctly uploaded including `_next` in the pathname