### PR TITLE
fix(js): preserve original error in browser onunhandledrejection handler

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -88,6 +88,7 @@ export interface Notice {
   __breadcrumbs: BreadcrumbRecord[],
   afterNotify?: AfterNotifyHandler,
   cause?: Error|Record<string, unknown>,
+  originalError?: Error,
   [key: string]: unknown
 }
 

--- a/packages/core/src/util.ts
+++ b/packages/core/src/util.ts
@@ -324,7 +324,7 @@ export function makeNotice(thing: Noticeable): Partial<Notice> {
     notice = {}
   } else if (isErrorObject(thing)) {
     const e = thing as Error
-    notice = merge(thing as Record<string, unknown>, { name: e.name, message: e.message, stack: e.stack, cause: e.cause })
+    notice = merge(thing as Record<string, unknown>, { name: e.name, message: e.message, stack: e.stack, cause: e.cause, originalError: e })
   } else if (typeof thing === 'object') {
     notice = shallowClone(thing)
   } else {

--- a/packages/core/test/util.test.ts
+++ b/packages/core/test/util.test.ts
@@ -3,6 +3,7 @@ import {
   merge,
   mergeNotice,
   objectIsEmpty,
+  makeNotice,
   runBeforeNotifyHandlers,
   runAfterNotifyHandlers,
   shallowClone,
@@ -450,5 +451,35 @@ describe('utils', function () {
       expect(result[0]['2']).toBe('SOURCE_SIZE_TOO_LARGE')
     })
 
+  })
+
+  describe('makeNotice', function () {
+    it('sets originalError when input is an Error', function () {
+      const err = new Error('test')
+      const notice = makeNotice(err)
+      expect(notice.originalError).toBe(err)
+    })
+
+    it('sets originalError with custom Error subclass properties accessible', function () {
+      class CustomError extends Error {
+        skipReporting = true
+        errorCode = 42
+      }
+      const err = new CustomError('custom')
+      const notice = makeNotice(err)
+      expect(notice.originalError).toBe(err)
+      expect((notice.originalError as CustomError).skipReporting).toBe(true)
+      expect((notice.originalError as CustomError).errorCode).toBe(42)
+    })
+
+    it('does not set originalError when input is a plain object', function () {
+      const notice = makeNotice({ name: 'test', message: 'msg' })
+      expect(notice.originalError).toBeUndefined()
+    })
+
+    it('does not set originalError when input is a string', function () {
+      const notice = makeNotice('test message')
+      expect(notice.originalError).toBeUndefined()
+    })
   })
 })

--- a/packages/js/src/browser/integrations/onunhandledrejection.ts
+++ b/packages/js/src/browser/integrations/onunhandledrejection.ts
@@ -30,13 +30,14 @@ export default function (_window: any = globalThisOrWindow()): Types.Plugin {
             const err = {
               name: reason.name,
               message: `UnhandledPromiseRejectionWarning: ${reason}`,
-              stack
+              stack,
+              originalError: reason
             }
             client.addBreadcrumb(
               `window.onunhandledrejection: ${err.name}`,
               {
                 category: 'error',
-                metadata: err
+                metadata: { name: err.name, message: err.message, stack: err.stack }
               }
             )
             client.notify(err)

--- a/packages/js/src/browser/integrations/onunhandledrejection.ts
+++ b/packages/js/src/browser/integrations/onunhandledrejection.ts
@@ -20,27 +20,18 @@ export default function (_window: any = globalThisOrWindow()): Types.Plugin {
           const { reason } = promiseRejectionEvent
 
           if (reason instanceof Error) {
-            // simulate v8 stack
-            // const fileName = reason.fileName || 'unknown'
-            // const lineNumber = reason.lineNumber || 0
-            const fileName = 'unknown'
-            const lineNumber = 0
-            const stackFallback = `${reason.message}\n    at ? (${fileName}:${lineNumber})`
-            const stack = reason.stack || stackFallback
-            const err = {
-              name: reason.name,
-              message: `UnhandledPromiseRejectionWarning: ${reason}`,
-              stack,
-              originalError: reason
+            if (!reason.stack) {
+              reason.stack = `${reason.message}\n    at ? (unknown:0)`
             }
+            reason.message = `UnhandledPromiseRejectionWarning: ${reason.message}`
             client.addBreadcrumb(
-              `window.onunhandledrejection: ${err.name}`,
+              `window.onunhandledrejection: ${reason.name}`,
               {
                 category: 'error',
-                metadata: { name: err.name, message: err.message, stack: err.stack }
+                metadata: { name: reason.name, message: reason.message, stack: reason.stack }
               }
             )
-            client.notify(err)
+            client.notify(reason)
             return
           }
 


### PR DESCRIPTION
## Summary

- Preserves the original Error instance via `originalError` property when handling unhandled promise rejections in the browser
- Allows `beforeNotify` handlers to access custom properties on Error subclasses
- Adds type definition for `originalError` on Notice interface

## Problem

The browser's `onunhandledrejection` handler creates a new plain object with only `name`, `message`, and `stack` properties, discarding the original Error instance. This makes it impossible to access custom error properties in `beforeNotify` callbacks.

For example, with a custom error class:

```typescript
class UnauthenticatedError extends Error {
  readonly skipReporting = true;
}
```

The following filter never works for unhandled rejections because the original error is lost:

```typescript
honeybadger.beforeNotify((notice) => {
  if (notice.skipReporting) return false;  // Always undefined
});
```

## Solution

Add an `originalError` property to the error object passed to `notify()`:

```typescript
honeybadger.beforeNotify((notice) => {
  if (notice.originalError?.skipReporting) {
    return false;
  }
});
```

## Test plan

- [x] Added tests verifying `originalError` is preserved
- [x] Added tests verifying custom properties are accessible via `originalError`
- [x] All existing tests pass

Closes #1180