### PR TITLE
ci: upgrade playwright to use new chrome headless

### DIFF
--- a/packages/js/package-lock.json
+++ b/packages/js/package-lock.json
@@ -16,7 +16,7 @@
         "honeybadger-checkins-sync": "scripts/check-ins-sync-bin.js"
       },
       "devDependencies": {
-        "@playwright/test": "1.49.0",
+        "@playwright/test": "1.51.0",
         "@rollup/plugin-commonjs": "^22.0.1",
         "@rollup/plugin-node-resolve": "^13.3.0",
         "@rollup/plugin-replace": "^5.0.2",
@@ -1025,12 +1025,12 @@
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.49.0",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.49.0.tgz",
-      "integrity": "sha512-DMulbwQURa8rNIQrf94+jPJQ4FmOVdpE5ZppRNvWVjvhC+6sOeo28r8MgIpQRYouXRtt/FCCXU7zn20jnHR4Qw==",
+      "version": "1.51.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.51.0.tgz",
+      "integrity": "sha512-dJ0dMbZeHhI+wb77+ljx/FeC8VBP6j/rj9OAojO08JI80wTZy6vRk9KvHKiDCUh4iMpEiseMgqRBIeW+eKX6RA==",
       "dev": true,
       "dependencies": {
-        "playwright": "1.49.0"
+        "playwright": "1.51.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -5009,12 +5009,12 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.49.0",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.49.0.tgz",
-      "integrity": "sha512-eKpmys0UFDnfNb3vfsf8Vx2LEOtflgRebl0Im2eQQnYMA4Aqd+Zw8bEOB+7ZKvN76901mRnqdsiOGKxzVTbi7A==",
+      "version": "1.51.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.51.0.tgz",
+      "integrity": "sha512-442pTfGM0xxfCYxuBa/Pu6B2OqxqqaYq39JS8QDMGThUvIOCd6s0ANDog3uwA0cHavVlnTQzGCN7Id2YekDSXA==",
       "dev": true,
       "dependencies": {
-        "playwright-core": "1.49.0"
+        "playwright-core": "1.51.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -5027,9 +5027,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.49.0",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.49.0.tgz",
-      "integrity": "sha512-R+3KKTQF3npy5GTiKH/T+kdhoJfJojjHESR1YEWhYuEKRVfVaxH3+4+GvXE5xyCngCxhxnykk0Vlah9v8fs3jA==",
+      "version": "1.51.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.51.0.tgz",
+      "integrity": "sha512-x47yPE3Zwhlil7wlNU/iktF7t2r/URR3VLbH6EknJd/04Qc/PSJ0EY3CMXipmglLG+zyRxW6HNo2EGbKLHPWMg==",
       "dev": true,
       "bin": {
         "playwright-core": "cli.js"
@@ -7472,12 +7472,12 @@
       }
     },
     "@playwright/test": {
-      "version": "1.49.0",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.49.0.tgz",
-      "integrity": "sha512-DMulbwQURa8rNIQrf94+jPJQ4FmOVdpE5ZppRNvWVjvhC+6sOeo28r8MgIpQRYouXRtt/FCCXU7zn20jnHR4Qw==",
+      "version": "1.51.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.51.0.tgz",
+      "integrity": "sha512-dJ0dMbZeHhI+wb77+ljx/FeC8VBP6j/rj9OAojO08JI80wTZy6vRk9KvHKiDCUh4iMpEiseMgqRBIeW+eKX6RA==",
       "dev": true,
       "requires": {
-        "playwright": "1.49.0"
+        "playwright": "1.51.0"
       }
     },
     "@rollup/plugin-commonjs": {
@@ -10584,13 +10584,13 @@
       }
     },
     "playwright": {
-      "version": "1.49.0",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.49.0.tgz",
-      "integrity": "sha512-eKpmys0UFDnfNb3vfsf8Vx2LEOtflgRebl0Im2eQQnYMA4Aqd+Zw8bEOB+7ZKvN76901mRnqdsiOGKxzVTbi7A==",
+      "version": "1.51.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.51.0.tgz",
+      "integrity": "sha512-442pTfGM0xxfCYxuBa/Pu6B2OqxqqaYq39JS8QDMGThUvIOCd6s0ANDog3uwA0cHavVlnTQzGCN7Id2YekDSXA==",
       "dev": true,
       "requires": {
         "fsevents": "2.3.2",
-        "playwright-core": "1.49.0"
+        "playwright-core": "1.51.0"
       },
       "dependencies": {
         "fsevents": {
@@ -10603,9 +10603,9 @@
       }
     },
     "playwright-core": {
-      "version": "1.49.0",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.49.0.tgz",
-      "integrity": "sha512-R+3KKTQF3npy5GTiKH/T+kdhoJfJojjHESR1YEWhYuEKRVfVaxH3+4+GvXE5xyCngCxhxnykk0Vlah9v8fs3jA==",
+      "version": "1.51.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.51.0.tgz",
+      "integrity": "sha512-x47yPE3Zwhlil7wlNU/iktF7t2r/URR3VLbH6EknJd/04Qc/PSJ0EY3CMXipmglLG+zyRxW6HNo2EGbKLHPWMg==",
       "dev": true
     },
     "plur": {

--- a/packages/js/package-lock.json
+++ b/packages/js/package-lock.json
@@ -16,7 +16,7 @@
         "honeybadger-checkins-sync": "scripts/check-ins-sync-bin.js"
       },
       "devDependencies": {
-        "@playwright/test": "1.48.0",
+        "@playwright/test": "1.49.0",
         "@rollup/plugin-commonjs": "^22.0.1",
         "@rollup/plugin-node-resolve": "^13.3.0",
         "@rollup/plugin-replace": "^5.0.2",
@@ -1025,12 +1025,12 @@
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.48.0",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.48.0.tgz",
-      "integrity": "sha512-W5lhqPUVPqhtc/ySvZI5Q8X2ztBOUgZ8LbAFy0JQgrXZs2xaILrUcNO3rQjwbLPfGK13+rZsDa1FpG+tqYkT5w==",
+      "version": "1.49.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.49.0.tgz",
+      "integrity": "sha512-DMulbwQURa8rNIQrf94+jPJQ4FmOVdpE5ZppRNvWVjvhC+6sOeo28r8MgIpQRYouXRtt/FCCXU7zn20jnHR4Qw==",
       "dev": true,
       "dependencies": {
-        "playwright": "1.48.0"
+        "playwright": "1.49.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -5009,12 +5009,12 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.48.0",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.48.0.tgz",
-      "integrity": "sha512-qPqFaMEHuY/ug8o0uteYJSRfMGFikhUysk8ZvAtfKmUK3kc/6oNl/y3EczF8OFGYIi/Ex2HspMfzYArk6+XQSA==",
+      "version": "1.49.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.49.0.tgz",
+      "integrity": "sha512-eKpmys0UFDnfNb3vfsf8Vx2LEOtflgRebl0Im2eQQnYMA4Aqd+Zw8bEOB+7ZKvN76901mRnqdsiOGKxzVTbi7A==",
       "dev": true,
       "dependencies": {
-        "playwright-core": "1.48.0"
+        "playwright-core": "1.49.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -5027,9 +5027,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.48.0",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.48.0.tgz",
-      "integrity": "sha512-RBvzjM9rdpP7UUFrQzRwR8L/xR4HyC1QXMzGYTbf1vjw25/ya9NRAVnXi/0fvFopjebvyPzsmoK58xxeEOaVvA==",
+      "version": "1.49.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.49.0.tgz",
+      "integrity": "sha512-R+3KKTQF3npy5GTiKH/T+kdhoJfJojjHESR1YEWhYuEKRVfVaxH3+4+GvXE5xyCngCxhxnykk0Vlah9v8fs3jA==",
       "dev": true,
       "bin": {
         "playwright-core": "cli.js"
@@ -7472,12 +7472,12 @@
       }
     },
     "@playwright/test": {
-      "version": "1.48.0",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.48.0.tgz",
-      "integrity": "sha512-W5lhqPUVPqhtc/ySvZI5Q8X2ztBOUgZ8LbAFy0JQgrXZs2xaILrUcNO3rQjwbLPfGK13+rZsDa1FpG+tqYkT5w==",
+      "version": "1.49.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.49.0.tgz",
+      "integrity": "sha512-DMulbwQURa8rNIQrf94+jPJQ4FmOVdpE5ZppRNvWVjvhC+6sOeo28r8MgIpQRYouXRtt/FCCXU7zn20jnHR4Qw==",
       "dev": true,
       "requires": {
-        "playwright": "1.48.0"
+        "playwright": "1.49.0"
       }
     },
     "@rollup/plugin-commonjs": {
@@ -10584,13 +10584,13 @@
       }
     },
     "playwright": {
-      "version": "1.48.0",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.48.0.tgz",
-      "integrity": "sha512-qPqFaMEHuY/ug8o0uteYJSRfMGFikhUysk8ZvAtfKmUK3kc/6oNl/y3EczF8OFGYIi/Ex2HspMfzYArk6+XQSA==",
+      "version": "1.49.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.49.0.tgz",
+      "integrity": "sha512-eKpmys0UFDnfNb3vfsf8Vx2LEOtflgRebl0Im2eQQnYMA4Aqd+Zw8bEOB+7ZKvN76901mRnqdsiOGKxzVTbi7A==",
       "dev": true,
       "requires": {
         "fsevents": "2.3.2",
-        "playwright-core": "1.48.0"
+        "playwright-core": "1.49.0"
       },
       "dependencies": {
         "fsevents": {
@@ -10603,9 +10603,9 @@
       }
     },
     "playwright-core": {
-      "version": "1.48.0",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.48.0.tgz",
-      "integrity": "sha512-RBvzjM9rdpP7UUFrQzRwR8L/xR4HyC1QXMzGYTbf1vjw25/ya9NRAVnXi/0fvFopjebvyPzsmoK58xxeEOaVvA==",
+      "version": "1.49.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.49.0.tgz",
+      "integrity": "sha512-R+3KKTQF3npy5GTiKH/T+kdhoJfJojjHESR1YEWhYuEKRVfVaxH3+4+GvXE5xyCngCxhxnykk0Vlah9v8fs3jA==",
       "dev": true
     },
     "plur": {

--- a/packages/js/package.json
+++ b/packages/js/package.json
@@ -57,7 +57,7 @@
     "@types/express": "^4.17.13"
   },
   "devDependencies": {
-    "@playwright/test": "1.48.0",
+    "@playwright/test": "1.49.0",
     "@rollup/plugin-commonjs": "^22.0.1",
     "@rollup/plugin-node-resolve": "^13.3.0",
     "@rollup/plugin-replace": "^5.0.2",

--- a/packages/js/package.json
+++ b/packages/js/package.json
@@ -57,7 +57,7 @@
     "@types/express": "^4.17.13"
   },
   "devDependencies": {
-    "@playwright/test": "1.49.0",
+    "@playwright/test": "1.51.0",
     "@rollup/plugin-commonjs": "^22.0.1",
     "@rollup/plugin-node-resolve": "^13.3.0",
     "@rollup/plugin-replace": "^5.0.2",


### PR DESCRIPTION
## Status
**READY**

## Description
Upgrades to _playwright@1.51_ (latest) that uses the new chrome headless browser. This fixes the failing CI tests.