### PR TITLE
fix(js): remove logger.debug from transport layer

### DIFF
--- a/packages/js/src/server/transport.ts
+++ b/packages/js/src/server/transport.ts
@@ -56,7 +56,6 @@ export class ServerTransport implements Types.Transport {
         }
 
         const req = transport.request(httpOptions, (res) => {
-          options.logger.debug(`statusCode: ${res.statusCode}`)
 
           let body = ''
           res.on('data', (chunk) => {


### PR DESCRIPTION
## Status
**READY**

## Description
The `ServerTransport` class is used to make HTTP requests from nodejs. Inside this class we have a single `logger.debug` method call. When calling the `ServerTransport.send`, we _should_ pass in the logger instance from the original Honeybadger instance. This ensures whatever logger was configured by the user is propagated downstream.

This class is used by the [Honeybadger.notify](https://github.com/honeybadger-io/honeybadger-js/blob/1ee0a9ffcba28b89bae06a84cfa0ebe4d9b39612/packages/core/src/client.ts#L458) and [Honeybadger.event](https://github.com/honeybadger-io/honeybadger-js/blob/1ee0a9ffcba28b89bae06a84cfa0ebe4d9b39612/packages/core/src/client.ts#L321) methods. `Honeybadger.event` uses a `ThrottledEventsLogger` class to send events in batches, which we pass down Honeybadger configuration (such as apiKey, logger) when we [instantiate](https://github.com/honeybadger-io/honeybadger-js/blob/1ee0a9ffcba28b89bae06a84cfa0ebe4d9b39612/packages/core/src/client.ts#L72) it.

Here's the catch:
Inside `ThrottledEventLogger` we [don't want](https://github.com/honeybadger-io/honeybadger-js/blob/1ee0a9ffcba28b89bae06a84cfa0ebe4d9b39612/packages/core/src/throttled_events_logger.ts#L89) to use the configured logger because we have enabled console instrumentation to send logs to HB insights by default ([server](https://github.com/honeybadger-io/honeybadger-js/blob/1ee0a9ffcba28b89bae06a84cfa0ebe4d9b39612/packages/js/src/server.ts#L18), [browser](https://github.com/honeybadger-io/honeybadger-js/blob/1ee0a9ffcba28b89bae06a84cfa0ebe4d9b39612/packages/js/src/server.ts#L18), [instrumentation](https://github.com/honeybadger-io/honeybadger-js/blob/master/packages/core/src/plugins/events.ts)). If we used the logger passed down from configuration, we would have created an endless loop (console.log -> Honeybadger.event -> ThrottledEventLogger -> console.log success -> Honeybadger.event -> etc.)
Therefore, we use the native log function which doesn't have the instrumentation and when calling the `ServerTransport` class, we pass the native log function for the same reason. The `ServerTransport` class is not aware of these peculiarities and simply calls `logger.debug`, which ends up in stdout regardless of how the user configured their logger.

Solution:
`ServerTransport` only has one use of the `logger` and that's `logger.debug`. I simply removed the call (the change in this PR) and the [caller](https://github.com/honeybadger-io/honeybadger-js/blob/1ee0a9ffcba28b89bae06a84cfa0ebe4d9b39612/packages/core/src/throttled_events_logger.ts#L73) of `ServerTransport.send` can log an error or a success message if needed.