### PR TITLE
feat(js): read config from file

### DIFF
--- a/packages/js/src/server.ts
+++ b/packages/js/src/server.ts
@@ -12,6 +12,10 @@ import { CheckinsConfig } from './server/checkins-manager/types'
 import { CheckinsClient } from './server/checkins-manager/client';
 
 const { endpoint } = Util
+const DEFAULT_PLUGINS = [
+  uncaughtException(),
+  unhandledRejection()
+]
 
 type HoneybadgerServerConfig = (Types.Config | Types.ServerlessConfig) & CheckinsConfig
 
@@ -61,8 +65,12 @@ class Honeybadger extends Client {
   }
 
   factory(opts?: Partial<HoneybadgerServerConfig>): this {
+    const clone = new Honeybadger({
+      __plugins: DEFAULT_PLUGINS,
+      ...(readConfigFromFileSystem() ?? {}),
+      ...opts,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const clone = new Honeybadger(opts) as any
+    }) as any
     clone.setNotifier(this.getNotifier())
 
     return clone
@@ -160,10 +168,7 @@ class Honeybadger extends Client {
 }
 
 const singleton = new Honeybadger({
-  __plugins: [
-    uncaughtException(),
-    unhandledRejection()
-  ],
+  __plugins: DEFAULT_PLUGINS,
   ...(readConfigFromFileSystem() ?? {})
 })
 

--- a/packages/js/src/server.ts
+++ b/packages/js/src/server.ts
@@ -66,7 +66,8 @@ class Honeybadger extends Client {
 
   factory(opts?: Partial<HoneybadgerServerConfig>): this {
     const clone = new Honeybadger({
-      __plugins: DEFAULT_PLUGINS,
+      // fixme: this can create unwanted side-effects, needs to be tested thoroughly before enabling
+      // __plugins: DEFAULT_PLUGINS,
       ...(readConfigFromFileSystem() ?? {}),
       ...opts,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/js/src/server/util.ts
+++ b/packages/js/src/server/util.ts
@@ -79,8 +79,14 @@ export function readConfigFromFileSystem(): Record<string, unknown> {
 }
 
 function readConfigForModule(moduleName: string): Record<string, unknown> {
-  const fileExplorer = cosmiconfigSync(moduleName)
-  const result = fileExplorer.search()
+  try {
+    const fileExplorer = cosmiconfigSync(moduleName)
+    const result = fileExplorer.search()
 
-  return result?.config ?? null
+    return result?.config ?? null
+  }
+  catch (e) {
+    console.debug(`[Honeybadger] Could not read config for module ${moduleName}: ${e.message}`)
+    return null
+  }
 }


### PR DESCRIPTION
## Status
**READY**

## Description
Configure Honeybadger using a config file (**server only**).
Closes: #1243

## Todos
- [x] Tests
- [x] Documentation (https://github.com/honeybadger-io/docs/issues/375)
- [x] Bonus: adds a _fixme_ comment for the known inconsistency when creating multiple Honeybadger clients where default plugins are not added by default
