### PR TITLE
ci: fix integration tests

### DIFF
--- a/packages/js/package-lock.json
+++ b/packages/js/package-lock.json
@@ -14,10 +14,10 @@
         "cosmiconfig": "^8.3.6"
       },
       "bin": {
-        "honeybadger-checkins-sync": "dist/server/checkins-sync-exec.js"
+        "honeybadger-checkins-sync": "dist/server/check-ins-sync-exec.js"
       },
       "devDependencies": {
-        "@playwright/test": "1.38.1",
+        "@playwright/test": "1.39.0",
         "@rollup/plugin-commonjs": "^22.0.1",
         "@rollup/plugin-node-resolve": "^13.3.0",
         "@rollup/plugin-replace": "^5.0.2",
@@ -1113,12 +1113,12 @@
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.38.1",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.38.1.tgz",
-      "integrity": "sha512-NqRp8XMwj3AK+zKLbZShl0r/9wKgzqI/527bkptKXomtuo+dOjU9NdMASQ8DNC9z9zLOMbG53T4eihYr3XR+BQ==",
+      "version": "1.39.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.39.0.tgz",
+      "integrity": "sha512-3u1iFqgzl7zr004bGPYiN/5EZpRUSFddQBra8Rqll5N0/vfpqlP9I9EXqAoGacuAbX6c9Ulg/Cjqglp5VkK6UQ==",
       "dev": true,
       "dependencies": {
-        "playwright": "1.38.1"
+        "playwright": "1.39.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -5165,12 +5165,12 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.38.1",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.38.1.tgz",
-      "integrity": "sha512-oRMSJmZrOu1FP5iu3UrCx8JEFRIMxLDM0c/3o4bpzU5Tz97BypefWf7TuTNPWeCe279TPal5RtPPZ+9lW/Qkow==",
+      "version": "1.39.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.39.0.tgz",
+      "integrity": "sha512-naE5QT11uC/Oiq0BwZ50gDmy8c8WLPRTEWuSSFVG2egBka/1qMoSqYQcROMT9zLwJ86oPofcTH2jBY/5wWOgIw==",
       "dev": true,
       "dependencies": {
-        "playwright-core": "1.38.1"
+        "playwright-core": "1.39.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -5183,9 +5183,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.38.1",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.38.1.tgz",
-      "integrity": "sha512-tQqNFUKa3OfMf4b2jQ7aGLB8o9bS3bOY0yMEtldtC2+spf8QXG9zvXLTXUeRsoNuxEYMgLYR+NXfAa1rjKRcrg==",
+      "version": "1.39.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.39.0.tgz",
+      "integrity": "sha512-+k4pdZgs1qiM+OUkSjx96YiKsXsmb59evFoqv8SKO067qBA+Z2s/dCzJij/ZhdQcs2zlTAgRKfeiiLm8PQ2qvw==",
       "dev": true,
       "bin": {
         "playwright-core": "cli.js"
@@ -7651,12 +7651,12 @@
       }
     },
     "@playwright/test": {
-      "version": "1.38.1",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.38.1.tgz",
-      "integrity": "sha512-NqRp8XMwj3AK+zKLbZShl0r/9wKgzqI/527bkptKXomtuo+dOjU9NdMASQ8DNC9z9zLOMbG53T4eihYr3XR+BQ==",
+      "version": "1.39.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.39.0.tgz",
+      "integrity": "sha512-3u1iFqgzl7zr004bGPYiN/5EZpRUSFddQBra8Rqll5N0/vfpqlP9I9EXqAoGacuAbX6c9Ulg/Cjqglp5VkK6UQ==",
       "dev": true,
       "requires": {
-        "playwright": "1.38.1"
+        "playwright": "1.39.0"
       }
     },
     "@rollup/plugin-commonjs": {
@@ -10806,19 +10806,19 @@
       }
     },
     "playwright": {
-      "version": "1.38.1",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.38.1.tgz",
-      "integrity": "sha512-oRMSJmZrOu1FP5iu3UrCx8JEFRIMxLDM0c/3o4bpzU5Tz97BypefWf7TuTNPWeCe279TPal5RtPPZ+9lW/Qkow==",
+      "version": "1.39.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.39.0.tgz",
+      "integrity": "sha512-naE5QT11uC/Oiq0BwZ50gDmy8c8WLPRTEWuSSFVG2egBka/1qMoSqYQcROMT9zLwJ86oPofcTH2jBY/5wWOgIw==",
       "dev": true,
       "requires": {
         "fsevents": "2.3.2",
-        "playwright-core": "1.38.1"
+        "playwright-core": "1.39.0"
       }
     },
     "playwright-core": {
-      "version": "1.38.1",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.38.1.tgz",
-      "integrity": "sha512-tQqNFUKa3OfMf4b2jQ7aGLB8o9bS3bOY0yMEtldtC2+spf8QXG9zvXLTXUeRsoNuxEYMgLYR+NXfAa1rjKRcrg==",
+      "version": "1.39.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.39.0.tgz",
+      "integrity": "sha512-+k4pdZgs1qiM+OUkSjx96YiKsXsmb59evFoqv8SKO067qBA+Z2s/dCzJij/ZhdQcs2zlTAgRKfeiiLm8PQ2qvw==",
       "dev": true
     },
     "plur": {

--- a/packages/js/package.json
+++ b/packages/js/package.json
@@ -57,7 +57,7 @@
     "cosmiconfig": "^8.3.6"
   },
   "devDependencies": {
-    "@playwright/test": "1.38.1",
+    "@playwright/test": "1.39.0",
     "@rollup/plugin-commonjs": "^22.0.1",
     "@rollup/plugin-node-resolve": "^13.3.0",
     "@rollup/plugin-replace": "^5.0.2",

--- a/packages/js/test/e2e/browserstack.config.ts
+++ b/packages/js/test/e2e/browserstack.config.ts
@@ -10,6 +10,25 @@ const clientPlaywrightVersion = cp
   .trim()
   .split(' ')[1]
 
+const getGitBranchUsingCommand = () => {
+  return cp
+    .execSync('git rev-parse --abbrev-ref HEAD')
+    .toString()
+}
+
+const getBuildLabel = () => {
+  let branchName = process.env.GITHUB_REF_NAME
+  if (!branchName) {
+    branchName = getGitBranchUsingCommand()
+  }
+
+  if (branchName.startsWith('fatal: not a git repository')) {
+    branchName = new Date().toDateString()
+  }
+
+  return `honeybadger-playwright-browserstack-${branchName}`
+}
+
 export const bsLocal = new BrowserStackLocal.Local()
 
 export const BS_LOCAL_ARGS = {
@@ -23,14 +42,13 @@ const defaultCapabilities = {
   os: 'osx',
   os_version: 'catalina',
   name: 'Honeybadger Integration Tests',
-  build: 'honeybadger-playwright-browserstack',
+  build: getBuildLabel(),
   'browserstack.username': process.env.BROWSERSTACK_USERNAME,
   'browserstack.accessKey': process.env.BROWSERSTACK_ACCESS_KEY,
   'browserstack.local': true, // we are running a local web server, so we need this to be true
   'browserstack.networkLogs': true,
   'browserstack.debug': true, // visual logs
   'browserstack.console': 'verbose', // console logs
-  'browserstack.playwrightVersion': clientPlaywrightVersion,
   'client.playwrightVersion': clientPlaywrightVersion,
 }
 

--- a/packages/js/test/e2e/browserstack.config.ts
+++ b/packages/js/test/e2e/browserstack.config.ts
@@ -30,6 +30,7 @@ const defaultCapabilities = {
   'browserstack.networkLogs': true,
   'browserstack.debug': true, // visual logs
   'browserstack.console': 'verbose', // console logs
+  'browserstack.playwrightVersion': clientPlaywrightVersion,
   'client.playwrightVersion': clientPlaywrightVersion,
 }
 


### PR DESCRIPTION
## Status
**READY**

## Description
It appears that e2e tests stopped working; they appear to be running forever. I am trying a few solutions in this PR.
I tried:
- manually setting the `playwrightVersion` for BrowserStack through `browserstack.playwrightVersion`. It didn't work, because [apparently BrowserStack first looks at browser version when selecting the playwrightVersion to run](https://www.browserstack.com/docs/automate/playwright/browsers-and-os#specify-playwright-version).
- [x] updating local playwright package to match what is running on BrowserStack. This made it to work, though it means we it's something we will have to do every once in while BrowserStack's version selection algorithm selects a newer version. This is OK, considering this is the recommended approach: keep playwright up-to-date so that newer browser versions will be tested and compatible with playwright's API.
