### PR TITLE
ci: bump publish workflows to Node 22 for npm@latest compatibility

### DIFF
--- a/.github/workflows/lerna-publish.yml
+++ b/.github/workflows/lerna-publish.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v6
         with:
-          node-version: '20.x'
+          node-version: '22.x'
           cache: 'npm'
 
       - name: Install latest NPM version (needed for trusted publishing)

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v6
         with:
-          node-version: '20.x'
+          node-version: '22.x'
           cache: 'npm'
 
       - name: Install latest NPM version (needed for trusted publishing)


### PR DESCRIPTION
## What

Bumps `node-version` from `20.x` to `22.x` in `lerna-publish.yml` and `npm-publish.yml`.

## Why

The [latest release publish run](https://github.com/honeybadger-io/honeybadger-js/actions/runs/29497897550/job/87620473441) failed at the "Install latest NPM version" step: `npm@latest` now resolves to npm 12, which dropped Node 20 support (requires `node ^22.22.2 || ^24.15.0 || >=26.0.0`), so `npm install -g npm@latest` fails with `EBADENGINE` on the Node 20 runner.

Both publish workflows use this pattern, so both are bumped. The CI test matrix is unaffected.

Once merged, the pending release from #1510 should publish on the next master push (or via re-running the workflow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)