### PR TITLE
chore: add agent skills for better agent coordination

### DIFF
--- a/.agents/skills/create-pull-request/SKILL.md
+++ b/.agents/skills/create-pull-request/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: create-pull-request
+description: >-
+  Pre-submission checklist for opening pull requests in honeybadger-js. Use when
+  creating, submitting, or opening a pull request, or when the user asks to
+  prepare a PR for review.
+---
+
+# Create Pull Request
+
+Run this checklist before opening a pull request.
+
+## 1. Remove planning artifacts
+
+Delete any agent-generated spec, plan, or implementation-notes markdown files from the branch (e.g. `PLAN.md`, `IMPLEMENTATION.md`, `.cursor/plans/*.md`).
+
+Move the essential spec content into the PR description instead — reviewers should not need to hunt for planning files in the diff.
+
+## 2. Request an AI review
+
+Before submitting, get a code review of the branch diff:
+
+1. **Codex CLI** (preferred): run `codex` to review the changes. If `codex` is not installed, skip to step 2.
+2. **Claude** (fallback): perform a thorough code review using Claude.
+
+Address any findings before opening the PR.
+
+## 3. PR title
+
+Use a [Conventional Commits](https://www.conventionalcommits.org/) title with a package scope. CI validates PR titles via commitlint.
+
+Examples: `fix(js): handle unstringifiable rejection reasons`, `feat(react): add error boundary hook`

--- a/.agents/skills/writing-documentation/SKILL.md
+++ b/.agents/skills/writing-documentation/SKILL.md
@@ -1,0 +1,34 @@
+---
+name: writing-documentation
+description: >-
+  Guides documentation changes for honeybadger-js. Use when documenting features,
+  updating READMEs, writing docs, or when a change needs user-facing documentation.
+---
+
+# Writing Documentation
+
+## Where documentation lives
+
+All product documentation lives in the [`honeybadger-io/docs`](https://github.com/honeybadger-io/docs) repository (Astro/Starlight, builds [docs.honeybadger.io](https://docs.honeybadger.io)).
+
+## Do not document in this repo
+
+Do not document new features or behavior changes in `README.md` files in `honeybadger-js`. Package READMEs cover installation and basic usage only.
+
+## Request a docs issue instead
+
+When a change needs user-facing documentation:
+
+1. **Recommend** a new GitHub issue in `honeybadger-io/docs` with a proposed title and body describing what needs documenting. Link back to the source PR.
+2. **Wait for explicit human approval** before creating the issue. Never create it unprompted.
+3. Present the recommendation clearly so the human can approve, edit, or decline.
+
+### Example recommendation
+
+> **Docs issue needed** for the new `breadcrumbsSelectorAttributes` option:
+>
+> - **Repo:** `honeybadger-io/docs`
+> - **Title:** Document `breadcrumbsSelectorAttributes` browser config option
+> - **Body:** Add a section under the JS browser configuration docs describing the new `breadcrumbsSelectorAttributes` option, which lets users specify DOM attributes used to build legible `ui.click` breadcrumb selectors. Link to PR #1510.
+>
+> Shall I create this issue?

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -202,6 +202,17 @@ NPM Trusted Publishing is configured per-package; only one workflow can be the t
 - **Examples are non-build artifacts.** `packages/*/examples/` directories are documentation; they are not built by the package build, are mostly excluded from lint, and shouldn't import from the package's `dist/` — they should consume the published API.
 - **Browser vs Node code in `packages/js`.** The split is enforced by file naming (`*.browser.test.ts` / `*.server.test.ts`) and entry points (`src/browser.ts` / `src/server.ts`). When adding browser-only or server-only code, place it under `src/browser/` or `src/server/` respectively.
 
+### Agent skills
+
+Project-level skills live in [`.agents/skills/`](.agents/skills/). Cursor and Claude Code both discover skills in this directory. Read the relevant `SKILL.md` before following a workflow it covers.
+
+| Skill | When to use |
+| ----- | ----------- |
+| [`create-pull-request`](.agents/skills/create-pull-request/SKILL.md) | Before opening or submitting a pull request — remove planning artifacts, request an AI review (Codex CLI or Claude), and format the PR title. |
+| [`writing-documentation`](.agents/skills/writing-documentation/SKILL.md) | When a change needs user-facing documentation — recommend a docs-repo issue (create only after human approval); do not document features in READMEs here. |
+
+**Keep skills up to date.** When new conventions are deduced during work, or when existing rules or conventions change as the code evolves, update the corresponding `SKILL.md` and add a row to the table above in the same PR.
+
 ## Quick reference: root scripts
 
 | Command             | What it does                                                       |


### PR DESCRIPTION
## Status
**READY**

## Description
Closes #1511.

Adds two project-level agent skills under `.agents/skills/` (discovered by both Cursor and Claude Code) and documents them in `AGENTS.md`:

- **`create-pull-request`** — pre-submission checklist: remove planning artifacts from the branch, request an AI review (Codex CLI or Claude fallback), use a conventional-commit PR title.
- **`writing-documentation`** — product docs live in `honeybadger-io/docs`; do not document features in READMEs here; recommend a docs-repo issue and create it only after human approval.

`AGENTS.md` includes a skills table and a note to keep skills up to date when conventions evolve.

## Related PRs
None.

## Todos
- [x] Tests (not applicable — markdown only)
- [x] Documentation (skills are the documentation)

## Steps to Test or Reproduce
1. Confirm `.agents/skills/create-pull-request/SKILL.md` and `.agents/skills/writing-documentation/SKILL.md` exist.
2. Confirm `AGENTS.md` has the "Agent skills" subsection with the table and keep-up-to-date note.
3. In Cursor or Claude Code, verify the skills are discoverable from `.agents/skills/`.

Made with [Cursor](https://cursor.com)