### PR TITLE
fix: handle case where events logger did not receive new configuration

### DIFF
--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -101,6 +101,7 @@ export abstract class Client {
     for (const k in opts) {
       this.config[k] = opts[k]
     }
+    this.__eventsLogger.configure(this.config)
     this.loadPlugins()
 
     return this

--- a/packages/core/src/throttled_events_logger.ts
+++ b/packages/core/src/throttled_events_logger.ts
@@ -16,6 +16,12 @@ export class ThrottledEventsLogger implements EventsLogger {
     this.logger = this.originalLogger()
   }
 
+  configure(opts: Partial<Config>): void {
+    for (const k in opts) {
+      this.config[k] = opts[k]
+    }
+  }
+
   logEvent(data: Record<string, unknown>) {
     this.queue.push(data)
 
@@ -74,6 +80,8 @@ export class ThrottledEventsLogger implements EventsLogger {
   }
 
   /**
+   * todo: improve this
+   *
    * The EventsLogger overrides the console methods
    * so if we want to log something we need to use the original methods
    */

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -9,6 +9,7 @@ export interface Logger {
 }
 
 export interface EventsLogger {
+  configure: (opts: Partial<Config>) => void
   logEvent(data: Record<string, unknown>): void
 }
 

--- a/packages/core/test/client.test.ts
+++ b/packages/core/test/client.test.ts
@@ -2,6 +2,7 @@ import * as stackTraceParser from 'stacktrace-parser'
 import { nullLogger, TestClient, TestTransport } from './helpers'
 import { Notice } from '../src/types'
 import { makeBacktrace, DEFAULT_BACKTRACE_SHIFT } from '../src/util'
+import { ThrottledEventsLogger } from '../src/throttled_events_logger';
 
 class MyError extends Error {
   context = null
@@ -52,6 +53,17 @@ describe('client', function () {
 
     it('is chainable', function () {
       expect(client.configure({})).toEqual(client)
+    })
+
+    it('configures event logger from base config', function () {
+      client.configure({
+        apiKey: 'testing',
+      })
+
+      // @ts-ignore
+      expect(client.__eventsLogger).toBeInstanceOf(ThrottledEventsLogger)
+      // @ts-ignore
+      expect(client.__eventsLogger.config.apiKey).toEqual(client.config.apiKey)
     })
   })
 


### PR DESCRIPTION
## Status
**READY**

## Description
I was trying to test the new plugin for logging events to Insights and noticed this bug.