### PR TITLE
fix(nextjs): return the correct result if file is missing

### DIFF
--- a/packages/nextjs/src/index.ts
+++ b/packages/nextjs/src/index.ts
@@ -67,13 +67,13 @@ function mergeWithExistingWebpackConfig(nextJsWebpackConfig, honeybadgerNextJsCo
 }
 
 async function injectHoneybadgerConfigToEntry(originalEntry, projectDir: string, configType: NextJsRuntime) {
+  const result = typeof originalEntry === 'function' ? await originalEntry() : { ...originalEntry }
   const hbConfigFile = getHoneybadgerConfigFile(projectDir, configType)
   if (!hbConfigFile) {
-    return originalEntry
+    return result
   }
 
   const hbConfigFileRelativePath = `./${hbConfigFile}`
-  const result = typeof originalEntry === 'function' ? await originalEntry() : { ...originalEntry }
   if (!Object.keys(result).length) {
     log('debug', `no entry points for configType[${configType}]`)
   }


### PR DESCRIPTION
## Status
**READY**

## Description
When creating a new `entry` for webpack configuration, we are passing the `originalEntry` so we can merge with Honeybadger's configuration. If we are not setting any Honeybadger configuration, the `originalEntry` must still be evaluated since its result is used in the new `entry`.
Fixes: #1348.
