### PR TITLE
fix(js): correct language in user feedback form link title

### DIFF
--- a/packages/js/assets/user-feedback-form.html
+++ b/packages/js/assets/user-feedback-form.html
@@ -130,7 +130,7 @@
     </form>
 
     <p id="honeybadger-feedback-footer">
-        <a id="honeybadger-feedback-link" href="https://www.honeybadger.io/" target="_blank" title="Exception, uptime, and performance monitoring for PHP.">
+        <a id="honeybadger-feedback-link" href="https://www.honeybadger.io/" target="_blank" title="Exception, uptime, and performance monitoring for JavaScript.">
             Powered by
             <svg class="honeybadger-logo" height="40" viewBox="0 0 190 40" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xml:space="preserve" xmlns:serif="http://www.serif.com/" style="fill-rule:evenodd;clip-rule:evenodd;stroke-linejoin:round;stroke-miterlimit:2;">
             <style>


### PR DESCRIPTION
## What

The "Powered by" link in the user feedback form template carried this title attribute:

```
title="Exception, uptime, and performance monitoring for PHP."
```

This is the JavaScript SDK. The string is a copy-paste leftover from the PHP client, present since the feedback form first landed in #965. Changed to "JavaScript".

## Why it matters

The title attribute surfaces as a link tooltip and is announced by screen readers, so users of the feedback form were told the wrong language.

## Context

Spotted while investigating #1664. That issue is about a *different* problem in the same footer (a now-404 remote logo image on CDN paths v6.0-v6.9); this PR does not fix that one.

## Testing

Text-only change to a static template. No tests or snapshots assert on this string.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011kC1D4cv2KwTbQ4ASeruTy