### PR TITLE
feat: flush events on process exit

### DIFF
--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -325,6 +325,14 @@ export abstract class Client {
     })
   }
 
+  /**
+   * This method currently flushes the event (Insights) queue.
+   * In the future, it should also flush the error queue (assuming an error throttler is implemented).
+   */
+  flushAsync(): Promise<void> {
+    return this.__eventsLogger.flushAsync();
+  }
+
   __getBreadcrumbs() {
     return this.__store.getContents('breadcrumbs').slice()
   }

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -11,6 +11,7 @@ export interface Logger {
 export interface EventsLogger {
   configure: (opts: Partial<Config>) => void
   log(data: EventPayload): void
+  flushAsync(): Promise<void>
 }
 
 export type EventPayload = {

--- a/packages/js/src/server.ts
+++ b/packages/js/src/server.ts
@@ -4,6 +4,7 @@ import { Client, Util, Types, Plugins as CorePlugins } from '@honeybadger-io/cor
 import { getSourceFile, readConfigFromFileSystem } from './server/util'
 import uncaughtException from './server/integrations/uncaught_exception_plugin'
 import unhandledRejection from './server/integrations/unhandled_rejection_plugin'
+import shutdown from './server/integrations/shutdown_plugin'
 import { errorHandler, requestHandler } from './server/middleware'
 import { lambdaHandler } from './server/aws_lambda'
 import { ServerTransport } from './server/transport'
@@ -15,6 +16,7 @@ const { endpoint } = Util
 const DEFAULT_PLUGINS = [
   uncaughtException(),
   unhandledRejection(),
+  shutdown(),
   CorePlugins.events(),
 ]
 

--- a/packages/js/src/server/integrations/shutdown_monitor.ts
+++ b/packages/js/src/server/integrations/shutdown_monitor.ts
@@ -1,0 +1,70 @@
+import Client from '../../server'
+import { fatallyLogAndExitGracefully } from '../util'
+
+export default class ShutdownMonitor {
+
+  // SIGTERM is raised by AWS Lambda when the function is being shut down
+  // SIGINT is raised by the user pressing CTRL+C
+  private static KILL_SIGNALS = ['SIGTERM', 'SIGINT'] as const
+
+  protected __isReporting: boolean
+  protected __client: typeof Client
+  protected __listener: (signal: string) => void
+
+  constructor() {
+    this.__isReporting = false
+    this.__listener = this.makeListener()
+  }
+
+  setClient(client: typeof Client) {
+    this.__client = client
+  }
+
+  makeListener() {
+    // noinspection UnnecessaryLocalVariableJS
+    const honeybadgerShutdownListener = async (signal: NodeJS.Signals) => {
+      if (this.__isReporting || !this.__client) {
+        return
+      }
+
+      this.__isReporting = true
+
+      await this.__client.flushAsync()
+
+      this.__isReporting = false
+
+      if (!this.hasOtherShutdownListeners(signal)) {
+        fatallyLogAndExitGracefully(signal)
+      }
+    }
+
+    return honeybadgerShutdownListener
+  }
+
+  maybeAddListener() {
+    for (const signal of ShutdownMonitor.KILL_SIGNALS) {
+      const signalListeners = process.listeners(signal);
+      if (!signalListeners.includes(this.__listener)) {
+        process.on(signal, this.__listener)
+      }
+    }
+  }
+
+  maybeRemoveListener() {
+    for (const signal of ShutdownMonitor.KILL_SIGNALS) {
+      const signalListeners = process.listeners(signal);
+      if (signalListeners.includes(this.__listener)) {
+        process.removeListener(signal, this.__listener)
+      }
+    }
+  }
+
+  hasOtherShutdownListeners(signal: NodeJS.Signals) {
+    const otherListeners = process
+      .listeners(signal)
+      .filter(listener => listener !== this.__listener)
+
+    return otherListeners.length > 0;
+
+  }
+}

--- a/packages/js/src/server/integrations/shutdown_plugin.ts
+++ b/packages/js/src/server/integrations/shutdown_plugin.ts
@@ -1,0 +1,21 @@
+import { Types } from '@honeybadger-io/core'
+import Client from '../../server'
+import ShutdownMonitor from './shutdown_monitor'
+
+const shutdownMonitor = new ShutdownMonitor()
+
+export default function (): Types.Plugin {
+  return {
+    load: (client: typeof Client) => {
+      shutdownMonitor.setClient(client)
+      // at the moment, the shutdown monitor only sends events from the queue
+      // if we implement a queue for throttling errors, we won't have to check for `config.eventsEnabled`
+      if (client.config.eventsEnabled) {
+        shutdownMonitor.maybeAddListener()
+      } else {
+        shutdownMonitor.maybeRemoveListener()
+      }
+    },
+    shouldReloadOnConfigure: true,
+  }
+}

--- a/packages/js/src/server/integrations/uncaught_exception_monitor.ts
+++ b/packages/js/src/server/integrations/uncaught_exception_monitor.ts
@@ -20,6 +20,7 @@ export default class UncaughtExceptionMonitor {
   }
 
   makeListener() {
+    // noinspection UnnecessaryLocalVariableJS
     const honeybadgerUncaughtExceptionListener = (uncaughtError: Error) => {
       if (this.__isReporting || !this.__client) { return }
 

--- a/packages/js/src/server/integrations/unhandled_rejection_monitor.ts
+++ b/packages/js/src/server/integrations/unhandled_rejection_monitor.ts
@@ -17,6 +17,7 @@ export default class UnhandledRejectionMonitor {
   }
 
   makeListener() {
+    // noinspection UnnecessaryLocalVariableJS
     const honeybadgerUnhandledRejectionListener = (reason: unknown, _promise: Promise<unknown>) => {
       this.__isReporting = true;
       this.__client.notify(reason as Types.Noticeable, { component: 'unhandledRejection' }, {

--- a/packages/js/src/server/util.ts
+++ b/packages/js/src/server/util.ts
@@ -6,6 +6,11 @@ import { promisify } from 'util'
 
 const readFile = promisify(fs.readFile)
 
+export function fatallyLogAndExitGracefully(signal: NodeJS.Signals): never {
+  console.log(`[Honeybadger] Received ${signal}, exiting immediately`)
+  process.exit()
+}
+
 export function fatallyLogAndExit(err: Error, source: string): never {
   console.error(`[Honeybadger] Exiting process due to ${source}`)
   console.error(err.stack || err)

--- a/packages/js/test/e2e/playwright.config.ts
+++ b/packages/js/test/e2e/playwright.config.ts
@@ -15,7 +15,7 @@ export default defineConfig({
   forbidOnly: !!process.env.CI,
   /* Retry on CI only */
   retries: process.env.CI ? 2 : 0,
-  workers: 8,
+  workers: 4,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
   reporter: [
     [process.env.CI ? 'github' : 'list'],

--- a/packages/js/test/unit/server.test.ts
+++ b/packages/js/test/unit/server.test.ts
@@ -409,7 +409,7 @@ describe('server client', function () {
   describe('__plugins', function () {
     it('exported singleton includes plugins', function () {
       Singleton.configure({ apiKey: 'foo' })
-      expect(Singleton.config.__plugins.length).toBe(3)
+      expect(Singleton.config.__plugins.length).toBe(4)
     })
 
     it('clients produced via factory don\'t include plugins', function () {

--- a/packages/js/test/unit/server/integrations/shutdown_monitor.server.test.ts
+++ b/packages/js/test/unit/server/integrations/shutdown_monitor.server.test.ts
@@ -1,0 +1,122 @@
+import { TestTransport, TestClient, nullLogger } from '../../helpers'
+import * as util from '../../../../src/server/util'
+import Singleton from '../../../../src/server'
+import ShutdownMonitor from '../../../../src/server/integrations/shutdown_monitor'
+
+describe('ShutdownMonitor', () => {
+  // Using any rather than the real type so we can test and spy on private methods
+  // eslint-disable-next-line  @typescript-eslint/no-explicit-any
+  let shutdownMonitor: any
+  let client: typeof Singleton
+  let fatallyLogAndExitGracefullySpy: jest.SpyInstance
+  let flushSpy: jest.SpyInstance
+
+  beforeEach(() => {
+    // We just need a really basic client, so ignoring type issues here
+    client = new TestClient(
+      { apiKey: 'testKey', afterUncaught: jest.fn(), logger: nullLogger() },
+      new TestTransport()
+    ) as unknown as typeof Singleton
+    shutdownMonitor = new ShutdownMonitor()
+    shutdownMonitor.setClient(client)
+    // Have to mock fatallyLogAndExit or we will crash the test
+    fatallyLogAndExitGracefullySpy = jest
+      .spyOn(util, 'fatallyLogAndExitGracefully')
+      .mockImplementation(() => true as never)
+    flushSpy = jest.spyOn(client, 'flushAsync')
+  })
+
+  afterEach(() => {
+    jest.clearAllMocks()
+    process.removeAllListeners('SIGTERM')
+    process.removeAllListeners('SIGINT')
+    shutdownMonitor.__isReporting = false
+    shutdownMonitor.__handlerAlreadyCalled = false
+  })
+
+  describe('constructor', () => {
+    it('sets variables', () => {
+      // Using any rather than the real type so we can test and spy on private methods
+      // eslint-disable-next-line  @typescript-eslint/no-explicit-any
+      const newMonitor = new ShutdownMonitor() as any
+      expect(newMonitor.__isReporting).toBe(false)
+      expect(newMonitor.__listener).toStrictEqual(expect.any(Function))
+      expect(newMonitor.__listener.name).toBe('honeybadgerShutdownListener')
+    })
+  })
+
+  describe('maybeAddListener', () => {
+    it('adds our listener a maximum of one time', () => {
+      expect(process.listeners('SIGINT')).toHaveLength(0)
+      expect(process.listeners('SIGTERM')).toHaveLength(0)
+
+      // Adds our listener
+      shutdownMonitor.maybeAddListener()
+      expect(process.listeners('SIGINT')).toHaveLength(1)
+      expect(process.listeners('SIGTERM')).toHaveLength(1)
+
+      // Doesn't add a duplicate
+      shutdownMonitor.maybeAddListener()
+      expect(process.listeners('SIGINT')).toHaveLength(1)
+      expect(process.listeners('SIGTERM')).toHaveLength(1)
+    })
+  })
+
+  describe('maybeRemoveListener', () => {
+    it('removes our listener if it is present', () => {
+      shutdownMonitor.maybeAddListener()
+      process.on('SIGINT', (signal) => { console.log(signal) })
+      process.on('SIGTERM', (signal) => { console.log(signal) })
+      expect(process.listeners('SIGINT')).toHaveLength(2)
+      expect(process.listeners('SIGTERM')).toHaveLength(2)
+
+      shutdownMonitor.maybeRemoveListener()
+      expect(process.listeners('SIGINT')).toHaveLength(1)
+      expect(process.listeners('SIGTERM')).toHaveLength(1)
+    })
+
+    it('does nothing if our listener is not present', () => {
+      process.on('SIGINT', (signal) => { console.log(signal) })
+      process.on('SIGTERM', (signal) => { console.log(signal) })
+      expect(process.listeners('SIGINT')).toHaveLength(1)
+      expect(process.listeners('SIGTERM')).toHaveLength(1)
+
+      shutdownMonitor.maybeRemoveListener()
+      expect(process.listeners('SIGINT')).toHaveLength(1)
+      expect(process.listeners('SIGTERM')).toHaveLength(1)
+    })
+  })
+
+  describe('__listener', () => {
+    it('calls flushAsync and fatallyLogAndExitGracefully', (done) => {
+      shutdownMonitor.__listener('SIGINT')
+      expect(flushSpy).toHaveBeenCalledTimes(1)
+      setTimeout(() => {
+        expect(fatallyLogAndExitGracefullySpy).toHaveBeenCalledWith('SIGINT')
+        done()
+      }, 10)
+    })
+
+    it('returns if it is already reporting', () => {
+      shutdownMonitor.__isReporting = true
+      shutdownMonitor.__listener('SIGINT')
+      expect(flushSpy).not.toHaveBeenCalled()
+      expect(fatallyLogAndExitGracefullySpy).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('hasOtherShutdownListeners', () => {
+    it('returns true if there are user-added listeners', () => {
+      shutdownMonitor.maybeAddListener()
+      process.on('SIGINT', function userAddedListener() {
+        return
+      })
+      expect(shutdownMonitor.hasOtherShutdownListeners('SIGINT')).toBe(true)
+    })
+
+    it('returns false if there are only our expected listeners', () => {
+      shutdownMonitor.maybeAddListener()
+      expect(shutdownMonitor.hasOtherShutdownListeners()).toBe(false)
+    })
+  })
+})

--- a/packages/js/test/unit/server/integrations/shutdown_plugin.server.test.ts
+++ b/packages/js/test/unit/server/integrations/shutdown_plugin.server.test.ts
@@ -1,0 +1,80 @@
+import plugin from '../../../../src/server/integrations/shutdown_plugin'
+import { TestTransport, TestClient, nullLogger } from '../../helpers'
+import * as util from '../../../../src/server/util'
+import Singleton from '../../../../src/server'
+
+describe('Shutdown Plugin', () => {
+  let client: typeof Singleton
+  let flushSpy: jest.SpyInstance
+
+  beforeEach(() => {
+    // We just need a really basic client, so ignoring type issues here
+    client = new TestClient(
+      { apiKey: 'testKey', afterUncaught: jest.fn(), logger: nullLogger(), eventsEnabled: true },
+      new TestTransport()
+    ) as unknown as typeof Singleton
+    // Have to mock fatallyLogAndExitGracefully or we will crash the test
+    jest
+      .spyOn(util, 'fatallyLogAndExitGracefully')
+      .mockImplementation(() => true as never)
+    flushSpy = jest.spyOn(client, 'flushAsync')
+  })
+
+  afterEach(() => {
+    jest.clearAllMocks()
+    process.removeAllListeners('SIGINT')
+    process.removeAllListeners('SIGTERM')
+  })
+
+  it('is a function which returns an object with a load function', () => {
+    expect(plugin()).toStrictEqual({
+      load: expect.any(Function),
+      shouldReloadOnConfigure: true,
+    })
+  })
+
+  describe('load', () => {
+    const load = plugin().load
+
+    it('attaches a listener for SIGTERM if eventsEnabled is true', () => {
+      load(client)
+      const listeners = process.listeners('SIGTERM')
+      expect(listeners).toHaveLength(1)
+      expect(listeners[0].name).toBe('honeybadgerShutdownListener')
+      process.emit('SIGTERM')
+      expect(flushSpy).toHaveBeenCalledTimes(1)
+    })
+
+    it('attaches a listener for SIGINT if eventsEnabled is true', () => {
+      load(client)
+      const listeners = process.listeners('SIGINT')
+      expect(listeners).toHaveLength(1)
+      expect(listeners[0].name).toBe('honeybadgerShutdownListener')
+      process.emit('SIGINT')
+      expect(flushSpy).toHaveBeenCalledTimes(1)
+    })
+
+    it('does not add a listener if enableUnhandledRejection is false', () => {
+      client.configure({ eventsEnabled: false })
+      load(client)
+      expect(process.listeners('SIGINT')).toHaveLength(0)
+      expect(process.listeners('SIGTERM')).toHaveLength(0)
+    })
+
+    it('adds or removes listener if needed when reloaded', () => {
+      load(client)
+      expect(process.listeners('SIGINT')).toHaveLength(1)
+      expect(process.listeners('SIGTERM')).toHaveLength(1)
+
+      client.configure({ eventsEnabled: false })
+      load(client)
+      expect(process.listeners('SIGINT')).toHaveLength(0)
+      expect(process.listeners('SIGTERM')).toHaveLength(0)
+
+      client.configure({ eventsEnabled: true })
+      load(client)
+      expect(process.listeners('SIGINT').length).toBe(1)
+      expect(process.listeners('SIGTERM').length).toBe(1)
+    })
+  })
+})


### PR DESCRIPTION
## Status
**READY**

## Description

Closes: #1429

Adds listeners for `SIGTERM` and `SIGINT` process events. When we add listeners for such events we have to exit the process. Similar to other listeners (uncaughtException), first I check if there are other listeners attached as well before exiting.
