### PR TITLE
feat(nextjs): instrument Pages Router API routes and skip Next.js control-flow errors

### DIFF
--- a/packages/nextjs/src/insights-instrumentation.ts
+++ b/packages/nextjs/src/insights-instrumentation.ts
@@ -1,0 +1,155 @@
+import Honeybadger from '@honeybadger-io/js';
+
+/**
+ * Edge-safe equivalents of the inbound instrumentation helpers in
+ * `@honeybadger-io/js` (src/server/instrumentation/http_event.ts). They are
+ * duplicated here because this module must also load on the edge runtime where
+ * Node builtins (the `crypto` module, `process.hrtime`) are unavailable. Keep
+ * the header names and the `request_id` / `correlation_id` contract in sync
+ * with that file.
+ *
+ * Both request shapes Next.js uses are supported: the `*RequestEventContext` /
+ * `*RequestEvent` pairs come in a web-`Headers`/`Request` variant (App Router
+ * route handlers and middleware) and a Node-bag variant (Pages Router API
+ * routes, which only ever run on the Node runtime).
+ */
+function generateId(): string {
+  const webCrypto = (globalThis as { crypto?: { randomUUID?: () => string } }).crypto
+  if (webCrypto && typeof webCrypto.randomUUID === 'function') {
+    try {
+      return webCrypto.randomUUID()
+    }
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    catch (error) {
+      // fall through to manual generation
+    }
+  }
+  // v4-shaped, not crypto-quality. Acceptable since this is a correlation id,
+  // not a security token.
+  return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, (ch) => {
+    const r = (Math.random() * 16) | 0
+    const v = ch === 'x' ? r : (r & 0x3) | 0x8
+    return v.toString(16)
+  })
+}
+
+function readHeader(headers: Headers, name: string): string | undefined {
+  const value = headers.get(name)
+  if (typeof value !== 'string') {
+    return undefined
+  }
+  const trimmed = value.trim()
+  return trimmed.length ? trimmed : undefined
+}
+
+// Node-style headers bag, as seen on the Pages Router `req` (an
+// `IncomingMessage`): lowercased keys, values that may be arrays.
+export type NodeHeaders = Record<string, string | string[] | undefined>
+
+// Minimal shape of a Node-style request (Pages Router `NextApiRequest`),
+// covering only what the instrumentation reads.
+export type NodeRequestLike = { method?: string; url?: string; headers: NodeHeaders }
+
+function readNodeHeader(headers: NodeHeaders, name: string): string | undefined {
+  if (!headers) {
+    return undefined
+  }
+  const lower = name.toLowerCase()
+  let value: string | string[] | undefined = headers[lower]
+  if (value === undefined) {
+    for (const key of Object.keys(headers)) {
+      if (key.toLowerCase() === lower) {
+        value = headers[key]
+        break
+      }
+    }
+  }
+  if (Array.isArray(value)) {
+    value = value[0]
+  }
+  if (typeof value !== 'string') {
+    return undefined
+  }
+  const trimmed = value.trim()
+  return trimmed.length ? trimmed : undefined
+}
+
+// A type alias (not an interface) so it stays assignable to the
+// Record<string, unknown> that setEventContext expects.
+export type RequestIds = {
+  request_id: string
+  correlation_id: string
+}
+
+// Shared id precedence. Kept in one place (rather than once per request shape)
+// so the header-name contract documented above is only spelled out once.
+function seedIds(read: (name: string) => string | undefined): RequestIds {
+  const requestId =
+    read('x-request-id') ??
+    read('request-id') ??
+    generateId()
+  const correlationId =
+    read('x-correlation-id') ??
+    read('x-amzn-trace-id') ??
+    requestId
+  return { request_id: requestId, correlation_id: correlationId }
+}
+
+// App Router / middleware: headers are a web `Headers` instance.
+export function seedRequestEventContext(headers: Headers): RequestIds {
+  return seedIds((name) => readHeader(headers, name))
+}
+
+// Pages Router: headers are a Node bag (Pages routes are Node-only, never edge).
+export function seedNodeRequestEventContext(headers: NodeHeaders): RequestIds {
+  return seedIds((name) => readNodeHeader(headers, name))
+}
+
+export function now(): number {
+  return typeof performance !== 'undefined' ? performance.now() : Date.now()
+}
+
+// Mirrors Util.resolveInsights from @honeybadger-io/core: the master gate and
+// the per-source flag must both be on.
+export function insightsHttpEnabled(): boolean {
+  const insights = Honeybadger.config.insights
+  return insights?.enabled === true && insights?.http === true
+}
+
+// The ids are embedded directly in the payload (instead of relying on the
+// store's eventContext merge) so the event carries them even on the edge
+// runtime, where there is no per-request store isolation. On the Node.js
+// runtime they match the seeded event context, so embedding is a no-op.
+function emitHandledEvent(method: string | undefined, path: string | undefined, status: number | undefined, start: number, ids: RequestIds): void {
+  const payload: Record<string, unknown> = {
+    method,
+    duration: Math.round(now() - start),
+    ...ids,
+  }
+  if (typeof path === 'string') {
+    payload.path = path
+  }
+  if (typeof status === 'number') {
+    payload.status = status
+  }
+  Honeybadger.event('request.handled', payload)
+}
+
+// App Router / middleware: `req.url` is absolute, so parse out the pathname.
+export function emitRequestEvent(req: Request, status: number | undefined, start: number, ids: RequestIds): void {
+  let path: string | undefined
+  try {
+    path = new URL(req.url).pathname
+  }
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  catch (error) {
+    // relative or malformed URL — leave path unset
+  }
+  emitHandledEvent(req.method, path, status, start, ids)
+}
+
+// Pages Router: `req.url` is a relative path that may carry a query string.
+export function emitNodeRequestEvent(req: NodeRequestLike, status: number | undefined, start: number, ids: RequestIds): void {
+  const path = typeof req.url === 'string' ? req.url.split('?')[0] : undefined
+  emitHandledEvent(req.method, path, status, start, ids)
+}

--- a/packages/nextjs/src/with-honeybadger.test.ts
+++ b/packages/nextjs/src/with-honeybadger.test.ts
@@ -1,0 +1,372 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import Honeybadger from '@honeybadger-io/js'
+import type { NextResponse } from 'next/server'
+import { withHoneybadger } from './with-honeybadger'
+
+describe('withHoneybadger', () => {
+  let workerLogSpy: jest.SpyInstance
+  let notifyAsyncSpy: jest.SpyInstance
+
+  // The events worker is `protected` on Client; in tests we read it via `as any`.
+  const eventsWorker = () => (Honeybadger as any).__eventsWorker
+
+  // client.event() pushes to the worker after the async beforeEvent chain
+  // resolves — give it a tick.
+  const waitForEvents = () => new Promise((resolve) => setTimeout(resolve, 50))
+
+  const nullLogger = () => ({
+    log: () => undefined,
+    info: () => undefined,
+    debug: () => undefined,
+    warn: () => undefined,
+    error: () => undefined,
+  })
+
+  const requestHandledCalls = () =>
+    workerLogSpy.mock.calls.filter(
+      (c) => (c[0] as Record<string, unknown>).event_type === 'request.handled'
+    )
+
+  const okHandler = jest.fn(async () => new Response('ok', { status: 200 }) as NextResponse)
+
+  beforeEach(() => {
+    // Configure explicitly so the wrapper's auto-configure (env-based) is
+    // skipped, and reset the insights gates mutated by previous tests.
+    Honeybadger.configure({
+      apiKey: 'test-api-key',
+      environment: 'test',
+      logger: nullLogger() as any,
+      insights: { enabled: false, console: false, http: false },
+    })
+    Honeybadger.clear()
+    // Stub the worker's queue entry point: the spy still records the merged
+    // event payloads, but nothing enters the queue — otherwise the worker's
+    // dispatch cooldown timer keeps the jest process alive after the run.
+    workerLogSpy = jest.spyOn(eventsWorker(), 'log').mockImplementation(() => undefined)
+    notifyAsyncSpy = jest.spyOn(Honeybadger, 'notifyAsync').mockResolvedValue(undefined as any)
+    okHandler.mockClear()
+  })
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  describe('with insights: { enabled: true, http: true }', () => {
+    beforeEach(() => {
+      Honeybadger.configure({ insights: { enabled: true, http: true } })
+    })
+
+    it('emits a request.handled event with method, path, status, and duration', async () => {
+      const wrapped = withHoneybadger(okHandler)
+      const res = await wrapped(new Request('http://localhost:3000/api/items?secret=1'))
+
+      expect(res.status).toBe(200)
+      await waitForEvents()
+
+      const calls = requestHandledCalls()
+      expect(calls).toHaveLength(1)
+      const payload = calls[0][0] as Record<string, unknown>
+      expect(payload).toMatchObject({
+        method: 'GET',
+        path: '/api/items',
+        status: 200,
+      })
+      expect(typeof payload.duration).toBe('number')
+      expect(payload.duration as number).toBeGreaterThanOrEqual(0)
+    })
+
+    it('carries request_id/correlation_id from the request headers', async () => {
+      const wrapped = withHoneybadger(okHandler)
+      await wrapped(new Request('http://localhost:3000/api/items', {
+        headers: { 'x-request-id': 'abc-123' },
+      }))
+      await waitForEvents()
+
+      const payload = requestHandledCalls()[0][0] as Record<string, unknown>
+      expect(payload.request_id).toBe('abc-123')
+      expect(payload.correlation_id).toBe('abc-123')
+    })
+
+    it('uses x-correlation-id for correlation_id (distinct from request_id)', async () => {
+      const wrapped = withHoneybadger(okHandler)
+      await wrapped(new Request('http://localhost:3000/api/items', {
+        headers: { 'x-request-id': 'req-1', 'x-correlation-id': 'trace-9' },
+      }))
+      await waitForEvents()
+
+      const payload = requestHandledCalls()[0][0] as Record<string, unknown>
+      expect(payload.request_id).toBe('req-1')
+      expect(payload.correlation_id).toBe('trace-9')
+    })
+
+    it('generates non-empty equal ids when no headers are present', async () => {
+      const wrapped = withHoneybadger(okHandler)
+      await wrapped(new Request('http://localhost:3000/api/items'))
+      await waitForEvents()
+
+      const payload = requestHandledCalls()[0][0] as Record<string, unknown>
+      expect(typeof payload.request_id).toBe('string')
+      expect((payload.request_id as string).length).toBeGreaterThan(0)
+      expect(payload.correlation_id).toBe(payload.request_id)
+    })
+
+    it('emits with status 500, notifies, and re-throws when the handler throws', async () => {
+      const error = new Error('boom')
+      const wrapped = withHoneybadger(async () => {
+        throw error
+      })
+
+      await expect(wrapped(new Request('http://localhost:3000/api/fail'))).rejects.toThrow('boom')
+      await waitForEvents()
+
+      const calls = requestHandledCalls()
+      expect(calls).toHaveLength(1)
+      const payload = calls[0][0] as Record<string, unknown>
+      expect(payload.status).toBe(500)
+      expect(payload.path).toBe('/api/fail')
+      expect(notifyAsyncSpy).toHaveBeenCalledWith(error)
+    })
+
+    it('does not emit request.handled when the first argument is not a Request', async () => {
+      const wrapped = withHoneybadger(okHandler as any)
+      const res = await wrapped(undefined as any)
+
+      expect(res.status).toBe(200)
+      await waitForEvents()
+
+      expect(requestHandledCalls()).toHaveLength(0)
+    })
+
+    it('does not leak event context between concurrent requests', async () => {
+      const slowHandler = async () => {
+        await new Promise((resolve) => setTimeout(resolve, 20))
+        return new Response('ok', { status: 200 }) as NextResponse
+      }
+      const wrapped = withHoneybadger(slowHandler)
+
+      await Promise.all([1, 2].map((i) => wrapped(new Request('http://localhost:3000/api/items', {
+        headers: { 'x-request-id': `rid-${i}` },
+      }))))
+      await waitForEvents()
+
+      const ids = requestHandledCalls().map((c) => (c[0] as Record<string, unknown>).request_id)
+      expect(ids.sort()).toEqual(['rid-1', 'rid-2'])
+    })
+  })
+
+  describe('gating', () => {
+    it('with default config, does not emit request.handled but programmatic events carry request_id/correlation_id', async () => {
+      const wrapped = withHoneybadger(async () => {
+        Honeybadger.event('custom', { msg: 'hi' })
+        return new Response('ok', { status: 200 }) as NextResponse
+      })
+
+      await wrapped(new Request('http://localhost:3000/api/custom', {
+        headers: { 'x-request-id': 'rid-prog' },
+      }))
+      await waitForEvents()
+
+      expect(requestHandledCalls()).toHaveLength(0)
+
+      const customCall = workerLogSpy.mock.calls.find(
+        (c) => (c[0] as Record<string, unknown>).event_type === 'custom'
+      )
+      expect(customCall).toBeDefined()
+      const payload = customCall[0] as Record<string, unknown>
+      expect(payload.request_id).toBe('rid-prog')
+      expect(payload.correlation_id).toBe('rid-prog')
+    })
+
+    it('with insights.http: true but insights.enabled missing (footgun), does not emit request.handled', async () => {
+      Honeybadger.configure({ insights: { http: true } })
+      const wrapped = withHoneybadger(okHandler)
+
+      await wrapped(new Request('http://localhost:3000/api/items'))
+      await waitForEvents()
+
+      expect(requestHandledCalls()).toHaveLength(0)
+    })
+
+    it('with insights.enabled: false, does not emit request.handled even when insights.http is true', async () => {
+      Honeybadger.configure({ insights: { enabled: false, http: true } })
+      const wrapped = withHoneybadger(okHandler)
+
+      await wrapped(new Request('http://localhost:3000/api/items'))
+      await waitForEvents()
+
+      expect(requestHandledCalls()).toHaveLength(0)
+    })
+  })
+
+  describe('edge runtime fallback (no Honeybadger.run)', () => {
+    let originalRun: unknown
+
+    beforeEach(() => {
+      originalRun = (Honeybadger as any).run;
+      (Honeybadger as any).run = undefined
+    })
+
+    afterEach(() => {
+      (Honeybadger as any).run = originalRun
+    })
+
+    it('emits request.handled with embedded ids but does not touch the shared event context', async () => {
+      Honeybadger.configure({ insights: { enabled: true, http: true } })
+      const setEventContextSpy = jest.spyOn(Honeybadger, 'setEventContext')
+      const wrapped = withHoneybadger(okHandler)
+
+      const res = await wrapped(new Request('http://localhost:3000/api/items', {
+        headers: { 'x-request-id': 'edge-rid' },
+      }))
+      expect(res.status).toBe(200)
+      await waitForEvents()
+
+      expect(setEventContextSpy).not.toHaveBeenCalled()
+      const calls = requestHandledCalls()
+      expect(calls).toHaveLength(1)
+      const payload = calls[0][0] as Record<string, unknown>
+      expect(payload).toMatchObject({
+        method: 'GET',
+        path: '/api/items',
+        status: 200,
+        request_id: 'edge-rid',
+        correlation_id: 'edge-rid',
+      })
+    })
+
+    it('with default config, does not emit request.handled', async () => {
+      const setEventContextSpy = jest.spyOn(Honeybadger, 'setEventContext')
+      const wrapped = withHoneybadger(okHandler)
+
+      const res = await wrapped(new Request('http://localhost:3000/api/items'))
+      expect(res.status).toBe(200)
+      await waitForEvents()
+
+      expect(setEventContextSpy).not.toHaveBeenCalled()
+      expect(requestHandledCalls()).toHaveLength(0)
+    })
+
+    it('still notifies and re-throws on error', async () => {
+      const error = new Error('edge boom')
+      const wrapped = withHoneybadger(async () => {
+        throw error
+      })
+
+      await expect(wrapped(new Request('http://localhost:3000/api/fail'))).rejects.toThrow('edge boom')
+      expect(notifyAsyncSpy).toHaveBeenCalledWith(error)
+    })
+  })
+
+  describe('Next.js control-flow errors', () => {
+    beforeEach(() => {
+      Honeybadger.configure({ insights: { enabled: true, http: true } })
+    })
+
+    it('re-throws redirect/notFound errors without notifying or emitting an event', async () => {
+      const redirect = Object.assign(new Error('NEXT_REDIRECT'), {
+        digest: 'NEXT_REDIRECT;replace;/login;307;',
+      })
+      const wrapped = withHoneybadger(async () => {
+        throw redirect
+      })
+
+      await expect(wrapped(new Request('http://localhost:3000/api/go'))).rejects.toBe(redirect)
+      await waitForEvents()
+
+      expect(notifyAsyncSpy).not.toHaveBeenCalled()
+      expect(requestHandledCalls()).toHaveLength(0)
+    })
+  })
+
+  describe('Pages Router API routes', () => {
+    // A Pages handler is invoked as `(req, res)` with Node-style objects; the
+    // status lives on `res.statusCode` rather than a returned Response.
+    const makeReq = (url: string, headers: Record<string, string | string[]> = {}, method = 'GET') =>
+      ({ method, url, headers }) as any
+    const makeRes = (statusCode = 200) =>
+      ({ statusCode, end: () => undefined, setHeader: () => undefined }) as any
+
+    describe('with insights: { enabled: true, http: true }', () => {
+      beforeEach(() => {
+        Honeybadger.configure({ insights: { enabled: true, http: true } })
+      })
+
+      it('emits a request.handled event from the Node req/res pair', async () => {
+        const handler = jest.fn(async (_req: any, res: any) => {
+          res.statusCode = 201
+        })
+        const wrapped = withHoneybadger(handler)
+        const res = makeRes(200)
+
+        await wrapped(makeReq('/api/items?secret=1', { 'x-request-id': 'pg-1' }, 'POST'), res)
+        await waitForEvents()
+
+        const calls = requestHandledCalls()
+        expect(calls).toHaveLength(1)
+        const payload = calls[0][0] as Record<string, unknown>
+        expect(payload).toMatchObject({
+          method: 'POST',
+          path: '/api/items',
+          status: 201,
+          request_id: 'pg-1',
+          correlation_id: 'pg-1',
+        })
+        expect(typeof payload.duration).toBe('number')
+      })
+
+      it('reads ids from Node headers (array values, case-insensitive)', async () => {
+        const handler = jest.fn(async (_req: any, _res: any) => undefined)
+        const wrapped = withHoneybadger(handler)
+
+        await wrapped(makeReq('/api/x', { 'X-Request-Id': ['rid-arr', 'other'] }), makeRes())
+        await waitForEvents()
+
+        const payload = requestHandledCalls()[0][0] as Record<string, unknown>
+        expect(payload.request_id).toBe('rid-arr')
+        expect(payload.correlation_id).toBe('rid-arr')
+      })
+
+      it('emits status 500, notifies, and re-throws when the handler throws', async () => {
+        const error = new Error('pages boom')
+        const wrapped = withHoneybadger(async () => {
+          throw error
+        })
+
+        await expect(wrapped(makeReq('/api/fail'), makeRes())).rejects.toThrow('pages boom')
+        await waitForEvents()
+
+        const payload = requestHandledCalls()[0][0] as Record<string, unknown>
+        expect(payload.status).toBe(500)
+        expect(payload.path).toBe('/api/fail')
+        expect(notifyAsyncSpy).toHaveBeenCalledWith(error)
+      })
+
+      it('does not leak event context between concurrent requests', async () => {
+        const slowHandler = async (_req: any, res: any) => {
+          await new Promise((resolve) => setTimeout(resolve, 20))
+          res.statusCode = 200
+        }
+        const wrapped = withHoneybadger(slowHandler)
+
+        await Promise.all(
+          [1, 2].map((i) => wrapped(makeReq('/api/items', { 'x-request-id': `rid-${i}` }), makeRes()))
+        )
+        await waitForEvents()
+
+        const ids = requestHandledCalls().map((c) => (c[0] as Record<string, unknown>).request_id)
+        expect(ids.sort()).toEqual(['rid-1', 'rid-2'])
+      })
+    })
+
+    it('with default config, does not emit request.handled', async () => {
+      const handler = jest.fn(async (_req: any, _res: any) => undefined)
+      const wrapped = withHoneybadger(handler)
+
+      await wrapped(makeReq('/api/items'), makeRes())
+      await waitForEvents()
+
+      expect(requestHandledCalls()).toHaveLength(0)
+      expect(handler).toHaveBeenCalledTimes(1)
+    })
+  })
+})

--- a/packages/nextjs/src/with-honeybadger.ts
+++ b/packages/nextjs/src/with-honeybadger.ts
@@ -1,5 +1,15 @@
 import Honeybadger from '@honeybadger-io/js';
 import { NextRequest, NextResponse } from 'next/server';
+import type { NextApiRequest, NextApiResponse } from 'next';
+import {
+  emitNodeRequestEvent,
+  emitRequestEvent,
+  insightsHttpEnabled,
+  now,
+  seedNodeRequestEventContext,
+  seedRequestEventContext,
+} from './insights-instrumentation';
+import type { NodeRequestLike } from './insights-instrumentation';
 
 function configure() {
   if (Honeybadger.config.apiKey?.length > 0) {
@@ -38,19 +48,149 @@ function configure() {
 }
 
 /**
- * Wraps a handler function with Honeybadger error reporting.
- * Use with Next.js API route handlers or middleware.
+ * Next.js uses thrown errors for control flow: `redirect()`, `notFound()`,
+ * `forbidden()` and `unauthorized()` all throw an error carrying a `digest`
+ * string (`NEXT_REDIRECT;...`, `NEXT_NOT_FOUND`, `NEXT_HTTP_ERROR_FALLBACK;...`).
+ * These are not real failures — the framework catches them upstream to produce
+ * the redirect/404/etc. — so we must let them propagate without reporting them,
+ * otherwise every redirect shows up as an error in Honeybadger.
  */
-export function withHoneybadger(handler: (req: NextRequest | Request, ...args: unknown[]) => Promise<NextResponse>) {
+function isNextControlFlowError(error: unknown): boolean {
+  const digest = (error as { digest?: unknown } | null | undefined)?.digest
+  return typeof digest === 'string' && digest.startsWith('NEXT_')
+}
+
+type AppRouterHandler = (req: NextRequest | Request, ...args: unknown[]) => Promise<NextResponse>
+type PagesApiHandler = (req: NextApiRequest, res: NextApiResponse, ...args: unknown[]) => unknown
+
+/**
+ * Detects a Pages Router API invocation: `(req, res)` where `res` is a Node
+ * `ServerResponse`. We branch on this structurally because — unlike an App
+ * Router route handler — there is no returned `Response` to read the status
+ * from; it lives on `res.statusCode`.
+ */
+function isPagesApiInvocation(args: unknown[]): args is [NodeRequestLike, NextApiResponse] {
+  const req = args[0] as { headers?: unknown } | undefined
+  const res = args[1] as { statusCode?: unknown; end?: unknown } | undefined
+  return (
+    !!req && typeof req.headers === 'object' && req.headers !== null &&
+    !!res && typeof res.statusCode === 'number' && typeof res.end === 'function'
+  )
+}
+
+/**
+ * App Router route handlers and middleware: a web `Request`/`NextRequest` in, a
+ * `Response`/`NextResponse` out. The status comes from the returned response.
+ */
+async function handleAppRouterRequest(call: () => unknown, req: Request, canIsolate: boolean): Promise<unknown> {
+  const ids = seedRequestEventContext(req.headers)
+  if (canIsolate) {
+    Honeybadger.setEventContext(ids)
+  }
+  const start = insightsHttpEnabled() ? now() : null
+  try {
+    const response = await call()
+    if (start !== null) {
+      emitRequestEvent(req, (response as Response | undefined)?.status, start, ids)
+    }
+    return response
+  } catch (error) {
+    if (isNextControlFlowError(error)) {
+      throw error
+    }
+    if (start !== null) {
+      emitRequestEvent(req, 500, start, ids)
+    }
+    await Honeybadger.notifyAsync(error as Error)
+    throw error
+  }
+}
+
+/**
+ * Pages Router API routes: a Node `req`/`res` pair. The handler writes to `res`
+ * and returns nothing meaningful, so the final status is read from
+ * `res.statusCode` once it resolves.
+ */
+async function handlePagesApiRequest(call: () => unknown, req: NodeRequestLike, res: NextApiResponse, canIsolate: boolean): Promise<unknown> {
+  const ids = seedNodeRequestEventContext(req.headers)
+  if (canIsolate) {
+    Honeybadger.setEventContext(ids)
+  }
+  const start = insightsHttpEnabled() ? now() : null
+  try {
+    const result = await call()
+    if (start !== null) {
+      emitNodeRequestEvent(req, res.statusCode, start, ids)
+    }
+    return result
+  } catch (error) {
+    if (isNextControlFlowError(error)) {
+      throw error
+    }
+    if (start !== null) {
+      emitNodeRequestEvent(req, 500, start, ids)
+    }
+    await Honeybadger.notifyAsync(error as Error)
+    throw error
+  }
+}
+
+/**
+ * Unrecognised invocation shape: still report errors, but emit no insights
+ * event since we can't reliably read the request.
+ */
+async function handleUninstrumented(call: () => unknown): Promise<unknown> {
+  try {
+    return await call()
+  } catch (error) {
+    if (isNextControlFlowError(error)) {
+      throw error
+    }
+    await Honeybadger.notifyAsync(error as Error)
+    throw error
+  }
+}
+
+/**
+ * Wraps a handler function with Honeybadger error reporting. Works with App
+ * Router route handlers, middleware, and Pages Router API routes.
+ *
+ * `request_id` / `correlation_id` are read from the `x-request-id` /
+ * `request-id` and `x-correlation-id` / `x-amzn-trace-id` headers (generated
+ * when absent). When `insights: { enabled: true, http: true }` is configured,
+ * a `request.handled` event carrying the ids plus method, path, status and
+ * duration is emitted per request.
+ *
+ * On the Node.js runtime each invocation additionally runs inside
+ * `Honeybadger.run(...)`, so context is isolated per request and the ids are
+ * seeded onto the event context — merged onto every event emitted during the
+ * request, including programmatic `Honeybadger.event(...)` calls. On the edge
+ * runtime (browser build, single global store) seeding the shared event
+ * context would leak ids between concurrent requests, so programmatic events
+ * there don't inherit them.
+ */
+export function withHoneybadger(handler: AppRouterHandler): AppRouterHandler
+export function withHoneybadger(handler: PagesApiHandler): PagesApiHandler
+export function withHoneybadger(handler: AppRouterHandler | PagesApiHandler) {
   configure();
   return new Proxy(handler, {
-    apply: async (target, thisArg, args) => {
-      try {
-        return await Reflect.apply(target, thisArg, args);
-      } catch (error) {
-        await Honeybadger.notifyAsync(error as Error);
-        throw error; // Re-throw the error after reporting it
+    apply: (target, thisArg, args) => {
+      const canIsolate = typeof Honeybadger.run === 'function'
+      const call = () => Reflect.apply(target, thisArg, args)
+
+      const invoke = (): unknown => {
+        // App Router / middleware first: a web Request as the first argument.
+        if (typeof Request !== 'undefined' && args[0] instanceof Request) {
+          return handleAppRouterRequest(call, args[0], canIsolate)
+        }
+        // Pages Router API route: a Node req/res pair.
+        if (isPagesApiInvocation(args)) {
+          return handlePagesApiRequest(call, args[0], args[1], canIsolate)
+        }
+        return handleUninstrumented(call)
       }
+
+      return canIsolate ? Honeybadger.run(invoke) : invoke()
     },
   });
 }

--- a/packages/nextjs/src/with-honeybadger.ts
+++ b/packages/nextjs/src/with-honeybadger.ts
@@ -54,6 +54,12 @@ function configure() {
  * These are not real failures — the framework catches them upstream to produce
  * the redirect/404/etc. — so we must let them propagate without reporting them,
  * otherwise every redirect shows up as an error in Honeybadger.
+ *
+ * We match on the `NEXT_` prefix rather than an exhaustive list so that any
+ * present or future framework control-flow digest is covered. This is safe:
+ * genuine errors that React tags with a `digest` use an opaque hash, and other
+ * Next.js bailout signals (e.g. `BAILOUT_TO_CLIENT_SIDE_RENDERING`,
+ * `DYNAMIC_SERVER_USAGE`) are not `NEXT_`-prefixed, so neither is skipped.
  */
 function isNextControlFlowError(error: unknown): boolean {
   const digest = (error as { digest?: unknown } | null | undefined)?.digest


### PR DESCRIPTION
## Summary

Extends `withHoneybadger` to instrument **Pages Router API routes** in addition to App Router route handlers / middleware, and stops Next.js control-flow throws from being reported as errors.

### Two explicit request paths
Rather than normalizing the request into a common shape, `withHoneybadger` now detects the invocation shape and dispatches to one of two self-contained handlers:

- **App Router / middleware** — web `Request` in, `Response` out. Status comes from the returned response; path from the absolute `req.url`. Behavior is unchanged.
- **Pages Router API routes** — Node `(req, res)` pair. Status is read from `res.statusCode` after the handler resolves; path from the relative `req.url` (query stripped); ids read from the Node header bag.

An unrecognized shape still reports errors but emits no insights event.

### Next.js control-flow errors
`redirect()` / `notFound()` / `forbidden()` / `unauthorized()` throw an error carrying a `NEXT_*` `digest`. These are framework control flow, not failures, so they now propagate untouched instead of producing a false-positive 500 `request.handled` event and an error notice.

### Instrumentation helpers
Adds Node-shape variants (`seedNodeRequestEventContext`, `emitNodeRequestEvent`) alongside the existing web-`Headers` ones. The id precedence and event-payload building are shared internally so the header-name contract is spelled out once.

## Testing
- `tsc --noEmit -p packages/nextjs` clean
- ESLint clean
- Jest: 19/19 pass (13 existing App Router + 4 Pages Router + 1 Pages gating + 1 control-flow)

🤖 Generated with [Claude Code](https://claude.com/claude-code)