### PR TITLE
fix: use HTTPS repository metadata for rollup plugin

### DIFF
--- a/packages/rollup-plugin/package.json
+++ b/packages/rollup-plugin/package.json
@@ -16,7 +16,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+ssh://git@github.com/honeybadger-io/honeybadger-js.git"
+    "url": "git+https://github.com/honeybadger-io/honeybadger-js.git"
   },
   "keywords": [
     "rollup",


### PR DESCRIPTION
## Summary
- update `@honeybadger-io/rollup-plugin` repository metadata to use the public HTTPS GitHub URL instead of SSH

## Verification
- `node -e "const p=require('./packages/rollup-plugin/package.json'); if (p.repository.url !== 'git+https://github.com/honeybadger-io/honeybadger-js.git') process.exit(1); if (p.repository.url.includes('git@github.com')) process.exit(2); console.log(p.repository.url)"`
