### PR TITLE
fix(react-native): remove wrong jest import

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -8,6 +8,10 @@
     "plugin:import/typescript"
   ],
   "parser": "@typescript-eslint/parser",
+  "plugins": [
+    "@typescript-eslint",
+    "eslint-plugin-local-rules"
+  ],
   "rules": {
     "quotes": [
       "error",
@@ -32,16 +36,14 @@
       {
         "argsIgnorePattern": "^_"
       }
-    ]
+    ],
+    "local-rules/no-test-imports": "error"
   },
   "settings": {
     "import/ignore": [
       "node_modules/react-native/index\\.js$"
     ]
   },
-  "plugins": [
-    "@typescript-eslint"
-  ],
   "env":
   {
     "jest": true,

--- a/eslint-local-rules.js
+++ b/eslint-local-rules.js
@@ -1,0 +1,45 @@
+'use strict';
+
+const TEST_FILE_REGEX= /\.(spec|test)\.(js|ts|tsx)/
+// we can add more modules here
+const TEST_MODULES_REGEX= /jest/
+
+module.exports = {
+  'no-test-imports': {
+    meta: {
+      type: 'problem',
+      docs: {
+        description: 'Disallow importing test files in source code',
+      },
+      fixable: 'code',
+      schema: [] // no options
+    },
+    create: function(context) {
+      return {
+        ImportDeclaration: function(node) {
+          const physicalFilename = context.getPhysicalFilename().toLowerCase();
+
+          // stop if the filename is not in the src/ directory or is a test file
+          if (!physicalFilename.includes('src/') ||
+              physicalFilename.match(TEST_FILE_REGEX)) {
+            return;
+          }
+
+          // if we get here, we're in a source file, not a test file
+          const importSource = node.source.value.trim();
+          // do not allow importing test files or modules that include 'jest', such as 'jest-fetch-mock'
+          if (importSource.match(TEST_FILE_REGEX) ||
+              importSource.match(TEST_MODULES_REGEX)) {
+            context.report({
+              node: node,
+              message: 'Do not import test modules in source code',
+              fix: function(fixer) {
+                return fixer.remove(node);
+              }
+            });
+          }
+        }
+      };
+    }
+  }
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@typescript-eslint/parser": "^5.6.0",
         "eslint": "^8.20.0",
         "eslint-plugin-import": "^2.25.3",
+        "eslint-plugin-local-rules": "^2.0.1",
         "eslint-plugin-promise": "^6.0.0",
         "lerna": "^6.0.1"
       }
@@ -4336,6 +4337,12 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "dev": true
+    },
+    "node_modules/eslint-plugin-local-rules": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-local-rules/-/eslint-plugin-local-rules-2.0.1.tgz",
+      "integrity": "sha512-AJhGd+GcI5r2dbjiGPixM8jnBl0XFxqoVbqzwKbYz+nTk+Cj5dNE3+OlhC176bl5r25KsGsIthLi1VqIW5Ga+A==",
       "dev": true
     },
     "node_modules/eslint-plugin-promise": {
@@ -13450,6 +13457,12 @@
           "dev": true
         }
       }
+    },
+    "eslint-plugin-local-rules": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-local-rules/-/eslint-plugin-local-rules-2.0.1.tgz",
+      "integrity": "sha512-AJhGd+GcI5r2dbjiGPixM8jnBl0XFxqoVbqzwKbYz+nTk+Cj5dNE3+OlhC176bl5r25KsGsIthLi1VqIW5Ga+A==",
+      "dev": true
     },
     "eslint-plugin-promise": {
       "version": "6.0.0",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "@typescript-eslint/parser": "^5.6.0",
     "eslint": "^8.20.0",
     "eslint-plugin-import": "^2.25.3",
+    "eslint-plugin-local-rules": "^2.0.1",
     "eslint-plugin-promise": "^6.0.0",
     "lerna": "^6.0.1"
   },

--- a/packages/react-native/src/transport.ts
+++ b/packages/react-native/src/transport.ts
@@ -1,7 +1,6 @@
 import { Types, Util } from '@honeybadger-io/core'
 import { Platform } from 'react-native'
 import * as pkg from '../package.json'
-import fetch from 'jest-fetch-mock';
 
 export class Transport implements Types.Transport {
   defaultHeaders(): Record<string, string> {


### PR DESCRIPTION
## Status
**READY**

## Description
Fixes: #1278.

- Removes an erroneous `jest-fetch-mock` import that was added by mistake in a source file.
- Also creates a custom eslint rule that will prevent similar errors in the future.