### PR TITLE
ci: remove node 14 from matrix

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [14.x, 16.x, 18.x]
+        node-version: [16.x, 18.x]
     env:
       CI: true
     steps:


### PR DESCRIPTION
## Status
**READY**

## Description
Removes v14 - first step of upgrading version matrix in CI (see #1421).
Part of #1421.