### PR TITLE
feat(core): preserve original error on unhandled rejection

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -88,6 +88,7 @@ export interface Notice {
   __breadcrumbs: BreadcrumbRecord[],
   afterNotify?: AfterNotifyHandler,
   cause?: Error|Record<string, unknown>,
+  originalError?: Error,
   [key: string]: unknown
 }
 

--- a/packages/core/src/util.ts
+++ b/packages/core/src/util.ts
@@ -324,7 +324,7 @@ export function makeNotice(thing: Noticeable): Partial<Notice> {
     notice = {}
   } else if (isErrorObject(thing)) {
     const e = thing as Error
-    notice = merge(thing as Record<string, unknown>, { name: e.name, message: e.message, stack: e.stack, cause: e.cause })
+    notice = merge(thing as Record<string, unknown>, { name: e.name, message: e.message, stack: e.stack, cause: e.cause, originalError: e })
   } else if (typeof thing === 'object') {
     notice = shallowClone(thing)
   } else {

--- a/packages/core/test/client.test.ts
+++ b/packages/core/test/client.test.ts
@@ -753,6 +753,27 @@ describe('client', function () {
       expect(payload.server.revision).toEqual('expected revision')
     })
 
+    it('exposes custom Error subclass properties via originalError', function () {
+      class UnauthenticatedError extends Error {
+        readonly skipReporting = true
+        readonly statusCode = 401
+      }
+
+      let notice: Notice
+      client.beforeNotify(function (n) {
+        notice = n
+        if ((n.originalError as UnauthenticatedError)?.skipReporting) {
+          return false
+        }
+      })
+
+      const err = new UnauthenticatedError('not authenticated')
+      expect(client.notify(err)).toEqual(false)
+      expect(notice.originalError).toBe(err)
+      expect((notice.originalError as UnauthenticatedError).skipReporting).toBe(true)
+      expect((notice.originalError as UnauthenticatedError).statusCode).toBe(401)
+    })
+
     it('calls all beforeNotify handlers even if one returns false', function () {
       client.configure({
         apiKey: undefined

--- a/packages/core/test/util.test.ts
+++ b/packages/core/test/util.test.ts
@@ -3,6 +3,7 @@ import {
   merge,
   mergeNotice,
   objectIsEmpty,
+  makeNotice,
   runBeforeNotifyHandlers,
   runAfterNotifyHandlers,
   shallowClone,
@@ -450,5 +451,35 @@ describe('utils', function () {
       expect(result[0]['2']).toBe('SOURCE_SIZE_TOO_LARGE')
     })
 
+  })
+
+  describe('makeNotice', function () {
+    it('sets originalError when input is an Error', function () {
+      const err = new Error('test')
+      const notice = makeNotice(err)
+      expect(notice.originalError).toBe(err)
+    })
+
+    it('sets originalError with custom Error subclass properties accessible', function () {
+      class CustomError extends Error {
+        skipReporting = true
+        errorCode = 42
+      }
+      const err = new CustomError('custom')
+      const notice = makeNotice(err)
+      expect(notice.originalError).toBe(err)
+      expect((notice.originalError as CustomError).skipReporting).toBe(true)
+      expect((notice.originalError as CustomError).errorCode).toBe(42)
+    })
+
+    it('does not set originalError when input is a plain object', function () {
+      const notice = makeNotice({ name: 'test', message: 'msg' })
+      expect(notice.originalError).toBeUndefined()
+    })
+
+    it('does not set originalError when input is a string', function () {
+      const notice = makeNotice('test message')
+      expect(notice.originalError).toBeUndefined()
+    })
   })
 })

--- a/packages/js/src/browser/integrations/onunhandledrejection.ts
+++ b/packages/js/src/browser/integrations/onunhandledrejection.ts
@@ -30,13 +30,14 @@ export default function (_window: any = globalThisOrWindow()): Types.Plugin {
             const err = {
               name: reason.name,
               message: `UnhandledPromiseRejectionWarning: ${reason}`,
-              stack
+              stack,
+              originalError: reason
             }
             client.addBreadcrumb(
               `window.onunhandledrejection: ${err.name}`,
               {
                 category: 'error',
-                metadata: err
+                metadata: { name: err.name, message: err.message, stack: err.stack }
               }
             )
             client.notify(err)

--- a/packages/js/src/browser/integrations/onunhandledrejection.ts
+++ b/packages/js/src/browser/integrations/onunhandledrejection.ts
@@ -20,27 +20,18 @@ export default function (_window: any = globalThisOrWindow()): Types.Plugin {
           const { reason } = promiseRejectionEvent
 
           if (reason instanceof Error) {
-            // simulate v8 stack
-            // const fileName = reason.fileName || 'unknown'
-            // const lineNumber = reason.lineNumber || 0
-            const fileName = 'unknown'
-            const lineNumber = 0
-            const stackFallback = `${reason.message}\n    at ? (${fileName}:${lineNumber})`
-            const stack = reason.stack || stackFallback
-            const err = {
-              name: reason.name,
-              message: `UnhandledPromiseRejectionWarning: ${reason}`,
-              stack,
-              originalError: reason
+            if (!reason.stack) {
+              reason.stack = `${reason.message}\n    at ? (unknown:0)`
             }
+            reason.message = `UnhandledPromiseRejectionWarning: ${reason.message}`
             client.addBreadcrumb(
-              `window.onunhandledrejection: ${err.name}`,
+              `window.onunhandledrejection: ${reason.name}`,
               {
                 category: 'error',
-                metadata: { name: err.name, message: err.message, stack: err.stack }
+                metadata: { name: reason.name, message: reason.message, stack: reason.stack }
               }
             )
-            client.notify(err)
+            client.notify(reason)
             return
           }
 

--- a/packages/js/src/browser/integrations/onunhandledrejection.ts
+++ b/packages/js/src/browser/integrations/onunhandledrejection.ts
@@ -2,7 +2,7 @@
 import { Types, Util } from '@honeybadger-io/core'
 import Client from '../../browser'
 
-const { instrument, globalThisOrWindow } = Util
+const { instrument, makeNotice, globalThisOrWindow } = Util
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export default function (_window: any = globalThisOrWindow()): Types.Plugin {
@@ -20,18 +20,19 @@ export default function (_window: any = globalThisOrWindow()): Types.Plugin {
           const { reason } = promiseRejectionEvent
 
           if (reason instanceof Error) {
-            if (!reason.stack) {
-              reason.stack = `${reason.message}\n    at ? (unknown:0)`
+            const notice = makeNotice(reason)
+            if (!notice.stack) {
+              notice.stack = `${reason.message}\n    at ? (unknown:0)`
             }
-            reason.message = `UnhandledPromiseRejectionWarning: ${reason.message}`
+            notice.message = `UnhandledPromiseRejectionWarning: ${notice.message}`
             client.addBreadcrumb(
-              `window.onunhandledrejection: ${reason.name}`,
+              `window.onunhandledrejection: ${notice.name}`,
               {
                 category: 'error',
-                metadata: { name: reason.name, message: reason.message, stack: reason.stack }
+                metadata: { name: notice.name, message: notice.message, stack: notice.stack }
               }
             )
-            client.notify(reason)
+            client.notify(notice)
             return
           }
 

--- a/packages/js/src/browser/integrations/onunhandledrejection.ts
+++ b/packages/js/src/browser/integrations/onunhandledrejection.ts
@@ -24,7 +24,7 @@ export default function (_window: any = globalThisOrWindow()): Types.Plugin {
             if (!notice.stack) {
               notice.stack = `${reason.message}\n    at ? (unknown:0)`
             }
-            notice.message = `UnhandledPromiseRejectionWarning: ${notice.message}`
+            notice.message = `UnhandledPromiseRejectionWarning: ${reason}`
             client.addBreadcrumb(
               `window.onunhandledrejection: ${notice.name}`,
               {

--- a/packages/js/test/unit/browser/integrations/onunhandledrejection.browser.test.ts
+++ b/packages/js/test/unit/browser/integrations/onunhandledrejection.browser.test.ts
@@ -49,7 +49,7 @@ describe('window.onunhandledrejection integration', function () {
     window.onunhandledrejection({ reason })
     expect(mockNotify.mock.calls.length).toBe(1)
     const notice = mockNotify.mock.calls[0][0]
-    expect(notice.message).toBe('UnhandledPromiseRejectionWarning: Test error')
+    expect(notice.message).toBe('UnhandledPromiseRejectionWarning: Error: Test error')
   })
 
   it('sets a fallback stack when the Error has no stack', function () {

--- a/packages/js/test/unit/browser/integrations/onunhandledrejection.browser.test.ts
+++ b/packages/js/test/unit/browser/integrations/onunhandledrejection.browser.test.ts
@@ -1,5 +1,6 @@
 import onUnhandledRejection from '../../../../src/browser/integrations/onunhandledrejection'
 import { nullLogger, TestClient, TestTransport } from '../../helpers'
+import { Notice } from '@honeybadger-io/core/build/src/types';
 
 describe('window.onunhandledrejection integration', function () {
   let client, mockNotify
@@ -47,8 +48,8 @@ describe('window.onunhandledrejection integration', function () {
     const reason = new Error('Test error')
     window.onunhandledrejection({ reason })
     expect(mockNotify.mock.calls.length).toBe(1)
-    expect(mockNotify.mock.calls[0][0]).toBe(reason)
-    expect(reason.message).toBe('UnhandledPromiseRejectionWarning: Test error')
+    const notice = mockNotify.mock.calls[0][0]
+    expect(notice.message).toBe('UnhandledPromiseRejectionWarning: Test error')
   })
 
   it('sets a fallback stack when the Error has no stack', function () {
@@ -58,8 +59,8 @@ describe('window.onunhandledrejection integration', function () {
     reason.stack = ''
     window.onunhandledrejection({ reason })
     expect(mockNotify.mock.calls.length).toBe(1)
-    expect(mockNotify.mock.calls[0][0]).toBe(reason)
-    expect(reason.stack).toBe('No stack\n    at ? (unknown:0)')
+    const notice = mockNotify.mock.calls[0][0]
+    expect(notice.stack).toBe('No stack\n    at ? (unknown:0)')
   })
 
   it('preserves custom properties on Error subclasses passed directly', function () {
@@ -75,9 +76,8 @@ describe('window.onunhandledrejection integration', function () {
     window.onunhandledrejection({ reason })
     expect(mockNotify.mock.calls.length).toBe(1)
 
-    const notifiedError = mockNotify.mock.calls[0][0]
-    expect(notifiedError).toBe(reason)
-    expect(notifiedError.skipReporting).toBe(true)
-    expect(notifiedError.errorType).toBe('CUSTOM')
+    const notifiedError: Notice = mockNotify.mock.calls[0][0]
+    expect((notifiedError.originalError as CustomError).skipReporting).toBe(true)
+    expect((notifiedError.originalError as CustomError).errorType).toBe('CUSTOM')
   })
 })


### PR DESCRIPTION
## Status
**READY**

## Description
Continuation from #1484.
