### PR TITLE
feat(cloudflare): make @cloudflare/workers-types an optional peer dep

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Releases are performed via [GitHub Actions](https://github.com/honeybadger-io/ho
 - runs `npm publish`
 
 > [!NOTE] 
-> Some packages may have a `postpublish` script, for example `@honeybadger-io/js` (found in `packages/js`) has a script to also publish to our *js.honeybadger.io* CDN (hosted on AWS via S3/CloudFront). 
+> Some packages may have a `postpublish` script, for example `@honeybadger-io/js` (found in `packages/js`) has a script to also publish to our *js.honeybadger.io* CDN (hosted on AWS via S3/CloudFront).
 
 ### Release Automation
 
@@ -110,7 +110,17 @@ The repository automatically releases new packages when a PR is merged on master
 
 #### Available Commands
 
-- `npm run release` - Calculates the next version, commits and publishes to NPM (and to our CDN). This command is executed from the [Publish New Release](https://github.com/honeybadger-io/honeybadger-js/blob/master/.github/workflows/lerna-publish.yml) workflow. 
+- `npm run release` - Calculates the next version, commits and publishes to NPM (and to our CDN). This command is executed from the [Publish New Release](https://github.com/honeybadger-io/honeybadger-js/blob/master/.github/workflows/lerna-publish.yml) workflow.
+
+### Releasing Package For The First Time
+
+If you are publishing a new package on NPM, the [**Publish New Release** workflow](https://github.com/honeybadger-io/honeybadger-js/actions/workflows/lerna-publish.yml) (`lerna-publish.yml`)
+will fail with a 404 error message. This is because the workflow assumes Trusted Publishing has been set up for all packages, but since this is a new package, there's no way for Trusted Publishing to have been set up.
+Therefore, a manual release is required:
+- Allow the automated release workflow to fail. NPM publishing will fail, but changelog generation and GitHub release will be successful.
+- Then, check out the master branch locally and pull the latest changes.
+- `npm login`
+- `lerna publish from-package --yes --loglevel silly`
 
 ## License
 

--- a/packages/cloudflare/README.md
+++ b/packages/cloudflare/README.md
@@ -53,6 +53,42 @@ export default withHoneybadger(getConfig, {
 
 `withHoneybadger` wraps all handlers present on your export: **fetch**, **scheduled**, **queue**, **email**, and **tail**. Errors in any handler are reported to Honeybadger and rethrown; reporting runs via `ctx.waitUntil()` so it does not block the response.
 
+## TypeScript types
+
+This package does not bundle Cloudflare Worker types. It relies on ambient types (`ExportedHandler`, `ExecutionContext`, `MessageBatch`, etc.) that your Worker project already provides. Either approach works:
+
+- **Runtime types via Wrangler** (recommended for Wrangler v3.66+). Generate a `worker-configuration.d.ts` from your `wrangler.toml`/`wrangler.jsonc`:
+
+  ```bash
+  npx wrangler types
+  ```
+
+  Then reference it from your `tsconfig.json`:
+
+  ```jsonc
+  {
+    "compilerOptions": {
+      "types": ["./worker-configuration.d.ts"]
+    }
+  }
+  ```
+
+- **`@cloudflare/workers-types`** (for older Wrangler or projects that prefer the published types):
+
+  ```bash
+  npm install --save-dev @cloudflare/workers-types
+  ```
+
+  ```jsonc
+  {
+    "compilerOptions": {
+      "types": ["@cloudflare/workers-types"]
+    }
+  }
+  ```
+
+`@cloudflare/workers-types` is declared as an optional peer dependency, so it won't be installed automatically.
+
 ## License
 
 This package is MIT licensed. See the [MIT-LICENSE](./MIT-LICENSE) file in this folder for details.

--- a/packages/cloudflare/package-lock.json
+++ b/packages/cloudflare/package-lock.json
@@ -8,14 +8,20 @@
       "name": "@honeybadger-io/cloudflare",
       "version": "0.2.0",
       "license": "MIT",
-      "dependencies": {
-        "@cloudflare/workers-types": "^4.20240208.0"
-      },
       "devDependencies": {
+        "@cloudflare/workers-types": "^4.20240208.0",
         "@types/jest": "^29.5.12",
         "jest": "^29.7.0",
         "ts-jest": "^29.1.2",
         "typescript": "^5.3.3"
+      },
+      "peerDependencies": {
+        "@cloudflare/workers-types": "^4"
+      },
+      "peerDependenciesMeta": {
+        "@cloudflare/workers-types": {
+          "optional": true
+        }
       }
     },
     "node_modules/@babel/code-frame": {
@@ -515,9 +521,10 @@
       "license": "MIT"
     },
     "node_modules/@cloudflare/workers-types": {
-      "version": "4.20260408.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20260408.1.tgz",
-      "integrity": "sha512-kE1tKfHUyIldsj3ea2XEqvLRHkDwc83YM7nar6SS5+cj81IoAFR/OZNDwZWHb6vx+pC31PBJGtROlfZzsgxudQ==",
+      "version": "4.20260420.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20260420.1.tgz",
+      "integrity": "sha512-DHT9JnSn9cIiCSdL76OxW+Xvc1+ml1CWzWvgVwreoHQ+E604aeFxPPHp9X7nE+XRWm2NH4l0OgtxUI5T/nuI3g==",
+      "dev": true,
       "license": "MIT OR Apache-2.0"
     },
     "node_modules/@istanbuljs/load-nyc-config": {
@@ -538,9 +545,9 @@
       }
     },
     "node_modules/@istanbuljs/schema": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.3.tgz",
-      "integrity": "sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==",
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.6.tgz",
+      "integrity": "sha512-+Sg6GCR/wy1oSmQDFq4LQDAhm3ETKnorxN+y5nbLULOR3P0c14f2Wurzj3/xqPXtasLFfHd5iRFQ7AJt4KH2cw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1010,13 +1017,13 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "25.5.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.5.2.tgz",
-      "integrity": "sha512-tO4ZIRKNC+MDWV4qKVZe3Ql/woTnmHDr5JD8UI5hn2pwBrHEwOEMZK7WlNb5RKB6EoJ02gwmQS9OrjuFnZYdpg==",
+      "version": "25.6.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
+      "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~7.18.0"
+        "undici-types": "~7.19.0"
       }
     },
     "node_modules/@types/stack-utils": {
@@ -1233,9 +1240,9 @@
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.16",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.16.tgz",
-      "integrity": "sha512-Lyf3aK28zpsD1yQMiiHD4RvVb6UdMoo8xzG2XzFIfR9luPzOpcBlAsT/qfB1XWS1bxWT+UtE4WmQgsp297FYOA==",
+      "version": "2.10.20",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.20.tgz",
+      "integrity": "sha512-1AaXxEPfXT+GvTBJFuy4yXVHWJBXa4OdbIebGN/wX5DlsIkU0+wzGnd2lOzokSk51d5LUmqjgBLRLlypLUqInQ==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -1246,9 +1253,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
-      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1354,9 +1361,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001787",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001787.tgz",
-      "integrity": "sha512-mNcrMN9KeI68u7muanUpEejSLghOKlVhRqS/Za2IeyGllJ9I9otGpR9g3nsw7n4W378TE/LyIteA0+/FOZm4Kg==",
+      "version": "1.0.30001788",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001788.tgz",
+      "integrity": "sha512-6q8HFp+lOQtcf7wBK+uEenxymVWkGKkjFpCvw5W25cmMwEDU45p1xQFBQv8JDlMMry7eNxyBaR+qxgmTUZkIRQ==",
       "dev": true,
       "funding": [
         {
@@ -1592,9 +1599,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.333",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.333.tgz",
-      "integrity": "sha512-skNh4FsE+IpCJV7xAQGbQ4eyOGvcEctVBAk7a5KPzxC3alES9rLrT+2IsPRPgeQr8LVxdJr8BHQ9481+TOr0xg==",
+      "version": "1.5.340",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.340.tgz",
+      "integrity": "sha512-908qahOGocRMinT2nM3ajCEM99H4iPdv84eagPP3FfZy/1ZGeOy2CZYzjhms81ckOPCXPlW7LkY4XpxD8r1DrA==",
       "dev": true,
       "license": "ISC"
     },
@@ -1626,6 +1633,16 @@
       "license": "MIT",
       "dependencies": {
         "is-arrayish": "^0.2.1"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/escalade": {
@@ -1893,9 +1910,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3250,12 +3267,13 @@
       }
     },
     "node_modules/resolve": {
-      "version": "1.22.11",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.11.tgz",
-      "integrity": "sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==",
+      "version": "1.22.12",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
+      "integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
+        "es-errors": "^1.3.0",
         "is-core-module": "^2.16.1",
         "path-parse": "^1.0.7",
         "supports-preserve-symlinks-flag": "^1.0.0"
@@ -3668,9 +3686,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "7.18.2",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
-      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "version": "7.19.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
+      "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
       "dev": true,
       "license": "MIT"
     },

--- a/packages/cloudflare/package.json
+++ b/packages/cloudflare/package.json
@@ -30,15 +30,23 @@
     "url": "https://github.com/honeybadger-io/honeybadger-js/issues"
   },
   "dependencies": {
-    "@cloudflare/workers-types": "^4.20240208.0",
     "@honeybadger-io/core": "^6.7.2",
     "@honeybadger-io/js": "^6.12.3"
   },
   "devDependencies": {
+    "@cloudflare/workers-types": "^4.20240208.0",
     "@types/jest": "^29.5.12",
     "jest": "^29.7.0",
     "ts-jest": "^29.1.2",
     "typescript": "^5.3.3"
+  },
+  "peerDependencies": {
+    "@cloudflare/workers-types": "^4"
+  },
+  "peerDependenciesMeta": {
+    "@cloudflare/workers-types": {
+      "optional": true
+    }
   },
   "publishConfig": {
     "access": "public"

--- a/packages/cloudflare/src/index.ts
+++ b/packages/cloudflare/src/index.ts
@@ -1,13 +1,5 @@
 import Honeybadger from '@honeybadger-io/js'
 import type { Types } from '@honeybadger-io/core'
-import type {
-  ExportedHandler,
-  ExecutionContext,
-  ForwardableEmailMessage,
-  MessageBatch,
-  ScheduledController,
-  TraceItem,
-} from '@cloudflare/workers-types'
 
 const HANDLER_NAMES = ['fetch', 'scheduled', 'queue', 'email', 'tail'] as const
 

--- a/packages/cloudflare/test/withHoneybadger.test.ts
+++ b/packages/cloudflare/test/withHoneybadger.test.ts
@@ -58,7 +58,7 @@ describe('withHoneybadger', () => {
       }
       const originalFetch = handler.fetch
       const wrapped = withHoneybadger(
-        (e) => ({ apiKey: e.HONEYBADGER_API_KEY }),
+        (e: typeof env) => ({ apiKey: e.HONEYBADGER_API_KEY }),
         handler
       )
       const request = new Request('https://example.com/')
@@ -112,7 +112,7 @@ describe('withHoneybadger', () => {
         fetch: jest.fn().mockResolvedValue(new Response('ok', { status: 200 })),
       }
       const wrapped = withHoneybadger(
-        (e) => ({ apiKey: e.HONEYBADGER_API_KEY }),
+        (e: typeof env) => ({ apiKey: e.HONEYBADGER_API_KEY }),
         handler
       )
       const request = new Request('https://example.com/')
@@ -133,7 +133,7 @@ describe('withHoneybadger', () => {
         fetch: jest.fn().mockResolvedValue(new Response('ok')),
       }
       const wrapped = withHoneybadger(
-        (e) => ({ apiKey: e.HONEYBADGER_API_KEY }),
+        (e: typeof env) => ({ apiKey: e.HONEYBADGER_API_KEY }),
         handler
       )
       const request = new Request('https://example.com/foo', { method: 'POST' })

--- a/packages/cloudflare/tsconfig.json
+++ b/packages/cloudflare/tsconfig.json
@@ -4,6 +4,7 @@
   "compilerOptions": {
     "rootDir": "./src",
     "outDir": "./dist",
-    "allowSyntheticDefaultImports": true
+    "allowSyntheticDefaultImports": true,
+    "types": ["@cloudflare/workers-types"]
   }
 }

--- a/packages/cloudflare/tsconfig.json
+++ b/packages/cloudflare/tsconfig.json
@@ -5,6 +5,6 @@
     "rootDir": "./src",
     "outDir": "./dist",
     "allowSyntheticDefaultImports": true,
-    "types": ["@cloudflare/workers-types"]
+    "types": ["@cloudflare/workers-types", "jest", "node"]
   }
 }


### PR DESCRIPTION
## Summary
- Moved `@cloudflare/workers-types` from `dependencies` to an optional `peerDependency` (range loosened to `^4`), so consumers can supply types either via `npx wrangler types` (runtime-generated `worker-configuration.d.ts`) or by installing `@cloudflare/workers-types` themselves.
- Removed explicit type imports from `src/index.ts` — handler types (`ExportedHandler`, `ExecutionContext`, `MessageBatch`, etc.) now resolve ambiently from whichever types package the consumer uses.
- Added a **TypeScript types** section to `packages/cloudflare/README.md` documenting both approaches.

## Test plan
- [x] `npm test` in `packages/cloudflare` passes
- [x] `npm run build` in `packages/cloudflare` succeeds with `@cloudflare/workers-types` as a devDependency
- [x] Sample Worker using `npx wrangler types` (no `@cloudflare/workers-types` installed) type-checks against the published package
- [x] Sample Worker using `@cloudflare/workers-types` still type-checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)