### PR TITLE
feat: adds configurable dev environments for source map upload plugins

### DIFF
--- a/packages/esbuild-plugin/README.md
+++ b/packages/esbuild-plugin/README.md
@@ -68,6 +68,9 @@ These plugin parameters correspond to the Honeybadger [Source Map Upload API](ht
     <dd>The name of the user that triggered this deploy, for example, "Jane"</dd>
   </dl>
   </dd>
+
+  <dt><code>developmentEnvironments</code> (optional &mdash; default: ["dev", "development", "test"])</dt>
+  <dd>Used to decide whether source maps should be uploaded or not.</dd>
 </dl>
 
 ### esbuild.config.js

--- a/packages/esbuild-plugin/src/index.ts
+++ b/packages/esbuild-plugin/src/index.ts
@@ -24,7 +24,7 @@ class HoneybadgerSourceMapPlugin {
     return {
       name: PLUGIN_NAME,
       setup(build: PluginBuild) {
-        if (self.isNonProdEnv()) {
+        if (self.isDevEnv(self.options.developmentEnvironments)) {
           return
         }
 
@@ -95,8 +95,12 @@ class HoneybadgerSourceMapPlugin {
     return assets
   }
 
-  private isNonProdEnv(): boolean {
-    return !!process.env.NODE_ENV && process.env.NODE_ENV !== 'production'
+  private isDevEnv(devEnvironments: string[]): boolean {
+    if (!process.env.NODE_ENV || process.env.NODE_ENV === '') {
+      return false
+    }
+
+    return devEnvironments.includes(process.env.NODE_ENV)
   }
 
   private handleError(error: Error): Message {

--- a/packages/plugin-core/src/options.ts
+++ b/packages/plugin-core/src/options.ts
@@ -11,6 +11,7 @@ export const DEFAULT_DEPLOY = false
 export const DEFAULT_DEPLOY_ENDPOINT = 'https://api.honeybadger.io/v1/deploys'
 export const DEFAULT_IGNORE_PATHS = []
 export const DEFAULT_IGNORE_ERRORS = false
+export const DEFAULT_DEVELOPMENT_ENVIRONMENTS = ['dev', 'development', 'test'];
 
 const required = [
   'apiKey',
@@ -27,6 +28,7 @@ const defaultOptions = {
   ignorePaths: DEFAULT_IGNORE_PATHS,
   ignoreErrors: DEFAULT_IGNORE_ERRORS,
   workerCount: DEFAULT_WORKER_COUNT,
+  developmentEnvironments: DEFAULT_DEVELOPMENT_ENVIRONMENTS
 }
 
 export function cleanOptions(
@@ -42,6 +44,11 @@ export function cleanOptions(
   // Validate ignorePaths
   if (options.ignorePaths && !Array.isArray(options.ignorePaths)) {
     throw new Error('ignorePaths must be an array')
+  }
+
+  // Validate developmentEnvironments
+  if (options.developmentEnvironments && !Array.isArray(options.developmentEnvironments)) {
+    throw new Error('developmentEnvironments must be an array')
   }
 
   // Don't allow excessive retries

--- a/packages/plugin-core/src/types.ts
+++ b/packages/plugin-core/src/types.ts
@@ -11,6 +11,7 @@ export type HbPluginOptions = {
   ignorePaths: Array<string>;
   ignoreErrors: boolean;
   workerCount: number;
+  developmentEnvironments: Array<string>;
 }
 
 // Options passed in by a user

--- a/packages/plugin-core/test/options.test.ts
+++ b/packages/plugin-core/test/options.test.ts
@@ -9,6 +9,7 @@ import {
   DEFAULT_IGNORE_ERRORS,
   DEFAULT_WORKER_COUNT,
   MIN_WORKER_COUNT,
+  DEFAULT_DEVELOPMENT_ENVIRONMENTS,
 } from '../src/options';
 
 describe('Options', () => {
@@ -41,7 +42,7 @@ describe('Options', () => {
         workerCount: 0
       })
       expect(result.workerCount).to.equal(MIN_WORKER_COUNT)
-    }) 
+    })
 
     it('should merge in default options', () => {
       const result = cleanOptions({
@@ -62,6 +63,7 @@ describe('Options', () => {
         ignorePaths: [],
         ignoreErrors: DEFAULT_IGNORE_ERRORS,
         workerCount: DEFAULT_WORKER_COUNT,
+        developmentEnvironments: DEFAULT_DEVELOPMENT_ENVIRONMENTS,
       })
     })
   });

--- a/packages/rollup-plugin/README.md
+++ b/packages/rollup-plugin/README.md
@@ -70,6 +70,9 @@ These plugin parameters correspond to the Honeybadger [Source Map Upload API](ht
     <dd>The name of the user that triggered this deploy, for example, "Jane"</dd>
   </dl>
   </dd>
+
+  <dt><code>developmentEnvironments</code> (optional &mdash; default: ["dev", "development", "test"])</dt>
+  <dd>Used to decide whether source maps should be uploaded or not.</dd>
 </dl>
 
 ### rollup.config.js

--- a/packages/rollup-plugin/src/index.ts
+++ b/packages/rollup-plugin/src/index.ts
@@ -1,4 +1,4 @@
-import { extractSourcemapDataFromBundle, isNonProdEnv } from './rollupUtils'
+import { extractSourcemapDataFromBundle, isDevEnv } from './rollupUtils'
 import { sendDeployNotification, uploadSourcemaps, cleanOptions, Types } from '@honeybadger-io/plugin-core'
 import type { OutputBundle, Plugin, NormalizedOutputOptions } from 'rollup'
 
@@ -13,7 +13,7 @@ export default function honeybadgerRollupPlugin(
       outputOptions: NormalizedOutputOptions,
       bundle: OutputBundle
     ) => {
-      if (isNonProdEnv()) {
+      if (isDevEnv(hbOptions.developmentEnvironments)) {
         if (!hbOptions.silent) {
           console.info('Honeybadger will not upload sourcemaps in non-production environment.')
         }

--- a/packages/rollup-plugin/src/rollupUtils.ts
+++ b/packages/rollup-plugin/src/rollupUtils.ts
@@ -55,6 +55,10 @@ function formatSourcemapData(
  * In Rollup without Vite, it may or may not be available,
  * so if it's missing we'll assume prod
  */
-export function isNonProdEnv(): boolean {
-  return !!process.env.NODE_ENV && process.env.NODE_ENV !== 'production'
+export function isDevEnv(devEnvironments: string[]): boolean {
+  if (!process.env.NODE_ENV || process.env.NODE_ENV === '') {
+    return false
+  }
+
+  return devEnvironments.includes(process.env.NODE_ENV)
 }

--- a/packages/rollup-plugin/test/index.test.ts
+++ b/packages/rollup-plugin/test/index.test.ts
@@ -6,7 +6,11 @@ import * as td from 'testdouble'
 describe('Index', () => {
   let honeybadgerRollupPlugin
   let core, rollupUtils
-  const options = { apiKey: 'test_key', assetsUrl: 'https://foo.bar' }
+  const options = {
+    apiKey: 'test_key',
+    assetsUrl: 'https://foo.bar',
+    developmentEnvironments: ['dev', 'development', 'test']
+  }
 
   beforeEach(async () => {
     core = td.replace('@honeybadger-io/plugin-core')
@@ -35,7 +39,7 @@ describe('Index', () => {
     const sourcemapData = [{ sourcemapFilename: 'index.map.js' }]
 
     it('should upload sourcemaps', async () => {
-      td.when(rollupUtils.isNonProdEnv()).thenReturn(false)
+      td.when(rollupUtils.isDevEnv(options.developmentEnvironments)).thenReturn(false)
       td.when(rollupUtils.extractSourcemapDataFromBundle(outputOptions, bundle, undefined)).thenReturn(sourcemapData)
       td.when(core.cleanOptions(options)).thenReturn(options)
 
@@ -48,7 +52,7 @@ describe('Index', () => {
 
     it('should send deploy notification if deploy is true', async () => {
       const deployTrueOpt = { ...options, deploy: true }
-      td.when(rollupUtils.isNonProdEnv()).thenReturn(false)
+      td.when(rollupUtils.isDevEnv(options.developmentEnvironments)).thenReturn(false)
       td.when(rollupUtils.extractSourcemapDataFromBundle({ outputOptions, bundle })).thenReturn(sourcemapData)
       td.when(core.cleanOptions(deployTrueOpt)).thenReturn(deployTrueOpt)
 
@@ -61,7 +65,7 @@ describe('Index', () => {
 
     it('should send deploy notification if deploy is an object', async () => {
       const deployObjOpt = { ...options, deploy: { localUsername: 'me' } }
-      td.when(rollupUtils.isNonProdEnv()).thenReturn(false)
+      td.when(rollupUtils.isDevEnv(options.developmentEnvironments)).thenReturn(false)
       td.when(rollupUtils.extractSourcemapDataFromBundle({ outputOptions, bundle })).thenReturn(sourcemapData)
       td.when(core.cleanOptions(deployObjOpt)).thenReturn(deployObjOpt)
 
@@ -74,7 +78,7 @@ describe('Index', () => {
 
     it('should not send deploy notification if deploy is false', async () => {
       const deployFalseOpt = { ...options, deploy: false }
-      td.when(rollupUtils.isNonProdEnv()).thenReturn(false)
+      td.when(rollupUtils.isDevEnv(options.developmentEnvironments)).thenReturn(false)
       td.when(rollupUtils.extractSourcemapDataFromBundle({ outputOptions, bundle })).thenReturn(sourcemapData)
       td.when(core.cleanOptions(deployFalseOpt)).thenReturn(deployFalseOpt)
 
@@ -87,7 +91,7 @@ describe('Index', () => {
     })
 
     it('should do nothing in non-prod environments', async () => {
-      td.when(rollupUtils.isNonProdEnv()).thenReturn(true)
+      td.when(rollupUtils.isDevEnv(options.developmentEnvironments)).thenReturn(true)
       td.when(core.cleanOptions(options)).thenReturn(options)
 
       const plugin = honeybadgerRollupPlugin(options)

--- a/packages/rollup-plugin/test/rollupUtils.test.ts
+++ b/packages/rollup-plugin/test/rollupUtils.test.ts
@@ -1,5 +1,5 @@
 import { expect } from 'chai'
-import { extractSourcemapDataFromBundle, isNonProdEnv } from '../src/rollupUtils';
+import { extractSourcemapDataFromBundle, isDevEnv } from '../src/rollupUtils';
 import bundle from './fixtures/bundle'
 import path from 'node:path'
 import { NormalizedOutputOptions } from 'rollup';
@@ -91,7 +91,8 @@ describe('extractSourcemapDataFromBundle', () => {
   })
 })
 
-describe('isNonProdEnv', () => {
+describe('isDevEnv', () => {
+  const developmentEnvironments = ['development', 'test', 'staging']
   let restore
 
   beforeEach(() => {
@@ -99,21 +100,31 @@ describe('isNonProdEnv', () => {
   })
 
   afterEach(() => {
+    // @ts-expect-error
     process.env.NODE_ENV = restore
   })
 
   it('returns true if NODE_ENV is non-prod', () => {
+    // @ts-expect-error
     process.env.NODE_ENV = 'development'
-    expect(isNonProdEnv()).to.equal(true)
+    expect(isDevEnv(developmentEnvironments)).to.equal(true)
+  })
+
+  it('returns false if NODE_ENV is non-prod but not in developmentEnvironments array', () => {
+    // @ts-expect-error
+    process.env.NODE_ENV = 'staging'
+    expect(isDevEnv(developmentEnvironments)).to.equal(false)
   })
 
   it('returns false if NODE_ENV is missing', () => {
+    // @ts-expect-error
     delete process.env.NODE_ENV
-    expect(isNonProdEnv()).to.equal(false)
+    expect(isDevEnv(developmentEnvironments)).to.equal(false)
   })
 
   it('returns false if NODE_ENV is prod', () => {
+    // @ts-expect-error
     process.env.NODE_ENV = 'production'
-    expect(isNonProdEnv()).to.equal(false)
+    expect(isDevEnv(developmentEnvironments)).to.equal(false)
   })
 })

--- a/packages/rollup-plugin/test/rollupUtils.test.ts
+++ b/packages/rollup-plugin/test/rollupUtils.test.ts
@@ -92,7 +92,7 @@ describe('extractSourcemapDataFromBundle', () => {
 })
 
 describe('isDevEnv', () => {
-  const developmentEnvironments = ['development', 'test', 'staging']
+  const developmentEnvironments = ['dev', 'development', 'test']
   let restore
 
   beforeEach(() => {
@@ -100,30 +100,25 @@ describe('isDevEnv', () => {
   })
 
   afterEach(() => {
-    // @ts-expect-error
     process.env.NODE_ENV = restore
   })
 
   it('returns true if NODE_ENV is non-prod', () => {
-    // @ts-expect-error
     process.env.NODE_ENV = 'development'
     expect(isDevEnv(developmentEnvironments)).to.equal(true)
   })
 
   it('returns false if NODE_ENV is non-prod but not in developmentEnvironments array', () => {
-    // @ts-expect-error
     process.env.NODE_ENV = 'staging'
     expect(isDevEnv(developmentEnvironments)).to.equal(false)
   })
 
   it('returns false if NODE_ENV is missing', () => {
-    // @ts-expect-error
     delete process.env.NODE_ENV
     expect(isDevEnv(developmentEnvironments)).to.equal(false)
   })
 
   it('returns false if NODE_ENV is prod', () => {
-    // @ts-expect-error
     process.env.NODE_ENV = 'production'
     expect(isDevEnv(developmentEnvironments)).to.equal(false)
   })

--- a/packages/rollup-plugin/tsconfig.json
+++ b/packages/rollup-plugin/tsconfig.json
@@ -2,9 +2,14 @@
   "extends": "../../tsconfig.base.json",
   "include": [
     "src/**/*.ts"
-  ], 
+  ],
   "compilerOptions": {
-    "rootDir": "./", 
+    "rootDir": "./",
     "allowSyntheticDefaultImports": true
   },
+  "references": [
+    {
+      "path": "../plugin-core"
+    }
+  ]
 }

--- a/packages/webpack/README.md
+++ b/packages/webpack/README.md
@@ -77,6 +77,9 @@ These plugin parameters correspond to the Honeybadger [Source Map Upload API](ht
     <dd>The name of the user that triggered this deploy, for example, "Jane"</dd>
   </dl>
   </dd>
+
+  <dt><code>developmentEnvironments</code> (optional &mdash; default: ["dev", "development", "test"])</dt>
+  <dd>Source maps upload will be skipped when the environment matches any of the values in this array or the webpack dev server is running.</dd>
 </dl>
 
 ### Vanilla webpack.config.js

--- a/packages/webpack/src/HoneybadgerSourceMapPlugin.js
+++ b/packages/webpack/src/HoneybadgerSourceMapPlugin.js
@@ -19,7 +19,7 @@ class HoneybadgerSourceMapPlugin {
   }
 
   async afterEmit (compilation) {
-    if (this.isDevServerRunning()) {
+    if (this.isDevEnv(this.options.developmentEnvironments)) {
       if (!this.options.silent) {
         console.info('\nHoneybadgerSourceMapPlugin will not upload source maps because webpack-dev-server is running.')
       }
@@ -41,8 +41,12 @@ class HoneybadgerSourceMapPlugin {
     }
   }
 
-  isDevServerRunning () {
-    return process.env.WEBPACK_DEV_SERVER === 'true'
+  isDevEnv (devEnvironments) {
+    if (process.env.WEBPACK_DEV_SERVER === 'true') {
+      return true
+    }
+
+    return !!(devEnvironments && devEnvironments.includes(process.env.NODE_ENV));
   }
 
   apply (compiler) {

--- a/packages/webpack/test/HoneybadgerSourceMapPlugin.test.js
+++ b/packages/webpack/test/HoneybadgerSourceMapPlugin.test.js
@@ -17,7 +17,7 @@ describe('HoneybadgerSourceMapPlugin', function () {
 
   const options = {
     apiKey: 'abcd1234',
-    assetsUrl: 'https://cdn.example.com/assets', 
+    assetsUrl: 'https://cdn.example.com/assets',
     endpoint: `${TEST_ENDPOINT}${SOURCEMAP_PATH}`,
     deployEndpoint: `${TEST_ENDPOINT}${DEPLOY_PATH}`,
   }
@@ -62,6 +62,7 @@ describe('HoneybadgerSourceMapPlugin', function () {
         revision: 'main',
         silent: false,
         workerCount: 5,
+        developmentEnvironments: ['dev', 'development', 'test']
       })
     })
   })
@@ -91,13 +92,13 @@ describe('HoneybadgerSourceMapPlugin', function () {
         id: 0,
         names: ['app'],
         files: ['app.5190.js', 'app.5190.js.map']
-      }, 
+      },
     ]
-    const assets = [{ 
+    const assets = [{
       sourcemapFilePath: '/fake/output/path/app.5190.js.map',
       sourcemapFilename: 'app.5190.js.map',
       jsFilePath: '/fake/output/path/app.5190.js',
-      jsFilename: 'app.5190.js', 
+      jsFilename: 'app.5190.js',
     }]
     const outputPath = '/fake/output/path'
 
@@ -141,7 +142,7 @@ describe('HoneybadgerSourceMapPlugin', function () {
       }
       sinon.stub(plugin, 'uploadSourceMaps')
       sinon.stub(plugin, 'sendDeployNotification')
-      
+
       await plugin.afterEmit(compilation)
       expect(plugin.sendDeployNotification.callCount).to.eq(1)
       expect(plugin.sendDeployNotification.calledWith(plugin.options)).to.equal(true)
@@ -209,7 +210,7 @@ describe('HoneybadgerSourceMapPlugin', function () {
         id: 0,
         names: ['app'],
         files: ['app.5190.js', 'app.5190.js.map']
-      }, 
+      },
       {
         id: 1,
         names: ['foo'],
@@ -220,17 +221,17 @@ describe('HoneybadgerSourceMapPlugin', function () {
     const compilation = {
       getStats: () => ({
         toJson: () => ({ chunks })
-      }), 
+      }),
       compiler: { outputPath },
       getPath: () => outputPath,
     }
 
     const expectedAssets = [
-      { 
+      {
         sourcemapFilePath: '/fake/output/path/app.5190.js.map',
         sourcemapFilename: 'app.5190.js.map',
         jsFilePath: '/fake/output/path/app.5190.js',
-        jsFilename: 'app.5190.js', 
+        jsFilename: 'app.5190.js',
       }
     ]
 


### PR DESCRIPTION
## Status
**READY**

## Description
Adds a configuration source map plugin option `developmentEnvironments`, similar to what we have for the [core plugin](https://github.com/honeybadger-io/honeybadger-js/blob/54c1fdb9823058281d14270576401d233c919958/packages/core/src/defaults.ts#L17). The sole purpose of this option is to be used in order to decide whether source maps should be uploaded or not.

Closes #1408.

## TODO

- [x] Create new `developmentEnvironments` option
- [x] Update webpack, rollup and esbuild plugins to use new option
- [x] Update README.md in rollup, esbuild and webpack plugins
- [x] Update tests
