### PR TITLE
fix(cloudflare): correctly skip reporting when apiKey is missing

### DIFF
--- a/packages/cloudflare/package.json
+++ b/packages/cloudflare/package.json
@@ -13,12 +13,17 @@
   "homepage": "https://github.com/honeybadger-io/honeybadger-js#readme",
   "license": "MIT",
   "main": "dist/index.js",
-  "module": "dist/index.js",
   "types": "dist/index.d.ts",
   "type": "module",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/honeybadger-io/honeybadger-js.git"
+  },
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
   },
   "scripts": {
     "test": "jest --config jest.config.cjs",

--- a/packages/cloudflare/src/index.ts
+++ b/packages/cloudflare/src/index.ts
@@ -3,8 +3,16 @@ import type { Types } from '@honeybadger-io/core'
 
 const HANDLER_NAMES = ['fetch', 'scheduled', 'queue', 'email', 'tail'] as const
 
+function isHbConfigured() {
+  if (Honeybadger.config.apiKey === null || Honeybadger.config.apiKey === undefined) {
+    return false;
+  }
+
+  return Honeybadger.config.apiKey.length === 0
+}
+
 function reportError(error: unknown): Promise<void> {
-  if (Honeybadger.config.apiKey === undefined || Honeybadger.config.apiKey.length === 0) {
+  if (!isHbConfigured()) {
     return Promise.resolve()
   }
   const noticeable = error instanceof Error ? error : new Error(String(error))
@@ -24,7 +32,7 @@ export function withHoneybadger<Env>(
       const fetchHandler = fn as NonNullable<ExportedHandler<Env>['fetch']>
       handler.fetch = async (request, env, ctx) => {
         const config = getConfig(env)
-        if (config.apiKey && (Honeybadger.config.apiKey === undefined || Honeybadger.config.apiKey.length === 0)) {
+        if (config.apiKey && !isHbConfigured()) {
           Honeybadger.configure(config)
           Honeybadger.setContext({ url: request.url, method: request.method })
         }
@@ -46,7 +54,7 @@ export function withHoneybadger<Env>(
         ctx: ExecutionContext
       ) => {
         const config = getConfig(env)
-        if (config.apiKey && (Honeybadger.config.apiKey === undefined || Honeybadger.config.apiKey.length === 0)) {
+        if (config.apiKey && !isHbConfigured()) {
           Honeybadger.configure(config)
           Honeybadger.setContext({
             cron: controller.cron,
@@ -71,7 +79,7 @@ export function withHoneybadger<Env>(
         ctx: ExecutionContext
       ) => {
         const config = getConfig(env)
-        if (config.apiKey && (Honeybadger.config.apiKey === undefined || Honeybadger.config.apiKey.length === 0)) {
+        if (config.apiKey && !isHbConfigured()) {
           Honeybadger.configure(config)
           Honeybadger.setContext({
             queue: batch.queue,
@@ -96,7 +104,7 @@ export function withHoneybadger<Env>(
         ctx: ExecutionContext
       ) => {
         const config = getConfig(env)
-        if (config.apiKey && (Honeybadger.config.apiKey === undefined || Honeybadger.config.apiKey.length === 0)) {
+        if (config.apiKey && !isHbConfigured()) {
           Honeybadger.configure(config)
         }
         try {
@@ -117,7 +125,7 @@ export function withHoneybadger<Env>(
         ctx: ExecutionContext
       ) => {
         const config = getConfig(env)
-        if (config.apiKey && (Honeybadger.config.apiKey === undefined || Honeybadger.config.apiKey.length === 0)) {
+        if (config.apiKey && !isHbConfigured()) {
           Honeybadger.configure(config)
         }
         try {

--- a/packages/cloudflare/src/index.ts
+++ b/packages/cloudflare/src/index.ts
@@ -8,7 +8,7 @@ function isHbConfigured() {
     return false;
   }
 
-  return Honeybadger.config.apiKey.length === 0
+  return Honeybadger.config.apiKey.length > 0
 }
 
 function reportError(error: unknown): Promise<void> {

--- a/packages/cloudflare/tsconfig.json
+++ b/packages/cloudflare/tsconfig.json
@@ -2,6 +2,10 @@
   "extends": "../../tsconfig.base.json",
   "include": ["src/**/*.ts"],
   "compilerOptions": {
+    "target": "ES2022", // Workers run modern V8. Drops the __awaiter/__generator down-level helpers; native async/await is emitted.
+    "module": "ESNext", // emits real import / export statements, matching "type": "module". This is what fixes the exports is not defined runtime error and the wrangler "has no exports" warning.
+    "moduleResolution": "Bundler", // pairs with module: ESNext; matches how esbuild/wrangler resolves.
+    "lib": ["ES2022"], // the base inherits no explicit lib, so it falls back to a target-derived default
     "rootDir": "./src",
     "outDir": "./dist",
     "allowSyntheticDefaultImports": true,


### PR DESCRIPTION
## Summary
- Extracts the apiKey presence check in `packages/cloudflare/src/index.ts` into a single `isHbConfigured()` helper, replacing the duplicated `apiKey === undefined || apiKey.length === 0` checks across all five handler wrappers (`fetch`, `scheduled`, `queue`, `email`, `tail`) and `reportError`.
- Also handles `apiKey === null` (previously only `undefined` was checked).
- Updates `packages/cloudflare/package.json` to declare an `exports` map (drops the legacy `module` field) so consumers resolve the ESM build via the standard exports field.
- Updates `packages/cloudflare/tsconfig.json` to target `ES2022` / `module: ESNext` / `moduleResolution: Bundler`. This emits real `import`/`export` statements that match `"type": "module"` and fixes the `exports is not defined` runtime error and the wrangler "has no exports" warning.

## Test plan
- [x] `npm test` in `packages/cloudflare` passes
- [x] `npm run build` in `packages/cloudflare` succeeds and emits ESM output
- [x] Sample Worker imports the built package without `exports is not defined`
- [x] Worker with no `apiKey` configured does not attempt to report
- [x] Worker with a valid `apiKey` reports errors as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)