### PR TITLE
fix(vue): handle anonymous components

### DIFF
--- a/packages/vue/src/index.js
+++ b/packages/vue/src/index.js
@@ -7,6 +7,8 @@ const NOTIFIER = {
   version: '__VERSION__'
 }
 
+const ANONYMOUS_COMPONENT = 'Anonymous Component'
+
 function shouldLogError (app, options) {
   if (app.config.warnHandler) {
     return true
@@ -19,6 +21,13 @@ function shouldLogError (app, options) {
 }
 
 function extractContext (vm) {
+  if (!vm) {
+    return {
+      isRoot: false,
+      name: ANONYMOUS_COMPONENT,
+    }
+  }
+
   const options = vm.$options || {}
   const name = options.name || options._componentTag
   const file = options.__file


### PR DESCRIPTION
## Status
**READY**

## Description
Fixes: #1427
After some research online, it seems that it's possible for `vm` to be undefined when the component being rendered is _anonymous_. This can vary depending on the vue.js version being used, how the component is being defined and how it's being imported. I don't have a definite reproducible example yet, but I'm pretty sure this fix should cover it.
