### PR TITLE
fix(react-native): fix sourcemap generation on React Native >= 0.82

### DIFF
--- a/packages/react-native/scripts/honeybadger-upload-sourcemaps.sh
+++ b/packages/react-native/scripts/honeybadger-upload-sourcemaps.sh
@@ -209,10 +209,15 @@ if $USE_HERMES; then
 	# react native <= 0.68
 	HERMES_PATH_2="$NODE_MODULES/hermes-engine/$OS_BIN/hermesc"
 
+ 	# react native >= 0.82
+ 	HERMES_PATH_3="$NODE_MODULES/hermes-compiler/hermesc/$OS_BIN/hermesc"
+
 	if [ -f "$HERMES_PATH_1" ]; then
 		HERMES_EXECUTABLE="$HERMES_PATH_1"
 	elif [ -f "$HERMES_PATH_2" ]; then
 		HERMES_EXECUTABLE="$HERMES_PATH_2"
+	elif [ -f "$HERMES_PATH_3" ]; then
+		HERMES_EXECUTABLE="$HERMES_PATH_3"
 	else
 		echo "Error: The Hermes compiler executable for Android was not found in the expected locations."
 		exit 1


### PR DESCRIPTION
## Status
<!--- **READY/WIP/HOLD** --->
**READY**

## Description
From React Native 0.82 the hermes compiler moved the its own package. This broke the sourcemap generation. This PR adds the new location to the `honeybadger-upload-sourcemaps` script.

Error:

```
Expo project detected automatically.
Using entry file: some-location/node_modules/.bin/../../node_modules/expo-router/entry.js
Generating the Android source map ...
Generating the iOS source map ...
Hermes is enabled ...
Error: The Hermes compiler executable for Android was not found in the expected locations.
```

## Steps to Test or Reproduce
Outline the steps to test or reproduce the PR here.

1. Initialize a React Native/Expo project on RN 0.82+
2. Install `@honeybadger-io/react-native`
3. Run `npx honeybadger-upload-sourcemaps --apiKey some-key --skip-upload --revision 0.0.1`
4. See the sourcemaps generated successfully (no error)