### PR TITLE
fix(js): handle unstringifiable unhandled-rejection reasons

### DIFF
--- a/packages/js/src/browser/integrations/onunhandledrejection.ts
+++ b/packages/js/src/browser/integrations/onunhandledrejection.ts
@@ -36,7 +36,18 @@ export default function (_window: any = globalThisOrWindow()): Types.Plugin {
             return
           }
 
-          const message = typeof reason === 'string' ? reason : (JSON.stringify(reason) ?? 'Unspecified reason')
+          let message: string
+          if (typeof reason === 'string') {
+            message = reason
+          } else {
+            try {
+              message = JSON.stringify(reason) ?? 'Unspecified reason'
+            } catch (_err) {
+              // Circular structures (e.g. DOM nodes with React fiber expandos) can't be stringified
+              const name = reason != null && reason.constructor ? reason.constructor.name : null
+              message = name ? `[${name}]` : Object.prototype.toString.call(reason)
+            }
+          }
           client.notify({
             name: 'window.onunhandledrejection',
             message: `UnhandledPromiseRejectionWarning: ${message}`

--- a/packages/js/test/unit/browser/integrations/onunhandledrejection.browser.test.ts
+++ b/packages/js/test/unit/browser/integrations/onunhandledrejection.browser.test.ts
@@ -80,4 +80,41 @@ describe('window.onunhandledrejection integration', function () {
     expect((notifiedError.originalError as CustomError).skipReporting).toBe(true)
     expect((notifiedError.originalError as CustomError).errorType).toBe('CUSTOM')
   })
+
+  it('reports constructor name when reason has circular references', function () {
+    const window = { onunhandledrejection: undefined }
+    onUnhandledRejection(window).load(client)
+
+    class CircularThing {
+      self: CircularThing
+      constructor() {
+        this.self = this
+      }
+    }
+    const reason = new CircularThing()
+
+    expect(() => window.onunhandledrejection({ reason })).not.toThrow()
+    expect(mockNotify.mock.calls.length).toBe(1)
+    expect(mockNotify.mock.calls[0][0]).toEqual(expect.objectContaining({
+      name: 'window.onunhandledrejection',
+      message: 'UnhandledPromiseRejectionWarning: [CircularThing]'
+    }))
+  })
+
+  it('reports DOM node constructor name when reason has a circular expando', function () {
+    const window = { onunhandledrejection: undefined }
+    onUnhandledRejection(window).load(client)
+
+    const reason = document.createElement('a')
+    // Simulate React fiber-style circular expandos that break JSON.stringify
+    const fiber = { stateNode: reason }
+    reason['__reactFiber$test'] = fiber
+
+    expect(() => window.onunhandledrejection({ reason })).not.toThrow()
+    expect(mockNotify.mock.calls.length).toBe(1)
+    expect(mockNotify.mock.calls[0][0]).toEqual(expect.objectContaining({
+      name: 'window.onunhandledrejection',
+      message: 'UnhandledPromiseRejectionWarning: [HTMLAnchorElement]'
+    }))
+  })
 })


### PR DESCRIPTION
## Status
**READY**

## Description
Fixes #1515. The browser `onunhandledrejection` handler used bare `JSON.stringify(reason)` for non-Error/non-string rejection reasons. Circular structures (common with React DOM nodes that carry `__reactFiber$` expandos) make stringify throw; that `TypeError` escaped the handler, was picked up by `window.onerror`, and was reported as an SDK-internal fault while the original rejection was never reported.

This wraps stringify in try/catch and falls back to a concise `[ConstructorName]` label (or `Object.prototype.toString`) when serialization fails.

## Related PRs
N/A

## Todos
- [x] Tests

## Steps to Test or Reproduce
```bash
cd packages/js
npx jest --env=jsdom --setupFiles="<rootDir>/test/unit/jest-browser-setup.js" --testPathPattern="onunhandledrejection.browser.test"
```

Manual repro (any page with React + Honeybadger):
```js
Promise.reject(document.querySelector('a'))
```
Expected notice: `UnhandledPromiseRejectionWarning: [HTMLAnchorElement]` (not a circular-structure TypeError from the SDK).

Made with [Cursor](https://cursor.com)