### PR TITLE
fix(js): request the feedback form for the js client version

### DIFF
--- a/packages/js/src/browser.ts
+++ b/packages/js/src/browser.ts
@@ -121,7 +121,10 @@ class Honeybadger extends Client {
   }
 
   private getUserFeedbackSubmitUrl() {
-    return getUserFeedbackScriptUrl(this.getVersion())
+    // The feedback form template is published per major.minor of this package, so the
+    // url must track NOTIFIER.version. It cannot use getVersion(), which reports the
+    // notifier a wrapper package (react, vue) may have installed via setNotifier().
+    return getUserFeedbackScriptUrl(NOTIFIER.version)
   }
 
   /** @internal */

--- a/packages/js/test/unit/browser/feedback-form.browser.test.ts
+++ b/packages/js/test/unit/browser/feedback-form.browser.test.ts
@@ -2,6 +2,10 @@ import fetch from 'jest-fetch-mock';
 import Singleton, { getUserFeedbackScriptUrl } from '../../../src/browser';
 import { nullLogger } from '../helpers';
 
+// Read before any test can call setNotifier(): the version of @honeybadger-io/js
+// itself, which is the version the feedback form script url must track.
+const clientPackageVersion = Singleton.getVersion()
+
 describe('showUserFeedbackForm', function () {
 
   let client: typeof Singleton
@@ -93,7 +97,27 @@ describe('showUserFeedbackForm', function () {
     expect(window['honeybadgerUserFeedbackOptions']).toMatchObject({
       noticeId: id
     })
-    expect(window.document.head.innerHTML).toMatch(`<script src="${getUserFeedbackScriptUrl(client.getVersion())}" async="true"></script>`)
+    expect(window.document.head.innerHTML).toMatch(`<script src="${getUserFeedbackScriptUrl(clientPackageVersion)}" async="true"></script>`)
+  })
+
+  it('should build the feedback script url from the js client version, not from the notifier', function () {
+    const id = '48b98609-dd3b-48ee-bffc-d51f309a2dfa'
+    client.configure({
+      apiKey: 'testing'
+    })
+    // Wrapper packages (react, vue) overwrite the notifier with their own version on init.
+    client.setNotifier({
+      name: '@honeybadger-io/react',
+      url: 'https://github.com/honeybadger-io/honeybadger-js/tree/master/packages/react',
+      version: '6.1.32'
+    })
+    // @ts-expect-error __lastNoticeId is private
+    client.__lastNoticeId = id
+    client.showUserFeedbackForm()
+
+    expect(client.getVersion()).toBe('6.1.32')
+    expect(window.document.head.innerHTML).toContain(getUserFeedbackScriptUrl(clientPackageVersion))
+    expect(window.document.head.innerHTML).not.toContain('/v6.1/')
   })
 
   it('should add user feedback options in window object', function () {


### PR DESCRIPTION
Fixes #1664.

## The bug

A user on `@honeybadger-io/react` v6.1.32 reported that the feedback form rendered the pre-6.10 template — the one with the now-404ing `<img src="https://www.honeybadger.io/images/navbar_logo.svg?1670031500">` — even though their `@honeybadger-io/js` was never older than 6.10.1.

The browser client built the form script url from `getVersion()`:

```ts
private getUserFeedbackSubmitUrl() {
  return getUserFeedbackScriptUrl(this.getVersion())
}
```

`getVersion()` returns `this.__notifier.version`, and the wrapper packages overwrite the notifier on init so notices are attributed to them rather than to `@honeybadger-io/js`:

```ts
// packages/react/src/index.tsx  (same shape in packages/vue/src/index.js)
Honeybadger.setNotifier({ name: '@honeybadger-io/react', /* ... */ version: '__VERSION__' })
```

`factory()` also copies the notifier onto clones, so every client in a React app inherits it. The url therefore came out as the *wrapper's* major.minor:

| Wrapper | Requested url | Template served |
| --- | --- | --- |
| `@honeybadger-io/react` 6.1.32 | `js.honeybadger.io/v6.1/…` | pre-6.10 (broken image) |
| `@honeybadger-io/vue` 6.2.18 | `js.honeybadger.io/v6.2/…` | pre-6.10 (broken image) |

I confirmed against the CDN that `v6.1` and `v6.2` still serve the old template, and that `v6.10`–`v6.16` serve the current inline-SVG one. The installed `@honeybadger-io/js` version was simply never consulted for this url.

This is also fragile beyond the wrong template: wrapper versions are independent of the js client's, so a wrapper version whose major.minor has no corresponding js release requests a path that does not exist and the form fails to load at all (`js.honeybadger.io/v7.0/…` already 403s).

## The fix

The form template is published per major.minor of **this** package — `packages/js/scripts/release-cdn.sh` (the `postpublish` hook for `packages/js`) derives the S3 prefix from `packages/js/package.json`'s version — so the url must track `NOTIFIER.version`, the constant this package sets on itself:

```ts
return getUserFeedbackScriptUrl(NOTIFIER.version)
```

`getVersion()` is left alone; reporting the wrapper's notifier is correct for notice attribution, it was just the wrong source for this one url. Referencing the module-level `NOTIFIER` from a method matches how `userAgent()` is already used in this file, and is evaluated well after module init.

Fixing it in `packages/js` fixes `react` and `vue` at once — no wrapper changes needed.

## Tests

Added a regression test that installs a react-shaped notifier the way the wrapper does and asserts the script url still tracks the js client version:

```ts
client.setNotifier({ name: '@honeybadger-io/react', /* ... */ version: '6.1.32' })
client.showUserFeedbackForm()

expect(client.getVersion()).toBe('6.1.32')
expect(window.document.head.innerHTML).toContain(getUserFeedbackScriptUrl(clientPackageVersion))
expect(window.document.head.innerHTML).not.toContain('/v6.1/')
```

Verified it fails on the old code with exactly the url from the issue:

```
Expected substring: "https://js.honeybadger.io/v__VERSION__/honeybadger-feedback-form.js"
Received string:    "<script src=\"https://js.honeybadger.io/v6.1/honeybadger-feedback-form.js\" async=\"true\"></script>"
```

The pre-existing `should add user feedback script tag on document.head` assertion was switched from `client.getVersion()` to the same captured js version, since `getVersion()` is no longer the contract being asserted.

`packages/js` browser suite passes. One unrelated server test, `test/unit/server/backtrace.server.test.ts › returns a parsed stacktrace in Honeybadger format`, fails on this branch — I confirmed it fails identically on `master`, so it is pre-existing and untouched by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
