### PR TITLE
chore(skills): require AI review before commits

### DIFF
--- a/.agents/skills/create-pull-request/SKILL.md
+++ b/.agents/skills/create-pull-request/SKILL.md
@@ -16,14 +16,9 @@ Delete any agent-generated spec, plan, or implementation-notes markdown files fr
 
 Move the essential spec content into the PR description instead — reviewers should not need to hunt for planning files in the diff.
 
-## 2. Request an AI review
+## 2. AI review
 
-Before submitting, get a code review of the branch diff:
-
-1. **Codex CLI** (preferred): run `codex` to review the changes. If `codex` is not installed, skip to step 2.
-2. **Claude** (fallback): perform a thorough code review using Claude.
-
-Address any findings before opening the PR.
+Commits on the PR branch must already have gone through the [`review-before-commit`](../review-before-commit/SKILL.md) skill. If any uncommitted changes remain, follow that skill before committing.
 
 ## 3. PR title
 

--- a/.agents/skills/review-before-commit/SKILL.md
+++ b/.agents/skills/review-before-commit/SKILL.md
@@ -1,0 +1,24 @@
+---
+name: review-before-commit
+description: >-
+  Mandatory AI code review before committing in honeybadger-js. Use when
+  committing code, preparing a commit, or before any git commit of agent
+  changes.
+---
+
+# Review Before Commit
+
+Run this checklist before every commit. Do not commit until it is complete.
+
+## 1. Request an AI review
+
+Get a code review of the working-tree / staged changes about to be committed:
+
+1. **Codex CLI** (preferred): run `codex` to review the changes. If `codex` is not installed, skip to step 2.
+2. **Claude** (fallback): perform a thorough code review using Claude.
+
+Address any findings.
+
+## 2. Present findings for human approval
+
+Present the addressed findings to the user for a human review and approval. Do not commit until the user approves.

--- a/.agents/skills/review-before-commit/SKILL.md
+++ b/.agents/skills/review-before-commit/SKILL.md
@@ -14,7 +14,7 @@ Run this checklist before every commit. Do not commit until it is complete.
 
 Get a code review of the working-tree / staged changes about to be committed:
 
-1. **Codex CLI** (preferred): run `codex` to review the changes. If `codex` is not installed, skip to step 2.
+1. **Codex CLI** (preferred): run `codex` to review the changes. If `codex` is not installed, skip to item 2.
 2. **Claude** (fallback): perform a thorough code review using Claude.
 
 Address any findings.

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@ browserstack.err
 .envrc
 
 .rollup.cache
+
+.vscode/settings.json

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -215,7 +215,8 @@ Project-level skills live in [`.agents/skills/`](.agents/skills/). Cursor and Cl
 
 | Skill | When to use |
 | ----- | ----------- |
-| [`create-pull-request`](.agents/skills/create-pull-request/SKILL.md) | Before opening or submitting a pull request — remove planning artifacts, request an AI review (Codex CLI or Claude), and format the PR title. |
+| [`review-before-commit`](.agents/skills/review-before-commit/SKILL.md) | Before every commit — request an AI review (Codex CLI or Claude), address findings, and get human approval. |
+| [`create-pull-request`](.agents/skills/create-pull-request/SKILL.md) | Before opening or submitting a pull request — remove planning artifacts and format the PR title. |
 | [`writing-documentation`](.agents/skills/writing-documentation/SKILL.md) | When a change needs user-facing documentation — recommend a docs-repo issue (create only after human approval); do not document features in READMEs here. |
 
 **Keep skills up to date.** When new conventions are deduced during work, or when existing rules or conventions change as the code evolves, update the corresponding `SKILL.md` and add a row to the table above in the same PR.


### PR DESCRIPTION
## Summary

I realized that the Codex review was only triggered when creating a pull request. It was not triggered with individual commits. Hence:

- Add a new `review-before-commit` skill that requires an AI review (Codex CLI or Claude) and human approval before every commit.
- Move the AI review requirement out of `create-pull-request` into the new shared skill.
- Update `AGENTS.md` to document the new skill and revise the `create-pull-request` description.

## Test plan
- [x] Verify the new `review-before-commit` skill text includes both AI review and human approval steps
- [x] Verify `create-pull-request` now references `review-before-commit` instead of embedding the logic
- [x] Verify `AGENTS.md` lists `review-before-commit` with the correct description


Made with [Cursor](https://cursor.com)