### PR TITLE
feat: events api improvements

### DIFF
--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -7,6 +7,7 @@ import {
   runBeforeNotifyHandlers,
   shallowClone,
   logger,
+  logDeprecatedMethod,
   generateStackTrace,
   filter,
   filterUrl,
@@ -300,6 +301,14 @@ export abstract class Client {
     })
 
     return this
+  }
+
+  /**
+   * @deprecated Use {@link event} instead.
+   */
+  logEvent(data: Record<string, unknown>): void {
+    logDeprecatedMethod(this.logger, 'Honeybadger.logEvent', 'Honeybadger.event')
+    this.event('log', data)
   }
 
   event(type: string, data: Record<string, unknown>): void {

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -302,8 +302,12 @@ export abstract class Client {
     return this
   }
 
-  logEvent(data: Record<string, unknown>): void {
-    this.__eventsLogger.logEvent(data)
+  event(type: string, data: Record<string, unknown>): void {
+    this.__eventsLogger.log({
+      event_type: type,
+      ts: new Date().toISOString(),
+      ...data
+    })
   }
 
   __getBreadcrumbs() {

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -311,7 +311,13 @@ export abstract class Client {
     this.event('log', data)
   }
 
-  event(type: string, data: Record<string, unknown>): void {
+  event(data: Record<string, unknown>): void;
+  event(type: string, data: Record<string, unknown>): void;
+  event(type: string | Record<string, unknown>, data?: Record<string, unknown>): void {
+    if (typeof type === 'object') {
+      data = type
+      type = type['event_type'] as string ?? undefined
+    }
     this.__eventsLogger.log({
       event_type: type,
       ts: new Date().toISOString(),

--- a/packages/core/src/defaults.ts
+++ b/packages/core/src/defaults.ts
@@ -9,6 +9,7 @@ export const CONFIG = {
   revision: null,
   reportData: null,
   breadcrumbsEnabled: true,
+  // we could decide the value of eventsEnabled based on `env` and `developmentEnvironments`
   eventsEnabled: false,
   maxBreadcrumbs: 40,
   maxObjectDepth: 8,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,4 +1,10 @@
+import events from './plugins/events'
+
 export { Client } from './client'
 export * from './store'
 export * as Types from './types'
 export * as Util from './util'
+
+export const Plugins = {
+  events
+}

--- a/packages/core/src/plugins/events.ts
+++ b/packages/core/src/plugins/events.ts
@@ -1,7 +1,7 @@
 /* eslint-disable prefer-rest-params */
 import { Client } from '../client'
 import { globalThisOrWindow, instrumentConsole } from '../util';
-import { EventPayload, Plugin } from '../types'
+import { Plugin } from '../types'
 
 export default function (_window = globalThisOrWindow()): Plugin {
   return {

--- a/packages/core/src/plugins/events.ts
+++ b/packages/core/src/plugins/events.ts
@@ -1,14 +1,12 @@
 /* eslint-disable prefer-rest-params */
-import { Types, Util } from '@honeybadger-io/core'
-import Client from '../../browser'
-import { globalThisOrWindow } from '../util';
+import { Client } from '../client'
+import { globalThisOrWindow, instrumentConsole } from '../util';
+import { Plugin } from '../types'
 
-const { instrumentConsole } = Util
-
-export default function (_window = globalThisOrWindow()): Types.Plugin {
+export default function (_window = globalThisOrWindow()): Plugin {
   return {
     shouldReloadOnConfigure: false,
-    load: (client: typeof Client) => {
+    load: (client: Client) => {
       function sendEventsToInsights() {
         return client.config.eventsEnabled
       }
@@ -22,10 +20,10 @@ export default function (_window = globalThisOrWindow()): Types.Plugin {
           return
         }
 
-        // todo: send browser info
-        client.logEvent({
-          level,
-          args
+        client.event('log', {
+          severity: level,
+          message: args[0],
+          args: args.slice(1)
         })
       })
     }

--- a/packages/core/src/plugins/events.ts
+++ b/packages/core/src/plugins/events.ts
@@ -1,7 +1,7 @@
 /* eslint-disable prefer-rest-params */
 import { Client } from '../client'
 import { globalThisOrWindow, instrumentConsole } from '../util';
-import { Plugin } from '../types'
+import { EventPayload, Plugin } from '../types'
 
 export default function (_window = globalThisOrWindow()): Plugin {
   return {
@@ -20,11 +20,23 @@ export default function (_window = globalThisOrWindow()): Plugin {
           return
         }
 
-        client.event('log', {
+        if (args.length === 0) {
+          return
+        }
+
+        const data: Record<string, unknown> = {
           severity: level,
-          message: args[0],
-          args: args.slice(1)
-        })
+        }
+
+        if (typeof args[0] === 'string') {
+          data.message = args[0]
+          data.args = args.slice(1)
+        }
+        else {
+          data.args = args
+        }
+
+        client.event('log', data)
       })
     }
   }

--- a/packages/core/src/throttled_events_logger.ts
+++ b/packages/core/src/throttled_events_logger.ts
@@ -4,11 +4,11 @@ import { endpoint } from './util'
 import { CONFIG as DEFAULT_CONFIG } from './defaults';
 
 export class ThrottledEventsLogger implements EventsLogger {
-  private queue: Record<string, any>[] = []
+  private queue: EventPayload[] = []
   private isProcessing = false
   private logger: Logger
 
-  constructor(private config: Partial<Config>, private transport: Transport) {
+  constructor(private readonly config: Partial<Config>, private transport: Transport) {
     this.config = {
       ...DEFAULT_CONFIG,
       ...config,

--- a/packages/core/src/throttled_events_logger.ts
+++ b/packages/core/src/throttled_events_logger.ts
@@ -1,10 +1,10 @@
-import { Transport, Config, EventsLogger, Logger } from './types'
+import { Transport, Config, EventsLogger, Logger, EventPayload } from './types'
 import { NdJson } from 'json-nd'
 import { endpoint } from './util'
 import { CONFIG as DEFAULT_CONFIG } from './defaults';
 
 export class ThrottledEventsLogger implements EventsLogger {
-  private queue: Record<string, unknown>[] = []
+  private queue: Record<string, any>[] = []
   private isProcessing = false
   private logger: Logger
 
@@ -22,8 +22,8 @@ export class ThrottledEventsLogger implements EventsLogger {
     }
   }
 
-  logEvent(data: Record<string, unknown>) {
-    this.queue.push(data)
+  log(payload: EventPayload) {
+    this.queue.push(payload)
 
     if (!this.isProcessing) {
       this.processQueue()
@@ -82,8 +82,9 @@ export class ThrottledEventsLogger implements EventsLogger {
   /**
    * todo: improve this
    *
-   * The EventsLogger overrides the console methods
-   * so if we want to log something we need to use the original methods
+   * The EventsLogger overrides the console methods to enable automatic instrumentation
+   * of console logs to the Honeybadger API.
+   * So if we want to log something in here we need to use the original methods.
    */
   private originalLogger() {
     return {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -10,8 +10,13 @@ export interface Logger {
 
 export interface EventsLogger {
   configure: (opts: Partial<Config>) => void
-  logEvent(data: Record<string, unknown>): void
+  log(data: EventPayload): void
 }
+
+export type EventPayload = {
+  event_type: string;
+  ts: string; // ISO Date string
+} & Record<string, unknown>
 
 export interface Config {
   apiKey?: string,

--- a/packages/core/src/util.ts
+++ b/packages/core/src/util.ts
@@ -564,3 +564,18 @@ function getSourceCodeSnippet(fileData: string, lineNumber: number, sourceRadius
 export function isBrowserConfig(config: BrowserConfig | Config): config is BrowserConfig {
   return (config as BrowserConfig).async !== undefined
 }
+
+/** globalThis has fairly good support. But just in case, lets check its defined.
+ * @see {https://caniuse.com/?search=globalThis}
+ */
+export function globalThisOrWindow () {
+  if (typeof globalThis !== 'undefined') {
+    return globalThis
+  }
+
+  if (typeof self !== 'undefined') {
+    return self
+  }
+
+  return window
+}

--- a/packages/core/src/util.ts
+++ b/packages/core/src/util.ts
@@ -579,3 +579,24 @@ export function globalThisOrWindow () {
 
   return window
 }
+
+const _deprecatedMethodCalls: Record<string, number> = {}
+/**
+ * Logs a deprecation warning, every X calls to the method.
+ */
+export function logDeprecatedMethod(logger: Logger, oldMethod: string, newMethod: string, callCountThreshold = 100) {
+  const key = `${oldMethod}-${newMethod}`
+  if (typeof _deprecatedMethodCalls[key] === 'undefined') {
+    _deprecatedMethodCalls[key] = 0
+  }
+
+  if (_deprecatedMethodCalls[key] % callCountThreshold !== 0) {
+    _deprecatedMethodCalls[key]++
+    return
+  }
+
+  const msg = `Deprecation warning: ${oldMethod} has been deprecated; please use ${newMethod} instead.`
+  logger.warn(msg)
+
+  _deprecatedMethodCalls[key]++
+}

--- a/packages/core/test/client.test.ts
+++ b/packages/core/test/client.test.ts
@@ -3,6 +3,7 @@ import { nullLogger, TestClient, TestTransport } from './helpers'
 import { Notice } from '../src/types'
 import { makeBacktrace, DEFAULT_BACKTRACE_SHIFT } from '../src/util'
 import { ThrottledEventsLogger } from '../src/throttled_events_logger';
+import { NdJson } from 'json-nd';
 
 class MyError extends Error {
   context = null
@@ -1025,6 +1026,44 @@ describe('client', function () {
 
       expect(payload.breadcrumbs.enabled).toEqual(false)
       expect(payload.breadcrumbs.trail).toEqual([])
+    })
+  })
+
+  describe('event', function () {
+    it('sends an event with only a payload object', function (done) {
+      const transport = client.transport();
+      const transportSpy = jest.spyOn(transport, 'send')
+      const timestamp = new Date().toISOString()
+      const expectedRequestPayload = {
+        ts: timestamp,
+        message: 'expected message'
+      }
+      client.event(expectedRequestPayload)
+
+      setTimeout(() => {
+        expect(transportSpy).toHaveBeenCalledWith(expect.anything(), NdJson.stringify([expectedRequestPayload]))
+        done()
+      })
+    })
+
+    it('sends an event with an event type and a payload object', function (done) {
+      const transport = client.transport();
+      const transportSpy = jest.spyOn(transport, 'send')
+      const timestamp = new Date().toISOString()
+      const payload = {
+        ts: timestamp,
+        message: 'expected message'
+      }
+      client.event('expected event', payload)
+
+      setTimeout(() => {
+        const expectedRequestPayload = {
+          event_type: 'expected event',
+          ...payload
+        }
+        expect(transportSpy).toHaveBeenCalledWith(expect.anything(), NdJson.stringify([expectedRequestPayload]))
+        done()
+      })
     })
   })
 

--- a/packages/core/test/helpers.ts
+++ b/packages/core/test/helpers.ts
@@ -16,6 +16,12 @@ export class TestTransport implements Transport {
     return {};
   }
   send<T>(_options: TransportOptions, _payload: T): Promise<{ statusCode: number; body: string }> {
+    if (typeof _payload === 'string') {
+      // sending an event
+      return Promise.resolve({ body: '', statusCode: 200 });
+    }
+
+    // sending a notice
     return Promise.resolve({ body: JSON.stringify({ id: 'uuid' }), statusCode: 201 });
   }
 }
@@ -31,6 +37,10 @@ export class TestClient extends BaseClient {
 
   public eventsLogger() {
     return this.__eventsLogger;
+  }
+
+  public transport() {
+    return this.__transport;
   }
 
   protected showUserFeedbackForm(_options: UserFeedbackFormOptions): Promise<void> {

--- a/packages/core/test/helpers.ts
+++ b/packages/core/test/helpers.ts
@@ -29,6 +29,10 @@ export class TestClient extends BaseClient {
     throw new Error('Method not implemented.');
   }
 
+  public eventsLogger() {
+    return this.__eventsLogger;
+  }
+
   protected showUserFeedbackForm(_options: UserFeedbackFormOptions): Promise<void> {
     throw new Error('Method not implemented.');
   }

--- a/packages/core/test/throttled_events_logger.test.ts
+++ b/packages/core/test/throttled_events_logger.test.ts
@@ -21,7 +21,7 @@ describe('ThrottledEventsLogger', () => {
     const consoleLogSpy = jest.spyOn(console, 'debug')
     const transport = new TestTransport()
     const eventsLogger = new ThrottledEventsLogger({ debug: true }, transport)
-    eventsLogger.logEvent({ name: 'foo' })
+    eventsLogger.log({ event_type: 'event', ts: new Date().toISOString(), name: 'foo' })
     await wait(100)
     // @ts-ignore
     expect(eventsLogger.queue.length).toBe(0)
@@ -35,11 +35,11 @@ describe('ThrottledEventsLogger', () => {
     const transport = new TestTransport()
     const transportSpy = jest.spyOn(transport, 'send')
     const eventsLogger = new ThrottledEventsLogger({ debug: true }, transport)
-    const event1 = { name: 'foo' }
-    const event2 = { name: 'foo', nested: { value: { play: 1 } } }
-    eventsLogger.logEvent(event1)
-    eventsLogger.logEvent(event2)
-    eventsLogger.logEvent(event1)
+    const event1 = { event_type: 'event', ts: new Date().toISOString(), name: 'foo' }
+    const event2 = { event_type: 'event', ts: new Date().toISOString(), name: 'foo', nested: { value: { play: 1 } } }
+    eventsLogger.log(event1)
+    eventsLogger.log(event2)
+    eventsLogger.log(event1)
     await wait(200)
     // @ts-ignore
     expect(eventsLogger.queue.length).toBe(0)

--- a/packages/core/test/util.test.ts
+++ b/packages/core/test/util.test.ts
@@ -1,5 +1,17 @@
 import { fake } from 'sinon'
-import { merge, mergeNotice, objectIsEmpty, runBeforeNotifyHandlers, runAfterNotifyHandlers, shallowClone, sanitize, logger, filter, filterUrl } from '../src/util'
+import {
+  merge,
+  mergeNotice,
+  objectIsEmpty,
+  runBeforeNotifyHandlers,
+  runAfterNotifyHandlers,
+  shallowClone,
+  sanitize,
+  logger,
+  filter,
+  filterUrl,
+  logDeprecatedMethod
+} from '../src/util'
 import { nullLogger, TestClient, TestTransport } from './helpers'
 
 describe('utils', function () {
@@ -304,6 +316,36 @@ describe('utils', function () {
       ).toEqual(
         { obj: '[ERROR] Error: expected error' }
       )
+    })
+  })
+
+  describe('logDeprecatedMethod', function () {
+    it('should log a deprecation warning', function () {
+      const console = nullLogger()
+      const warnSpy = jest.spyOn(console, 'warn')
+      logDeprecatedMethod(console, 'deprecatedMethod', 'newMethod');
+      expect(warnSpy).toHaveBeenNthCalledWith(1, 'Deprecation warning: deprecatedMethod has been deprecated; please use newMethod instead.')
+    });
+
+    it('should log a deprecation warning only once even if called multiple times', function () {
+      const console = nullLogger()
+      const warnSpy = jest.spyOn(console, 'warn')
+      logDeprecatedMethod(console, 'deprecatedMethod2', 'newMethod2', 5);
+      logDeprecatedMethod(console, 'deprecatedMethod2', 'newMethod2', 5);
+      logDeprecatedMethod(console, 'deprecatedMethod2', 'newMethod2', 5);
+      logDeprecatedMethod(console, 'deprecatedMethod2', 'newMethod2', 5);
+      logDeprecatedMethod(console, 'deprecatedMethod2', 'newMethod2', 5);
+      expect(warnSpy).toHaveBeenCalledTimes(1)
+    })
+
+    it('should log two deprecation warnings if the method is called more than the specified call count', function () {
+      const console = nullLogger()
+      const warnSpy = jest.spyOn(console, 'warn')
+      logDeprecatedMethod(console, 'deprecatedMethod3', 'newMethod3', 3);
+      logDeprecatedMethod(console, 'deprecatedMethod3', 'newMethod3', 3);
+      logDeprecatedMethod(console, 'deprecatedMethod3', 'newMethod3', 3);
+      logDeprecatedMethod(console, 'deprecatedMethod3', 'newMethod3', 3);
+      expect(warnSpy).toHaveBeenCalledTimes(2)
     })
   })
 })

--- a/packages/js/examples/express/index.js
+++ b/packages/js/examples/express/index.js
@@ -4,10 +4,12 @@ const express = require('express')
 const app = express()
 const port = 3000
 
-const Honeybadger = require('@honeybadger-io/js')
+const Honeybadger = require('../../dist/server/honeybadger')
 Honeybadger.configure({
   apiKey: process.env.HONEYBADGER_API_KEY,
-  reportData: true
+  reportData: true,
+  eventsEnabled: true,
+  debug: true,
 })
 
 app.use(Honeybadger.requestHandler)
@@ -48,6 +50,16 @@ app.get('/checkin/:id', (req, res) => {
     .then(() => {
       res.send('Done!')
     })
+})
+
+app.get('/event', (req, res) => {
+  // should send an event to Honeybadger, with type 'test-event'
+  Honeybadger.event('test-event', { message: 'Event sent!', source: 'Honeybadger.event', path: req.url })
+
+  // should send an event to Honeybadger, with type 'log'
+  console.log('Event sent!', { source: 'console.log' , path: req.url })
+
+  res.send('Done. Check your Honeybadger Insights page!')
 })
 
 app.use(Honeybadger.errorHandler)

--- a/packages/js/examples/express/index.js
+++ b/packages/js/examples/express/index.js
@@ -54,7 +54,11 @@ app.get('/checkin/:id', (req, res) => {
 
 app.get('/event', (req, res) => {
   // should send an event to Honeybadger, with type 'test-event'
-  Honeybadger.event('test-event', { message: 'Event sent!', source: 'Honeybadger.event', path: req.url })
+  Honeybadger.event('button_click', {
+    action: 'buy_now',
+    user_id: 123,
+    product_id: 456
+  })
 
   // should send an event to Honeybadger, with type 'log'
   console.log('Event sent!', { source: 'console.log' , path: req.url })

--- a/packages/js/src/browser.ts
+++ b/packages/js/src/browser.ts
@@ -1,14 +1,13 @@
-import { Types, Util, Client } from '@honeybadger-io/core'
-import { encodeCookie, decodeCookie, preferCatch, globalThisOrWindow } from './browser/util'
+import { Types, Util, Client, Plugins as CorePlugins } from '@honeybadger-io/core'
+import { encodeCookie, decodeCookie, preferCatch } from './browser/util'
 import { onError, ignoreNextOnError } from './browser/integrations/onerror'
 import onUnhandledRejection from './browser/integrations/onunhandledrejection'
 import breadcrumbs from './browser/integrations/breadcrumbs'
-import events from './browser/integrations/events'
 import timers from './browser/integrations/timers'
 import eventListeners from './browser/integrations/event_listeners'
 import { BrowserTransport } from './browser/transport'
 
-const { merge, filter, objectIsExtensible } = Util
+const { merge, filter, objectIsExtensible, globalThisOrWindow } = Util
 
 const getProjectRoot = () => {
   const global = globalThisOrWindow()
@@ -274,7 +273,7 @@ const singleton = new Honeybadger({
     timers(),
     eventListeners(),
     breadcrumbs(),
-    events(),
+    CorePlugins.events(),
   ]
 })
 

--- a/packages/js/src/browser/integrations/breadcrumbs.ts
+++ b/packages/js/src/browser/integrations/breadcrumbs.ts
@@ -1,9 +1,9 @@
 /* eslint-disable prefer-rest-params */
 import { Types, Util } from '@honeybadger-io/core'
-import { stringNameOfElement, stringSelectorOfElement, stringTextOfElement, localURLPathname, nativeFetch, globalThisOrWindow } from '../util'
+import { stringNameOfElement, stringSelectorOfElement, stringTextOfElement, localURLPathname, nativeFetch } from '../util'
 import Client from '../../browser'
 
-const { sanitize, instrument, instrumentConsole } = Util
+const { sanitize, instrument, instrumentConsole, globalThisOrWindow } = Util
 
 export default function (_window = globalThisOrWindow()): Types.Plugin {
   return {

--- a/packages/js/src/browser/integrations/event_listeners.ts
+++ b/packages/js/src/browser/integrations/event_listeners.ts
@@ -1,8 +1,7 @@
 import { Types, Util } from '@honeybadger-io/core'
 import Client from '../../browser'
-import { globalThisOrWindow } from '../util'
 
-const { instrument } = Util
+const { instrument, globalThisOrWindow } = Util
 
 export default function (_window = globalThisOrWindow()): Types.Plugin {
   return {

--- a/packages/js/src/browser/integrations/onerror.ts
+++ b/packages/js/src/browser/integrations/onerror.ts
@@ -1,8 +1,7 @@
 /* eslint-disable prefer-rest-params */
 import { Types, Util } from '@honeybadger-io/core'
 import Client from '../../browser'
-import { globalThisOrWindow } from '../util'
-const { instrument, makeNotice } = Util
+const { instrument, makeNotice, globalThisOrWindow } = Util
 
 let ignoreOnError = 0
 let currentTimeout

--- a/packages/js/src/browser/integrations/onunhandledrejection.ts
+++ b/packages/js/src/browser/integrations/onunhandledrejection.ts
@@ -1,9 +1,8 @@
 /* eslint-disable prefer-rest-params */
 import { Types, Util } from '@honeybadger-io/core'
 import Client from '../../browser'
-import { globalThisOrWindow } from '../util'
 
-const { instrument } = Util
+const { instrument, globalThisOrWindow } = Util
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export default function (_window: any = globalThisOrWindow()): Types.Plugin {

--- a/packages/js/src/browser/integrations/timers.ts
+++ b/packages/js/src/browser/integrations/timers.ts
@@ -1,9 +1,8 @@
 /* eslint-disable prefer-rest-params */
 import { Types, Util } from '@honeybadger-io/core'
 import Client from '../../browser'
-import { globalThisOrWindow } from '../util'
 
-const { instrument } = Util
+const { instrument, globalThisOrWindow } = Util
 
 export default function (_window = globalThisOrWindow()): Types.Plugin {
   return {

--- a/packages/js/src/browser/transport.ts
+++ b/packages/js/src/browser/transport.ts
@@ -1,7 +1,6 @@
 import { Types, Util } from '@honeybadger-io/core'
-import { globalThisOrWindow } from './util'
 
-const { sanitize } = Util
+const { sanitize, globalThisOrWindow } = Util
 
 /**
  * Helper function to get typesafe Object.entries()

--- a/packages/js/src/browser/util.ts
+++ b/packages/js/src/browser/util.ts
@@ -1,3 +1,7 @@
+import { Util } from '@honeybadger-io/core';
+
+const { globalThisOrWindow } = Util;
+
 /**
  * Converts an HTMLElement into a human-readable string.
  * @param {!HTMLElement} element
@@ -187,18 +191,3 @@ export const preferCatch = (function() {
   }
   return preferCatch
 })()
-
-/** globalThis has fairly good support. But just in case, lets check its defined.
- * @see {https://caniuse.com/?search=globalThis}
- */
-export function globalThisOrWindow () {
-  if (typeof globalThis !== 'undefined') {
-    return globalThis
-  }
-
-  if (typeof self !== 'undefined') {
-    return self
-  }
-
-  return window
-}

--- a/packages/js/src/server.ts
+++ b/packages/js/src/server.ts
@@ -1,6 +1,6 @@
 import os from 'os'
 import domain from 'domain'
-import { Client, Util, Types } from '@honeybadger-io/core'
+import { Client, Util, Types, Plugins as CorePlugins } from '@honeybadger-io/core'
 import { getSourceFile, readConfigFromFileSystem } from './server/util'
 import uncaughtException from './server/integrations/uncaught_exception_plugin'
 import unhandledRejection from './server/integrations/unhandled_rejection_plugin'
@@ -14,7 +14,8 @@ import { CheckInsClient } from './server/check-ins-manager/client';
 const { endpoint } = Util
 const DEFAULT_PLUGINS = [
   uncaughtException(),
-  unhandledRejection()
+  unhandledRejection(),
+  CorePlugins.events(),
 ]
 
 type HoneybadgerServerConfig = (Types.Config | Types.ServerlessConfig) & CheckInsConfig

--- a/packages/js/test/unit/server.test.ts
+++ b/packages/js/test/unit/server.test.ts
@@ -409,7 +409,7 @@ describe('server client', function () {
   describe('__plugins', function () {
     it('exported singleton includes plugins', function () {
       Singleton.configure({ apiKey: 'foo' })
-      expect(Singleton.config.__plugins.length).toBe(2)
+      expect(Singleton.config.__plugins.length).toBe(3)
     })
 
     it('clients produced via factory don\'t include plugins', function () {


### PR DESCRIPTION
## Status
**READY**

## Description
Closes #1258.
- Adds `event` method, which replaces logEvent to match Client Library Spec. The already existing `logEvent` method is marked as deprecated.
- `Honeybadger.event` method will send `event_type` and `ts` by default.
- Console instrumentation for both client and server (nodejs).

## Todos
- [x] Tests
- [x] Console instrumentation for server side (nodejs)
- [x] Create `event` method
- [x] Mark `logEvent` method as deprecated
- [x] Send `event_type` and `ts` by default
- [x] [Documentation](https://github.com/honeybadger-io/docs/issues/438)