### PR TITLE
feat(esbuild-plugin): add support for custom output path

### DIFF
--- a/packages/esbuild-plugin/src/index.ts
+++ b/packages/esbuild-plugin/src/index.ts
@@ -13,14 +13,14 @@ class HoneybadgerSourceMapPlugin {
 
   private static idSeed = 0
 
-  private readonly options: Types.HbPluginOptions & { overwriteOutputPath: string }
+  private readonly options: Types.HbPluginOptions & { overwriteOutputPath: string | undefined }
 
   /**
    *
    * @param options These options will be passed to the plugin-core utility functions
    * @param overwriteOutputPath Set this to overwrite the path to write the generated files
    */
-  constructor(options: Types.HbPluginUserOptions, overwriteOutputPath: string = null) {
+  constructor(options: Types.HbPluginUserOptions, overwriteOutputPath?: string) {
     this.options = { ...cleanOptions(options), overwriteOutputPath }
   }
 
@@ -72,7 +72,7 @@ class HoneybadgerSourceMapPlugin {
     await Promise.all(createFolderTasks)
 
     for (const file of outputFiles) {
-      const filePath = this.options.overwriteOutputPath != null
+      const filePath = this.options.overwriteOutputPath
         ? join(this.options.overwriteOutputPath, basename(file.path))
         : file.path
       writeFileTasks.push(writeFile(filePath, file.contents))
@@ -142,6 +142,6 @@ class HoneybadgerSourceMapPlugin {
   }
 }
 
-export function honeybadgerSourceMapPlugin(options: Types.HbPluginUserOptions, outputPath: string = null) {
-  return new HoneybadgerSourceMapPlugin(options, outputPath).setup()
+export function honeybadgerSourceMapPlugin(options: Types.HbPluginUserOptions, overwriteOutputPath?: string) {
+  return new HoneybadgerSourceMapPlugin(options, overwriteOutputPath).setup()
 }


### PR DESCRIPTION
## Status
**READY**

## Description
- [x] Adds support for custom output path.

Fixes #1426.
In most cases, the resulting file path (found in `result.outputFiles`) is the correct path.
For example, the following [@nx/esbuild](https://nx.dev/technologies/build-tools/esbuild/api/executors/esbuild) configuration works without the need to overwrite the output path.
```
/**
 * "build": {
 *       "executor": "@nx/esbuild:esbuild",
 *       "options": {
 *         "main": "apps/app/src/main.ts",
 *         "tsConfig": "apps/app/tsconfig.app.json",
 *         "outputPath": "dist/apps/app"
 *       }
 *     }
 */
```
However, when used with @nx/angular:application as an esbuild plugin, it seems that the `outputPath` configuration is not propagated to the esbuild plugin. This PR addresses this limitation by allowing to pass a value to overwrite the output path:
```
// project.json
"build": {
  "executor": "@nx/angular:application",
  "options": {
    ...
    "plugins": [
      {
        "path": "apps/my-app/plugins/hb-plugin-entry.js",
        "options": {
          "outputPath": "dist/apps/my-app"
        }
      }
    ]
}
```
The `hb-plugin-entry.js` file:
```
import { honeybadgerSourceMapPlugin } from '@honeybadger-io/esbuild-plugin';

const hbPluginOptions = {
  apiKey: 'abc123',
  assetsUrl: 'https://test.com',
  revision: 'v1.0.0',
};

// note the `outputPath` param here
module.exports = function ({ outputPath }) {
  return honeybadgerSourceMapPlugin(hbPluginOptions, outputPath);
}
```

