### PR TITLE
chore: normalize package repository metadata

### DIFF
--- a/packages/rollup-plugin/package.json
+++ b/packages/rollup-plugin/package.json
@@ -16,7 +16,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+ssh://git@github.com/honeybadger-io/honeybadger-js.git"
+    "url": "git+https://github.com/honeybadger-io/honeybadger-js.git"
   },
   "keywords": [
     "rollup",


### PR DESCRIPTION
## Status
**READY**

## Description
Normalize the @honeybadger-io/rollup-plugin package repository metadata by replacing the SSH Git URL with a public HTTPS Git URL.

## Related PRs
N/A

## What problem does this PR solve?
The published package metadata currently uses `git+ssh://git@github.com/honeybadger-io/honeybadger-js.git`, which assumes SSH access. A public HTTPS URL is easier for package consumers and metadata tooling to resolve.

## How has this been tested?
Metadata-only change. Confirmed the compare diff is 1 addition and 1 deletion in `packages/rollup-plugin/package.json`.
