### PR TITLE
Fix for generating sourcemaps for Expo projects.

### DIFF
--- a/packages/react-native/README.md
+++ b/packages/react-native/README.md
@@ -63,6 +63,12 @@ As of version 0.70, React Native uses Hermes as the default JavaScript engine. T
 npx honeybadger-upload-sourcemaps --no-hermes --apiKey <your project API key> --revision <build revision>
 ```
 
+If your React Native project uses Expo, include the `--expo` param.
+
+```shell
+npx honeybadger-upload-sourcemaps --apiKey <your project API key> --revision <build revision> --expo
+```
+
 If you just want to generate the source maps without uploading them to Honeybadger, you can use the `--skip-upload` flag.
 
 ```shell


### PR DESCRIPTION
## Status
<!--- **READY/WIP/HOLD** --->
**READY/WIP/HOLD**

## Description
This is an update to the honeybadger-upload-sourcemaps.sh script that includes the proper way of generating and uploading sourcemaps for Expo projects. The README.md doc was updated to reflect the new --expo param.

## Steps to Test or Reproduce
Outline the steps to test or reproduce the PR here.
```bash
> git pull --prune
> git checkout <branch>
> grunt jasmine
```
1. Run npx honeybadger-upload-sourcemaps --apiKey <api_key> --revision <revision> --expo to generate iOS and Android sourcemaps in an Expo project.
2. Send a test crash
3. Check to make sure the sourcemaps are applied
